### PR TITLE
EscapeMode.minimum for xhtml

### DIFF
--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -46,4 +46,11 @@ public class DocumentTest {
         doc.outputSettings().escapeMode(Entities.EscapeMode.extended);
         assertEquals("<p title=\"&pi;\">&pi; &amp; &lt; &gt; </p>", doc.body().html());
     }
+
+    @Test public void testReferences() {
+        Document doc = Jsoup.parse("&lt; &gt; &amp; &quot; &apos; &times;");
+        doc.outputSettings().escapeMode(Entities.EscapeMode.minimum);
+        assertEquals("&lt; &gt; &amp; &quot; &apos; ×", doc.body().html());
+    }
+
 }


### PR DESCRIPTION
Hi Jonathan,

I've added EscapeMode.minimum feature to my forked jsoup repository.
Could you pull this commit?

This is useful to transform dirty HTML to XHTML.
You can use only it, gt, amp, quot, apos in XHTML. EscapeMode.minimum keep them and convert other references.

Thanks,
Akira
