### PR TITLE
Makes jsoup work with scala

### DIFF
--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -203,7 +203,7 @@ public class Document extends Element {
     /**
      * A Document's output settings control the form of the text() and html() methods.
      */
-    public class OutputSettings implements Cloneable {
+    public static class OutputSettings implements Cloneable {
         private Entities.EscapeMode escapeMode = Entities.EscapeMode.base;
         private Charset charset = Charset.forName("UTF-8");
         private CharsetEncoder charsetEncoder = charset.newEncoder();


### PR DESCRIPTION
Jsoup is currently not compatible with scala.  This was previously reported and discussed here:
  http://groups.google.com/group/jsoup/browse_thread/thread/3f7ec2fa41dfb87f

This change fixes this in a way that doesn't impact the public API of jsoup in a meaningful way -- it makes the OutputSettings class static.  All existing code should work just fine with this change since you can always access a static member via non-static means (you may start to see a compiler warning however).

All tests pass (including UrlConnectTest).
