### PR TITLE
Cookie parsing

### DIFF
--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -212,7 +212,20 @@ public interface Connection {
      * @return If this request is configured to do a range request and there is a lower bound, it's the offset of the last byte.  Else, it's -1.
      */
     public long rangeEnd();
+    
+    
+    /**
+     * Sets if this connection should ignore read errors (i.e. when a socket timeout error happens, it just returns what it has)
+     * @param ignoreReadError   Set to true to ignore read errors
+     * @return  this for chaining
+     */
+    public Connection ignoreReadError(boolean ignoreReadError);
 
+    /**
+     * True if this connection should ignore read errors
+     * @return True if this request should ignore read errors
+     */
+    public boolean ignoreReadError();
 
     /**
      * Common methods for Requests and Responses
@@ -411,6 +424,18 @@ public interface Connection {
          * @return If this request is configured to do a range request and there is a lower bound, it's the offset of the last byte.  Else, it's -1.
          */
         public long rangeEnd();
+        
+        /**
+         * Sets if this request should ignore read errors (i.e. when a socket timeout error happens, it just returns what it has)
+         * @param ignoreReadError   Set to true to ignore read errors
+         */
+        public void ignoreReadError(boolean ignoreReadError);
+        
+        /**
+         * True if this request should ignore read errors
+         * @return True if this request should ignore read errors
+         */
+        public boolean ignoreReadError();
     }
 
     /**

--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -193,6 +193,26 @@ public interface Connection {
      */
     public Connection response(Response response);
 
+    /**
+     * Do an HTTP range request
+     * @param start The start of range. Pass -1 to cancel range request
+     * @param end   The end of range. Pass -1 for no lower bound (goes to end of file)
+     * @return this Connection, for chaining
+     */
+    public Connection range(long start, long end);
+
+    /**
+     * Get the start of the range, if there is one
+     * @return If this request is configured to do a range request, it's the offset of the first byte.  Else, it's -1.
+     */
+    public long rangeStart();
+
+    /**
+     * Get the end of the range, if there is one
+     * @return If this request is configured to do a range request and there is a lower bound, it's the offset of the last byte.  Else, it's -1.
+     */
+    public long rangeEnd();
+
 
     /**
      * Common methods for Requests and Responses
@@ -373,6 +393,24 @@ public interface Connection {
          */
         public Collection<KeyVal> data();
 
+        /**
+         * Do an HTTP range request
+         * @param start The start of range. Pass -1 to cancel range request
+         * @param end   The end of range. Pass -1 for no lower bound (goes to end of file)
+         */
+        public void range(long start, long end);
+
+        /**
+         * Get the start of the range, if there is one
+         * @return If this request is configured to do a range request, it's the offset of the first byte.  Else, it's -1.
+         */
+        public long rangeStart();
+        
+        /**
+         * Get the end of the range, if there is one
+         * @return If this request is configured to do a range request and there is a lower bound, it's the offset of the last byte.  Else, it's -1.
+         */
+        public long rangeEnd();
     }
 
     /**

--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -96,6 +96,31 @@ public class DataUtil {
         ByteBuffer byteData = ByteBuffer.wrap(outStream.toByteArray());
         return byteData;
     }
+    
+    /**
+     * Same as readToByteBuffer, but it doesn't throw an exception.
+     * @param inStream  InputStream to read
+     * @return  Everything that it has read up until the end or an exception
+     */
+    static ByteBuffer safeReadToByteBuffer(InputStream inStream) {
+        byte[] buffer = new byte[bufferSize];
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream(bufferSize);
+        try
+        {
+            int read;
+            while(true) {
+                read  = inStream.read(buffer);
+                if (read == -1) break;
+                outStream.write(buffer, 0, read);
+            }
+        }
+        catch(IOException ioe)
+        {
+            // TODO what do I do with this?
+        }
+        ByteBuffer byteData = ByteBuffer.wrap(outStream.toByteArray());
+        return byteData;
+    }
 
     /**
      * Parse out a charset from a content type header.

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -12,7 +12,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.text.ParseException;
 import java.util.*;
 import java.util.zip.GZIPInputStream;
 

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -100,6 +100,12 @@ public class HttpConnectionTest {
         assertEquals("http://example.com", con.request().url().toExternalForm());
     }
 
+    @Test public void rangeRequest() throws MalformedURLException, IOException {
+        Connection.Response res = HttpConnection.connect(new URL("http://example.com"))
+                                            .followRedirects(true).range(0, 10).execute();
+        assertEquals("<!DOCTYPE h", res.body());
+    }
+
     @Test(expected=IllegalArgumentException.class) public void throwsOnMalformedUrl() {
         Connection con = HttpConnection.connect("bzzt");
     }

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -80,6 +80,21 @@ public class HttpConnectionTest {
         assertEquals("data", res.cookie("four"));
     }
 
+    @Test public void multipleCookies() {
+        // prep http response header map
+        Map<String, List<String>> headers = new HashMap<String, List<String>>();
+        List<String> cookieStrings = new ArrayList<String>();
+        cookieStrings.add("cookie=1;");
+        cookieStrings.add("cookie=2;");
+        cookieStrings.add("cookie=3; expires=Mon, 23-Aug-2012 02:20:35 GMT;");
+        cookieStrings.add("cookie=4; expires=Mon, 23-Aug-2010 02:20:35 GMT;");
+
+        headers.put("Set-Cookie", cookieStrings);
+        HttpConnection.Response res = new HttpConnection.Response();
+        res.processResponseHeaders(headers);
+        assertEquals("3", res.cookie("cookie"));
+    }
+
     @Test public void connectWithUrl() throws MalformedURLException {
         Connection con = HttpConnection.connect(new URL("http://example.com"));
         assertEquals("http://example.com", con.request().url().toExternalForm());


### PR DESCRIPTION
This change makes HttpConnection.Response try to parse the cookie with [HttpCookie](http://docs.oracle.com/javase/6/docs/api/java/net/HttpCookie.html) first and adds the cookie if it hasn't expired.  If HttpCookie can't parse it, then it falls back to the old method of parsing the cookie (including ignoring "expires" and other stuff).

I suppose that a full solution might require having the fallback method parsing the cookie into a map or something, but this is a start for spec-compliant cookies.
