### PR TITLE
Fix Issue #126

### DIFF
--- a/src/main/java/org/jsoup/parser/TreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilderState.java
@@ -810,6 +810,7 @@ enum TreeBuilderState {
                 return tb.process(t);
             } else if (t.isComment()) {
                 tb.insert(t.asComment());
+                return true;
             } else if (t.isDoctype()) {
                 tb.error(this);
                 return false;


### PR DESCRIPTION
Fixes #126 where the comments inside table tags were copied to body tags. Successive runs through the parser increases the number of comments in the body.
