### PR TITLE
This is my solution for my suggestion issue #168

### DIFF
--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -65,7 +65,7 @@ public class Document extends Element {
      */
     public String title() {
         Element titleEl = getElementsByTag("title").first();
-        return titleEl != null ? titleEl.text().trim() : "";
+        return titleEl != null ? titleEl.text().trim().replaceAll("\\n", "").replaceAll("(\\s){2,}", " ") : "";
     }
 
     /**


### PR DESCRIPTION
I changed return value code from

return titleEl != null ? titleEl.text().trim() : "";

to

return titleEl != null ? titleEl.text().trim().replaceAll("\\n", "").replaceAll("(\\s){2,}", " ") : "";

for removing unnecessary spaces and newline chars in the document title if exists.