### PR TITLE
Change what considered as "whitespace"

### DIFF
--- a/src/main/java/org/jsoup/helper/StringUtil.java
+++ b/src/main/java/org/jsoup/helper/StringUtil.java
@@ -71,7 +71,7 @@ public final class StringUtil {
 
         int l = string.length();
         for (int i = 0; i < l; i++) {
-            if (!Character.isWhitespace(string.codePointAt(i)))
+            if (!StringUtil.isWhitespace(string.codePointAt(i)))
                 return false;
         }
         return true;
@@ -94,6 +94,18 @@ public final class StringUtil {
         return true;
     }
 
+    /**
+     * Tests if a code point is "whitespace" defined in spec.
+     * @param c code point to test
+     * @return true if code point is whitespace, false otherwise
+     */
+    public static boolean isWhitespace(int c){
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\f' || c == '\r'){
+            return true;
+        }
+        return false;
+    }
+
     public static String normaliseWhitespace(String string) {
         StringBuilder sb = new StringBuilder(string.length());
 
@@ -103,7 +115,7 @@ public final class StringUtil {
         int l = string.length();
         for (int i = 0; i < l; i++) {
             int c = string.codePointAt(i);
-            if (Character.isWhitespace(c)) {
+            if (isWhitespace(c)) {
                 if (lastWasWhite) {
                     modified = true;
                     continue;

--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -1,5 +1,6 @@
 package org.jsoup.parser;
 
+import org.jsoup.helper.StringUtil;
 import org.jsoup.helper.Validate;
 
 /**
@@ -128,7 +129,7 @@ public class TokenQueue {
      @return if starts with whitespace
      */
     public boolean matchesWhitespace() {
-        return !isEmpty() && Character.isWhitespace(queue.charAt(pos));
+        return !isEmpty() && StringUtil.isWhitespace(queue.charAt(pos));
     }
 
     /**

--- a/src/main/java/org/jsoup/parser/TreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilderState.java
@@ -1458,7 +1458,7 @@ enum TreeBuilderState {
             // todo: this checks more than spec - "\t", "\n", "\f", "\r", " "
             for (int i = 0; i < data.length(); i++) {
                 char c = data.charAt(i);
-                if (!Character.isWhitespace(c))
+                if (!StringUtil.isWhitespace(c))
                     return false;
             }
             return true;

--- a/src/test/java/org/jsoup/helper/StringUtilTest.java
+++ b/src/test/java/org/jsoup/helper/StringUtilTest.java
@@ -2,9 +2,11 @@ package org.jsoup.helper;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class StringUtilTest {
 
@@ -40,6 +42,18 @@ public class StringUtilTest {
 
         assertTrue(StringUtil.isNumeric("1"));
         assertTrue(StringUtil.isNumeric("1234"));
+    }
+
+    @Test public void isWhitespace() {
+        assertTrue(StringUtil.isWhitespace('\t'));
+        assertTrue(StringUtil.isWhitespace('\n'));
+        assertTrue(StringUtil.isWhitespace('\r'));
+        assertTrue(StringUtil.isWhitespace('\f'));
+        assertTrue(StringUtil.isWhitespace(' '));
+        
+        assertFalse(StringUtil.isWhitespace('\u00a0'));
+        assertFalse(StringUtil.isWhitespace('\u2000'));
+        assertFalse(StringUtil.isWhitespace('\u3000'));
     }
 
     @Test public void normaliseWhiteSpace() {


### PR DESCRIPTION
Hi,

In the spec., only '\t', ' ', '\n', '\r', 'f' are considered whitespace, yet currently jsoup check with Character.isWhitespace. These changes changed to only check these 5 code points.
