### PR TITLE
HttpURLConnection.disconnect()

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -441,6 +441,8 @@ public class HttpConnection implements Connection {
                 if (dataStream != null) dataStream.close();
             }
 
+            conn.disconnect();
+
             res.executed = true;
             return res;
         }


### PR DESCRIPTION
I was hitting java error "too many files open" in my multi-threaded crawler that uses Jsoup and on inspecting with lsof found that many of the connections where in TCP CLOSE_WAIT state.  Closing the HttpURLConnection by calling disconnect() fixed this.
