### PR TITLE
Upgrade to maven-resources-plugin version 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.4</version>
       </plugin>
     </plugins>
     <resources>


### PR DESCRIPTION
Eclipse m2e doesn't work with the old version 2.3 and recommends updating to version 2.4. Indeed the project works fine in Eclipse with this version. Command line build also still works.
