### PR TITLE
Add output settings "indent" and "normaliseWhitespace"

### DIFF
--- a/src/main/java/org/jsoup/nodes/Comment.java
+++ b/src/main/java/org/jsoup/nodes/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends Node {
     }
 
     void outerHtmlHead(StringBuilder accum, int depth, Document.OutputSettings out) {
-        if (out.prettyPrint())
+        if (out.prettyPrint() && out.indent())
             indent(accum, depth, out);
         accum
                 .append("<!--")

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -209,6 +209,8 @@ public class Document extends Element {
         private Charset charset = Charset.forName("UTF-8");
         private CharsetEncoder charsetEncoder = charset.newEncoder();
         private boolean prettyPrint = true;
+        private boolean normaliseWhitespace = true;
+        private boolean indent = true;
         private int indentAmount = 1;
 
         public OutputSettings() {}
@@ -289,6 +291,42 @@ public class Document extends Element {
          */
         public OutputSettings prettyPrint(boolean pretty) {
             prettyPrint = pretty;
+            return this;
+        }
+
+        /**
+         * Get if whitespace normalisation for pretty printing is enabled. Default is true. If disabled then whitespaces are not changed when pretty printing
+         * @return if whitespace normalisation for pretty printing is enabled.
+         */
+        public boolean normaliseWhitespace() {
+            return normaliseWhitespace;
+        }
+
+        /**
+         * Enable or disable whitespace normalisation for pretty printing
+         * @param normaliseWhitespace new whitespace normalisation setting
+         * @return this, for chaining
+         */
+        public OutputSettings normaliseWhitespace(boolean normaliseWhitespace) {
+            this.normaliseWhitespace = normaliseWhitespace;
+            return this;
+        }
+
+        /**
+         * Get if indentation for pretty printing is enabled. Default is true. If disabled then indentation is not changed when pretty printing
+         * @return if indentation for pretty printing is enabled.
+         */
+        public boolean indent() {
+            return indent;
+        }
+
+        /**
+         * Enable or disable indentation for pretty printing
+         * @param indent new indent setting
+         * @return this, for chaining
+         */
+        public OutputSettings indent(boolean indent) {
+            this.indent = indent;
             return this;
         }
 

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1042,7 +1042,7 @@ public class Element extends Node {
     }
 
     void outerHtmlHead(StringBuilder accum, int depth, Document.OutputSettings out) {
-        if (accum.length() > 0 && out.prettyPrint() && (tag.formatAsBlock() || (parent() != null && parent().tag().formatAsBlock())))
+        if (accum.length() > 0 && out.prettyPrint() && out.indent() && (tag.formatAsBlock() || (parent() != null && parent().tag().formatAsBlock())))
             indent(accum, depth, out);
         accum
                 .append("<")
@@ -1057,7 +1057,7 @@ public class Element extends Node {
 
     void outerHtmlTail(StringBuilder accum, int depth, Document.OutputSettings out) {
         if (!(childNodes.isEmpty() && tag.isSelfClosing())) {
-            if (out.prettyPrint() && !childNodes.isEmpty() && tag.formatAsBlock())
+            if (out.prettyPrint() && out.indent() && !childNodes.isEmpty() && tag.formatAsBlock())
                 indent(accum, depth, out);
             accum.append("</").append(tagName()).append(">");
         }

--- a/src/main/java/org/jsoup/nodes/TextNode.java
+++ b/src/main/java/org/jsoup/nodes/TextNode.java
@@ -91,11 +91,11 @@ public class TextNode extends Node {
 
     void outerHtmlHead(StringBuilder accum, int depth, Document.OutputSettings out) {
         String html = Entities.escape(getWholeText(), out);
-        if (out.prettyPrint() && parent() instanceof Element && !((Element) parent()).preserveWhitespace()) {
+        if (out.prettyPrint() && out.normaliseWhitespace() && parent() instanceof Element && !((Element) parent()).preserveWhitespace()) {
             html = normaliseWhitespace(html);
         }
 
-        if (out.prettyPrint() && siblingIndex() == 0 && parentNode instanceof Element && ((Element) parentNode).tag().formatAsBlock() && !isBlank())
+        if (out.prettyPrint() && out.indent() && siblingIndex() == 0 && parentNode instanceof Element && ((Element) parentNode).tag().formatAsBlock() && !isBlank())
             indent(accum, depth, out);
         accum.append(html);
     }


### PR DESCRIPTION
Pretty printing normalises whitespaces and indents the HTML tags.
Sometimes it is useful to disable whitespace normalisation or
indentation. So this change introduces two new output settings which can
be used to specify what pretty printing actually does.
