### PR TITLE
Add cobertura and a fix version for maven-project-info-reports-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
   <reporting>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.5.1</version>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>2.5.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -193,5 +193,19 @@
       <timezone>+11</timezone>
     </developer>
   </developers>
-
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.5.2</version>
+        <configuration>
+          <formats>
+            <format>html</format>
+            <format>xml</format>
+          </formats>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>


### PR DESCRIPTION
Hello,

I wanted to display the code coverage for jsoup. So I added the cobertura-maven-plugin. As maven 3 complained about no given version for maven-project-info-reports-plugin I added this as well.

Regards
Mirko