### PR TITLE
Defect 249

### DIFF
--- a/src/main/java/org/jsoup/nodes/FormElement.java
+++ b/src/main/java/org/jsoup/nodes/FormElement.java
@@ -1,11 +1,10 @@
 package org.jsoup.nodes;
 
-import java.util.ArrayList;
-
 import org.jsoup.parser.Tag;
+import org.jsoup.select.Elements;
 
 public class FormElement extends Element {
-	private ArrayList<Element> formElements = new ArrayList<Element>();
+	private Elements formElements = new Elements();
 	public FormElement(Tag tag, String baseUri, Attributes attributes) {
         super(tag, baseUri, attributes);
 			// TODO Auto-generated constructor stub
@@ -15,7 +14,7 @@ public class FormElement extends Element {
 		formElements.add(element);
 	}
 	
-	public ArrayList<Element> getElements(){
+	public Elements getElements(){
 		return formElements;
 	}	
 }

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -142,6 +142,13 @@ class HtmlTreeBuilder extends TreeBuilder {
         if (errors.canAddError())
             errors.add(new ParseError(reader.pos(), "Unexpected token [%s] when in state [%s]", currentToken.tokenType(), state));
     }
+    
+    void addToForm(Element el){
+    	FormElement fe = getFormElement();
+    	if(fe != null){
+    		fe.addElement(el);
+    	}
+    }
 
     Element insert(Token.StartTag startTag) {
         // handle empty unknown tags

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -395,7 +395,8 @@ enum HtmlTreeBuilderState {
                             tb.process(startTag);
                         } else {
                             tb.reconstructFormattingElements();
-                            tb.insert(startTag);
+                            Element el = tb.insert(startTag);
+                            tb.addToForm(el);
                             tb.framesetOk(false);
                         }
                     } else if (name.equals("a")) {
@@ -446,13 +447,7 @@ enum HtmlTreeBuilderState {
                     } else if (name.equals("input")) {
                         tb.reconstructFormattingElements();
                         Element el = tb.insertEmpty(startTag);
-                        
-                        FormElement fe = tb.getFormElement();
-                        if(fe != null)
-                        {
-                        	fe.addElement(el);
-                        }
-                        
+                        tb.addToForm(el);                        
                         if (!el.attr("type").equalsIgnoreCase("hidden"))
                             tb.framesetOk(false);
                     } else if (StringUtil.in(name, "param", "source", "track")) {
@@ -500,7 +495,8 @@ enum HtmlTreeBuilderState {
                         tb.process(new Token.StartTag("hr"));
                         tb.process(new Token.EndTag("form"));
                     } else if (name.equals("textarea")) {
-                        tb.insert(startTag);
+                        Element el = tb.insert(startTag);
+                        tb.addToForm(el);
                         // todo: If the next token is a U+000A LINE FEED (LF) character token, then ignore that token and move on to the next one. (Newlines at the start of textarea elements are ignored as an authoring convenience.)
                         tb.tokeniser.transition(TokeniserState.Rcdata);
                         tb.markInsertionMode();
@@ -521,7 +517,8 @@ enum HtmlTreeBuilderState {
                         handleRawtext(startTag, tb);
                     } else if (name.equals("select")) {
                         tb.reconstructFormattingElements();
-                        tb.insert(startTag);
+                        Element el = tb.insert(startTag);
+                        tb.addToForm(el);
                         tb.framesetOk(false);
 
                         HtmlTreeBuilderState state = tb.state();
@@ -855,12 +852,7 @@ enum HtmlTreeBuilderState {
                     if (!startTag.attributes.get("type").equalsIgnoreCase("hidden")) {
                         return anythingElse(t, tb);
                     } else {
-                        Element el = tb.insertEmpty(startTag);
-                        FormElement fe = tb.getFormElement();
-                        if(fe != null)
-                        {
-                        	fe.addElement(el);
-                        }
+                        tb.insertEmpty(startTag);
                     }
                 } else if (name.equals("form")) {
                     tb.error(this);

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -742,4 +742,21 @@ public class HtmlParserTest {
         Document doc = Jsoup.parse(html);
         assertEquals("<!--?xml encoding='UTF-8' ?--> <html> <head></head> <body> One </body> </html>", StringUtil.normaliseWhitespace(doc.outerHtml()));
     }
+    
+    @Test public void parsesFormWithinTable() {
+        String html = "<html><body><table>" +
+            "<form action=\"/hello.php\" method=\"post\">" +
+            "<tr><td>User:</td><td>" +
+            "<input type=\"text\" name=\"user\" /></td></tr>" +
+            "<tr><td>Password:</td><td>" +
+            "<input type=\"password\" name=\"pass\" /></td></tr>" +
+            "<tr><td><input type=\"submit\" value=\"login\" /></td></tr>" +
+            "<tr><td><textarea/></td></tr>" +
+            "<tr><td><select></select></td></tr>" +
+            "</form></table> </body> </html>";
+        Document doc = Jsoup.parse(html);
+        FormElement form = (FormElement)doc.select("form").get(0);
+        Elements inputs = form.getElements();
+        assertEquals(inputs.size(), 5);
+    }
 }


### PR DESCRIPTION
It is meant to fix 249.

Add's a FormElement which extends Element and keeps track of elements associated with a form (That aren't necessarily found within a form).
When a form is open and an input added it checks if a form is open and adds the element to the form.
When the form is closed since no forms are around the inputs won't be added anywhere.

Tested with two different forms in the same table, they both get 3 input elements each (Different elements).

Not sure if it follows your standards but I said in a message on the group, you won't be able to do everything with one base Element unless you want it crowded.
