### PR TITLE
http://www.w3.org/TR/xhtml1/#C_16 states:

### DIFF
--- a/src/main/java/org/jsoup/nodes/Entities.java
+++ b/src/main/java/org/jsoup/nodes/Entities.java
@@ -111,7 +111,7 @@ public class Entities {
     private static final Object[][] xhtmlArray = {
             {"quot", 0x00022},
             {"amp", 0x00026},
-            {"apos", 0x00027},
+//            {"apos", 0x00027}, // Not properly supported by all browsers: http://www.w3.org/TR/xhtml1/#C_16
             {"lt", 0x0003C},
             {"gt", 0x0003E}
     };

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -54,7 +54,9 @@ public class DocumentTest {
     @Test public void testXhtmlReferences() {
         Document doc = Jsoup.parse("&lt; &gt; &amp; &quot; &apos; &times;");
         doc.outputSettings().escapeMode(Entities.EscapeMode.xhtml);
-        assertEquals("&lt; &gt; &amp; &quot; &apos; ×", doc.body().html());
+        assertEquals("&lt; &gt; &amp; &quot; ' ×", doc.body().html());
+        // NB: &apos; is not preserved so as to be backwards compatible with HTML 4 user agents.
+        // See http://www.w3.org/TR/xhtml1/#C_16
     }
 
     @Test public void testNormalisesStructure() {


### PR DESCRIPTION
The [XHTML spec](http://www.w3.org/TR/xhtml1/#C_16) states:

"C.16. The Named Character Reference &apos;

The named character reference `&apos;` (the apostrophe, U+0027) was introduced in XML 1.0 but does not appear in HTML. Authors should therefore use `&#39;` instead of `&apos;` to work as expected in HTML 4 user agents."

While `&apos;` is more human readable, it will be ignored by some clients, so it seems best to ignore it completely.
