### PR TITLE
Document.sourceUri()

### DIFF
--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class Document extends Element {
     private OutputSettings outputSettings = new OutputSettings();
     private QuirksMode quirksMode = QuirksMode.noQuirks;
-    private String sourceUri;
+    private String location;
 
     /**
      Create a new, empty Document.
@@ -27,7 +27,7 @@ public class Document extends Element {
      */
     public Document(String baseUri) {
         super(Tag.valueOf("#root"), baseUri);
-        this.sourceUri = baseUri;
+        this.location = baseUri;
     }
 
     /**
@@ -51,8 +51,8 @@ public class Document extends Element {
      * this will return the final URI from which the document was served up.  
      * @return sourceUri
      */
-    public String sourceUri() {
-     return sourceUri;
+    public String location() {
+     return location;
     }
     
     /**

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class Document extends Element {
     private OutputSettings outputSettings = new OutputSettings();
     private QuirksMode quirksMode = QuirksMode.noQuirks;
+    private String sourceUri;
 
     /**
      Create a new, empty Document.
@@ -26,6 +27,7 @@ public class Document extends Element {
      */
     public Document(String baseUri) {
         super(Tag.valueOf("#root"), baseUri);
+        this.sourceUri = baseUri;
     }
 
     /**
@@ -44,6 +46,15 @@ public class Document extends Element {
         return doc;
     }
 
+    /**
+     * Accessor to the final URI this Document was parsed from. If the starting URL is a redirect, 
+     * this will return the final URI from which the document was served up.  
+     * @return sourceUri
+     */
+    public String sourceUri() {
+     return sourceUri;
+    }
+    
     /**
      Accessor to the document's {@code head} element.
      @return {@code head}

--- a/src/test/java/org/jsoup/integration/ParseTest.java
+++ b/src/test/java/org/jsoup/integration/ParseTest.java
@@ -158,7 +158,7 @@ public class ParseTest {
         assertEquals("In July, GM said its electric Chevrolet Volt will be sold in the United States at $41,000 -- $8,000 more than its nearest competitor, the Nissan Leaf.", p.text());
     }
 
-    File getFile(String resourceName) {
+    public File getFile(String resourceName) {
         try {
             File file = new File(ParseTest.class.getResource(resourceName).toURI());
             return file;

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -1,7 +1,11 @@
 package org.jsoup.nodes;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
+import org.jsoup.integration.ParseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -80,6 +84,22 @@ public class DocumentTest {
         assertEquals(doc.html(), clone.html());
         assertEquals("<!DOCTYPE html><html><head><title>Doctype test</title></head><body></body></html>",
                 TextUtil.stripNewlines(clone.html()));
+    }
+    
+    @Test public void testLocation() throws IOException {
+    	File in = new ParseTest().getFile("/htmltests/yahoo-jp.html");
+        Document doc = Jsoup.parse(in, "UTF-8", "http://www.yahoo.co.jp/index.html");
+        String location = doc.location();
+        String baseUri = doc.baseUri();
+        assertEquals("http://www.yahoo.co.jp/index.html",location);
+        assertEquals("http://www.yahoo.co.jp/_ylh=X3oDMTB0NWxnaGxsBF9TAzIwNzcyOTYyNjUEdGlkAzEyBHRtcGwDZ2Ex/",baseUri);
+        in = new ParseTest().getFile("/htmltests/nyt-article-1.html");
+        doc = Jsoup.parse(in, null, "http://www.nytimes.com/2010/07/26/business/global/26bp.html?hp");
+        location = doc.location();
+        baseUri = doc.baseUri();
+        assertEquals("http://www.nytimes.com/2010/07/26/business/global/26bp.html?hp",location);
+        assertEquals("http://www.nytimes.com/2010/07/26/business/global/26bp.html?hp",baseUri);
+        
     }
 
 }


### PR DESCRIPTION
Add an accessor method sourceUri to retrieve the final (in case of redirects) URI from which the document was parsed. 