### PR TITLE
Made test method for attribute protected so it can be overridden

### DIFF
--- a/src/main/java/org/jsoup/safety/Whitelist.java
+++ b/src/main/java/org/jsoup/safety/Whitelist.java
@@ -335,7 +335,7 @@ public class Whitelist {
      * @param attr attribute under test
      * @return true if allowed
      */
-    boolean isSafeAttribute(String tagName, Element el, Attribute attr) {
+    protected boolean isSafeAttribute(String tagName, Element el, Attribute attr) {
         TagName tag = TagName.valueOf(tagName);
         AttributeKey key = AttributeKey.valueOf(attr.getKey());
 


### PR DESCRIPTION
The release notes for 1.7.2 made me hopeful: "Allow Whitelist test methods to be extended" - however only the test method for tags was made protected (relating to Issue #85), not the test method for attributes.

My use case is that I want to extend the Whitelist so that I can filter the contents of the attributes (only allow certain values for attributes, only allow certain CSS styles in the "style" attribute). If this test method was protected as in my pull request I would only have to override this method to make it all happen out of the box. Without it I will have to write my own Cleaner as well that traverses the Document again after the regular cleaner to check the attribute values.
