### PR TITLE
Fix for PrematureEOF 

### DIFF
--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -120,7 +120,7 @@ public class DataUtil {
         int read;
         int remaining = maxSize;
 
-        while (true) {
+        while (inStream.available() > 0) {
             read = inStream.read(buffer);
             if (read == -1) break;
             if (capped) {

--- a/src/test/java/org/jsoup/integration/PrematureEOFTest.java
+++ b/src/test/java/org/jsoup/integration/PrematureEOFTest.java
@@ -1,0 +1,23 @@
+package org.jsoup.integration;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author mariuszs@gmail.com
+ */
+public class PrematureEOFTest {
+
+    @Test
+    public void fetchURl() throws IOException {
+        String url = "http://www.dotnetnuke.com/Resources/Blogs/rssid/99.aspx";
+        Document doc = Jsoup.connect(url).get();
+        assertTrue(doc.body().html().contains("channel"));
+    }
+}


### PR DESCRIPTION
This is for situation like below, server is badly configured, but works. With my fix JSoup can read data from server like this.

<pre>
$ curl  --raw -S -v  --ignore-content-length http://www.dotnetnuke.com/Resources/Blogs/rssid/99.aspx
* About to connect() to www.dotnetnuke.com port 80 (#0)
*   Trying 66.29.208.101...
* connected
* Connected to www.dotnetnuke.com (66.29.208.101) port 80 (#0)
> GET /Resources/Blogs/rssid/99.aspx HTTP/1.1
> User-Agent: curl/7.27.0
> Host: www.dotnetnuke.com
> Accept: */*
> 
< HTTP/1.1 200 OK
< Cache-Control: private
< Transfer-Encoding: chunked
< Content-Type: application/xml; charset=utf-8
< Server: Microsoft-IIS/7.0
< X-AspNet-Version: 4.0.30319
< Access-Control-Allow-Origin: *
< Date: Fri, 26 Apr 2013 18:44:57 GMT
< 
28c
<?xml version="1.0" encoding="utf-8"?>
<rss version="2.0">
  <channel xmlns:blog="http://www.dotnetnuke.com/blog/" xmlns:slash="http://purl.org/rss/1.0/modules/slash/">
    <title>Alec Whittington</title>
    <description>My personal blog on DotNetNuke.</description>
    <link>http://www.dotnetnuke.com/Resources/Blogs/BlogId/99.aspx</link>
    <language>en-US</language>
    <webMaster />
    <pubDate>Fri, 26 Apr 2013 08:19:16 GMT</pubDate>
    <lastBuildDate>Fri, 26 Apr 2013 08:19:16 GMT</lastBuildDate>
    <docs>http://backend.userland.com/rss</docs>
    <generator>Blog RSS Generator Version 1.0.0.0</generator>
  </channel>
</rss>
* transfer closed with outstanding read data remaining
* Closing connection #0
curl: (18) transfer closed with outstanding read data remaining
</pre>
