### PR TITLE
Add hasOwn selector syntax; Allow NodeVisitors to remove the node they're visiting

### DIFF
--- a/src/main/java/org/jsoup/select/NodeTraversor.java
+++ b/src/main/java/org/jsoup/select/NodeTraversor.java
@@ -25,22 +25,26 @@ public class NodeTraversor {
     public void traverse(Node root) {
         Node node = root;
         int depth = 0;
-        
+
         while (node != null) {
+            Node parent = node.parent();
+            Node nextSibling = node.nextSibling();
             visitor.head(node, depth);
-            if (node.childNodeSize() > 0) {
+            if (node.childNodes().size() > 0 && (node.parent() != null || node == root)) {
                 node = node.childNode(0);
                 depth++;
             } else {
-                while (node.nextSibling() == null && depth > 0) {
+                while (nextSibling == null && node != null && depth > 0) {
                     visitor.tail(node, depth);
-                    node = node.parent();
+                    node = node.parent() == null? parent : node.parent();
+                    parent = null;
+                    nextSibling = node == null? null : node.nextSibling();
                     depth--;
                 }
                 visitor.tail(node, depth);
                 if (node == root)
                     break;
-                node = node.nextSibling();
+                node = nextSibling;
             }
         }
     }

--- a/src/main/java/org/jsoup/select/QueryParser.java
+++ b/src/main/java/org/jsoup/select/QueryParser.java
@@ -156,7 +156,9 @@ class QueryParser {
         else if (tq.matchChomp(":eq("))
             indexEquals();
         else if (tq.matches(":has("))
-            has();
+            has(false);
+        else if (tq.matches(":hasOwn("))
+            has(true);
         else if (tq.matches(":contains("))
             contains(false);
         else if (tq.matches(":containsOwn("))
@@ -314,11 +316,14 @@ class QueryParser {
     }
 
     // pseudo selector :has(el)
-    private void has() {
-        tq.consume(":has");
+    private void has(boolean own) {
+        tq.consume(own ? ":hasOwn" : ":has");
         String subQuery = tq.chompBalanced('(', ')');
         Validate.notEmpty(subQuery, ":has(el) subselect must not be empty");
-        evals.add(new StructuralEvaluator.Has(parse(subQuery)));
+        if(own)
+            evals.add(new StructuralEvaluator.HasOwn(parse(subQuery)));
+        else
+            evals.add(new StructuralEvaluator.Has(parse(subQuery)));
     }
 
     // pseudo selector :contains(text), containsOwn(text)

--- a/src/main/java/org/jsoup/select/StructuralEvaluator.java
+++ b/src/main/java/org/jsoup/select/StructuralEvaluator.java
@@ -32,6 +32,24 @@ abstract class StructuralEvaluator extends Evaluator {
         }
     }
 
+    static class HasOwn extends StructuralEvaluator {
+        public HasOwn(Evaluator evaluator) {
+            this.evaluator = evaluator;
+        }
+
+        public boolean matches(Element root, Element element) {
+            for (Element e : element.children()) {
+                if (e != element && evaluator.matches(root, e))
+                    return true;
+            }
+            return false;
+        }
+
+        public String toString() {
+            return String.format(":hasOwn(%s)", evaluator);
+        }
+    }
+
     static class Not extends StructuralEvaluator {
         public Not(Evaluator evaluator) {
             this.evaluator = evaluator;

--- a/src/test/java/org/jsoup/select/SelectorTest.java
+++ b/src/test/java/org/jsoup/select/SelectorTest.java
@@ -464,6 +464,13 @@ public class SelectorTest {
         assertEquals("Two", divs.first().text());
     }
 
+    @Test public void testHasOwn() {
+        Document doc = Jsoup.parse("<div><p><span>One</span></p></div> <div><span>Two</span></div>");
+        Elements divs = doc.select("div:hasOwn(span)");
+        assertEquals(1, divs.size());
+        assertEquals("Two", divs.first().text());
+    }
+
     @Test public void testPseudoContains() {
         Document doc = Jsoup.parse("<div><p>The Rain.</p> <p class=light>The <i>rain</i>.</p> <p>Rain, the.</p></div>");
 


### PR DESCRIPTION
Add hasOwn selector syntax:
Mirroring matchesOwn & containsOwn, allow selection of an element which directly contains the given selector.

Allow NodeVisitors to remove the node they're visiting:
Useful for example when pruning elements - rather than building up a list of elements to remove then removing them you can remove them during traversal.
