### PR TITLE
Fix a parsing issue with input tags directly inside tables

### DIFF
--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -849,6 +849,7 @@ enum HtmlTreeBuilderState {
                         return anythingElse(t, tb);
                     } else {
                         tb.insertEmpty(startTag);
+                        return true;
                     }
                 } else if (name.equals("form")) {
                     tb.error(this);


### PR DESCRIPTION
Using the following html result in duplicate input tag after parsing
<html>
<body>
<input type="hidden" name="a" value="">

<table>
<input type="hidden" name="b" value="" />
</table>

</body>
</html>
