### PR TITLE
HttpConnection - Redirect with '#' char on Android

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -447,7 +447,7 @@ public class HttpConnection implements Connection {
                 if (needsRedirect && req.followRedirects()) {
                     req.method(Method.GET); // always redirect with a get. any data param from original req are dropped.
                     req.data().clear();
-                    req.url(new URL(req.url(), res.header("Location")));
+                    req.url(new URL(req.url(), res.header("Location").split("#")[0]));
                     for (Map.Entry<String, String> cookie : res.cookies.entrySet()) { // add response cookies to request (for e.g. login posts)
                         req.cookie(cookie.getKey(), cookie.getValue());
                     }


### PR DESCRIPTION
I've noticed that, for some weird reason, on Android. when a redirect response contains a '#' (for exemple : http://www.20minutes.fr/article/1180291/1180291#xtor=RSS-145), HttpURLConnection fails and returns a 404 error.

So, I've fixed HttpConnection in order to extract only the left part of the URL, and then, it works.
