### PR TITLE
Implement EscapeMode.xhtml_minimal

### DIFF
--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -1,8 +1,8 @@
 package org.jsoup.nodes;
 
-import org.jsoup.helper.Validate;
-
 import java.util.Map;
+
+import org.jsoup.helper.Validate;
 
 /**
  A single key + value attribute. Keys are trimmed and normalised to lower-case.
@@ -66,14 +66,14 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
      @return HTML
      */
     public String html() {
-        return key + "=\"" + Entities.escape(value, (new Document("")).outputSettings()) + "\"";
+        return key + "=\"" + Entities.escape(value, Attribute.class, (new Document("")).outputSettings()) + "\"";
     }
-    
+
     protected void html(StringBuilder accum, Document.OutputSettings out) {
         accum
             .append(key)
             .append("=\"")
-            .append(Entities.escape(value, out))
+            .append(Entities.escape(value, Attribute.class, out))
             .append("\"");
     }
 
@@ -81,6 +81,7 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
      Get the string representation of this attribute, implemented as {@link #html()}.
      @return string
      */
+    @Override
     public String toString() {
         return html();
     }

--- a/src/main/java/org/jsoup/nodes/TextNode.java
+++ b/src/main/java/org/jsoup/nodes/TextNode.java
@@ -28,10 +28,11 @@ public class TextNode extends Node {
         this.text = text;
     }
 
+    @Override
     public String nodeName() {
         return "#text";
     }
-    
+
     /**
      * Get the text content of this text node.
      * @return Unencoded, normalised text.
@@ -40,7 +41,7 @@ public class TextNode extends Node {
     public String text() {
         return normaliseWhitespace(getWholeText());
     }
-    
+
     /**
      * Set the text content of this text node.
      * @param text unencoded text
@@ -89,9 +90,10 @@ public class TextNode extends Node {
         return tailNode;
     }
 
+    @Override
     void outerHtmlHead(StringBuilder accum, int depth, Document.OutputSettings out) {
-        String html = Entities.escape(getWholeText(), out);
-        if (out.prettyPrint() && parent() instanceof Element && !Element.preserveWhitespace((Element) parent())) {
+        String html = Entities.escape(getWholeText(), TextNode.class, out);
+        if (out.prettyPrint() && parent() instanceof Element && !Element.preserveWhitespace(parent())) {
             html = normaliseWhitespace(html);
         }
 
@@ -100,8 +102,10 @@ public class TextNode extends Node {
         accum.append(html);
     }
 
+    @Override
     void outerHtmlTail(StringBuilder accum, int depth, Document.OutputSettings out) {}
 
+    @Override
     public String toString() {
         return outerHtml();
     }

--- a/src/test/java/org/jsoup/nodes/EntitiesTest.java
+++ b/src/test/java/org/jsoup/nodes/EntitiesTest.java
@@ -1,41 +1,73 @@
 package org.jsoup.nodes;
 
-import org.jsoup.Jsoup;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.nio.charset.Charset;
 
+import org.jsoup.Jsoup;
+import org.junit.Test;
+
 public class EntitiesTest {
     @Test public void escape() {
-        String text = "Hello &<> Å å π 新 there ¾ ©";
-        String escapedAscii = Entities.escape(text, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.base);
-        String escapedAsciiFull = Entities.escape(text, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.extended);
-        String escapedAsciiXhtml = Entities.escape(text, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.xhtml);
-        String escapedUtfFull = Entities.escape(text, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.base);
-        String escapedUtfMin = Entities.escape(text, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.xhtml);
+        String text = "Hello &<> Å å π 新 there ¾ © \"'";
+        String escapedAscii = Entities.escape(text, Attribute.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.base);
+        String escapedAsciiFull = Entities.escape(text, Attribute.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.extended);
+        String escapedAsciiXhtml = Entities.escape(text, Attribute.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.xhtml);
+        String escapedAsciiXhtmlMinimal = Entities.escape(text, Attribute.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.xhtml_minimal);
+        String escapedUtfFull = Entities.escape(text, Attribute.class, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.base);
+        String escapedUtfMin = Entities.escape(text, Attribute.class, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.xhtml);
+        String escapedUtfMinMinimal = Entities.escape(text, Attribute.class, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.xhtml_minimal);
 
-        assertEquals("Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy;", escapedAscii);
-        assertEquals("Hello &amp;&lt;&gt; &angst; &aring; &pi; &#x65b0; there &frac34; &copy;", escapedAsciiFull);
-        assertEquals("Hello &amp;&lt;&gt; &#xc5; &#xe5; &#x3c0; &#x65b0; there &#xbe; &#xa9;", escapedAsciiXhtml);
-        assertEquals("Hello &amp;&lt;&gt; &Aring; &aring; π 新 there &frac34; &copy;", escapedUtfFull);
-        assertEquals("Hello &amp;&lt;&gt; Å å π 新 there ¾ ©", escapedUtfMin);
+        String escapedTextAscii = Entities.escape(text, TextNode.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.base);
+        String escapedTextAsciiFull = Entities.escape(text, TextNode.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.extended);
+        String escapedTextAsciiXhtml = Entities.escape(text, TextNode.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.xhtml);
+        String escapedTextAsciiXhtmlMinimal = Entities.escape(text, TextNode.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.xhtml_minimal);
+        String escapedTextUtfFull = Entities.escape(text, TextNode.class, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.base);
+        String escapedTextUtfMin = Entities.escape(text, TextNode.class, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.xhtml);
+        String escapedTextUtfMinMinimal = Entities.escape(text, TextNode.class, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.xhtml_minimal);
+
+        assertEquals("Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &quot;'", escapedAscii);
+        assertEquals("Hello &amp;&lt;&gt; &angst; &aring; &pi; &#x65b0; there &frac34; &copy; &quot;&apos;", escapedAsciiFull);
+        assertEquals("Hello &amp;&lt;&gt; &#xc5; &#xe5; &#x3c0; &#x65b0; there &#xbe; &#xa9; &quot;&apos;", escapedAsciiXhtml);
+        assertEquals("Hello &amp;&lt;&gt; &#xc5; &#xe5; &#x3c0; &#x65b0; there &#xbe; &#xa9; &quot;&apos;", escapedAsciiXhtmlMinimal);
+        assertEquals("Hello &amp;&lt;&gt; &Aring; &aring; π 新 there &frac34; &copy; &quot;'", escapedUtfFull);
+        assertEquals("Hello &amp;&lt;&gt; Å å π 新 there ¾ © &quot;&apos;", escapedUtfMin);
+        assertEquals("Hello &amp;&lt;&gt; Å å π 新 there ¾ © &quot;&apos;", escapedUtfMinMinimal);
+
+        assertEquals("Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &quot;'", escapedTextAscii);
+        assertEquals("Hello &amp;&lt;&gt; &angst; &aring; &pi; &#x65b0; there &frac34; &copy; &quot;&apos;", escapedTextAsciiFull);
+        assertEquals("Hello &amp;&lt;&gt; &#xc5; &#xe5; &#x3c0; &#x65b0; there &#xbe; &#xa9; &quot;&apos;", escapedTextAsciiXhtml);
+        assertEquals("Hello &amp;&lt;&gt; &#xc5; &#xe5; &#x3c0; &#x65b0; there &#xbe; &#xa9; \"'", escapedTextAsciiXhtmlMinimal);
+        assertEquals("Hello &amp;&lt;&gt; &Aring; &aring; π 新 there &frac34; &copy; &quot;'", escapedTextUtfFull);
+        assertEquals("Hello &amp;&lt;&gt; Å å π 新 there ¾ © &quot;&apos;", escapedTextUtfMin);
+        assertEquals("Hello &amp;&lt;&gt; Å å π 新 there ¾ © \"'", escapedTextUtfMinMinimal);
+
         // odd that it's defined as aring in base but angst in full
 
         // round trip
         assertEquals(text, Entities.unescape(escapedAscii));
         assertEquals(text, Entities.unescape(escapedAsciiFull));
         assertEquals(text, Entities.unescape(escapedAsciiXhtml));
+        assertEquals(text, Entities.unescape(escapedAsciiXhtmlMinimal));
         assertEquals(text, Entities.unescape(escapedUtfFull));
         assertEquals(text, Entities.unescape(escapedUtfMin));
+        assertEquals(text, Entities.unescape(escapedUtfMinMinimal));
+
+        assertEquals(text, Entities.unescape(escapedTextAscii));
+        assertEquals(text, Entities.unescape(escapedTextAsciiFull));
+        assertEquals(text, Entities.unescape(escapedTextAsciiXhtml));
+        assertEquals(text, Entities.unescape(escapedTextAsciiXhtmlMinimal));
+        assertEquals(text, Entities.unescape(escapedTextUtfFull));
+        assertEquals(text, Entities.unescape(escapedTextUtfMin));
+        assertEquals(text, Entities.unescape(escapedTextUtfMinMinimal));
+
     }
 
     @Test public void escapeSupplementaryCharacter(){
         String text = new String(Character.toChars(135361));
-        String escapedAscii = Entities.escape(text, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.base);
+        String escapedAscii = Entities.escape(text, TextNode.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.base);
         assertEquals("&#x210c1;", escapedAscii);
-        String escapedUtf = Entities.escape(text, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.base);
+        String escapedUtf = Entities.escape(text, TextNode.class, Charset.forName("UTF-8").newEncoder(), Entities.EscapeMode.base);
         assertEquals(text, escapedUtf);
     }
 
@@ -53,19 +85,19 @@ public class EntitiesTest {
         assertEquals("Hello &= &", Entities.unescape(text, false));
     }
 
-    
+
     @Test public void caseSensitive() {
         String unescaped = "Ü ü & &";
-        assertEquals("&Uuml; &uuml; &amp; &amp;", Entities.escape(unescaped, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.extended));
-        
+        assertEquals("&Uuml; &uuml; &amp; &amp;", Entities.escape(unescaped, TextNode.class, Charset.forName("ascii").newEncoder(), Entities.EscapeMode.extended));
+
         String escaped = "&Uuml; &uuml; &amp; &AMP";
         assertEquals("Ü ü & &", Entities.unescape(escaped));
     }
-    
+
     @Test public void quoteReplacements() {
         String escaped = "&#92; &#36;";
         String unescaped = "\\ $";
-        
+
         assertEquals(unescaped, Entities.unescape(escaped));
     }
 


### PR DESCRIPTION
This patch implements EscapeMode.xhtml_minimal, which is like Escapemode.xhtml but does not encode single and double quotes when serializing text nodes.

Aside from reducing the size of the emitted text, this fixes my particular problem where Velocity directives inside the HTML were being mangled.
