### PR TITLE
Fix Validation of cookie names in HttpConnection

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -283,7 +283,7 @@ public class HttpConnection implements Connection {
         }
 
         public String cookie(String name) {
-            Validate.notNull(name, "Cookie name must not be null");
+            Validate.notEmpty(name, "Cookie name must not be empty");
             return cookies.get(name);
         }
 
@@ -295,12 +295,12 @@ public class HttpConnection implements Connection {
         }
 
         public boolean hasCookie(String name) {
-            Validate.notEmpty("Cookie name must not be empty");
+            Validate.notEmpty(name, "Cookie name must not be empty");
             return cookies.containsKey(name);
         }
 
         public T removeCookie(String name) {
-            Validate.notEmpty("Cookie name must not be empty");
+            Validate.notEmpty(name, "Cookie name must not be empty");
             cookies.remove(name);
             return (T) this;
         }


### PR DESCRIPTION
cookie name validation is inconsistent
- getting the cookie by name uses notNull check while setting it requires notEmpty (a stronger constraint)
- hasCookie and deleteCookie validate constant strings instead of passed cookie name
