### PR TITLE
Preallocate children ArrayList

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -181,7 +181,7 @@ public class Element extends Node {
      */
     public Elements children() {
         // create on the fly rather than maintaining two lists. if gets slow, memoize, and mark dirty on change
-        List<Element> elements = new ArrayList<Element>();
+        List<Element> elements = new ArrayList<Element>(childNodes.size());
         for (Node node : childNodes) {
             if (node instanceof Element)
                 elements.add((Element) node);


### PR DESCRIPTION
This helped reduce garbage from frequent reallocations for Elements with lots of children. Next step would be to memoize this function because it is at the top of profiles for parsing complex pages with Goose.
