### PR TITLE
Added useCache parameter to JSoup's Connection. Fix #336

### DIFF
--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -80,6 +80,13 @@ public interface Connection {
     public Connection followRedirects(boolean followRedirects);
 
     /**
+     * Configures the connection to (not) use URL cache. By default this is <b>false</b>.
+     * @param useCache true if cache should be used.
+     * @return this Connection, for chaining
+     */
+    public Connection useCache(boolean useCache);
+    
+    /**
      * Set the request method to use, GET or POST. Default is GET.
      * @param method HTTP request method
      * @return this Connection, for chaining
@@ -383,6 +390,20 @@ public interface Connection {
          */
         public Request followRedirects(boolean followRedirects);
 
+        /**
+         * Get the current useCache configuration.
+         * @return true if useCache is enabled.
+         */
+        public boolean useCache();
+        
+        /**
+         * Configures the request to (not) use system URL cache. By default this is <b>false</b>.
+         *
+         * @param useCache true if system URL cache should be used.
+         * @return this Request, for chaining
+         */
+        public Request useCache(boolean useCache);
+        
         /**
          * Get the current ignoreHttpErrors configuration.
          * @return true if errors will be ignored; false (default) if HTTP errors will cause an IOException to be thrown.

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -83,6 +83,11 @@ public class HttpConnection implements Connection {
         req.followRedirects(followRedirects);
         return this;
     }
+    
+    public Connection useCache(boolean useCache) {
+    	req.useCache(useCache);
+    	return this;
+    }
 
     public Connection referrer(String referrer) {
         Validate.notNull(referrer, "Referrer must not be null");
@@ -314,6 +319,7 @@ public class HttpConnection implements Connection {
         private int timeoutMilliseconds;
         private int maxBodySizeBytes;
         private boolean followRedirects;
+        private boolean useCache;
         private Collection<Connection.KeyVal> data;
         private boolean ignoreHttpErrors = false;
         private boolean ignoreContentType = false;
@@ -323,6 +329,7 @@ public class HttpConnection implements Connection {
             timeoutMilliseconds = 3000;
             maxBodySizeBytes = 1024 * 1024; // 1MB
             followRedirects = true;
+            useCache = false;
             data = new ArrayList<Connection.KeyVal>();
             method = Connection.Method.GET;
             headers.put("Accept-Encoding", "gzip");
@@ -356,6 +363,15 @@ public class HttpConnection implements Connection {
         public Connection.Request followRedirects(boolean followRedirects) {
             this.followRedirects = followRedirects;
             return this;
+        }
+        
+        public boolean useCache() {
+        	return useCache;
+        }
+        
+        public Connection.Request useCache(boolean useCache) {
+        	this.useCache = useCache;
+        	return this;
         }
 
         public boolean ignoreHttpErrors() {
@@ -436,7 +452,8 @@ public class HttpConnection implements Connection {
             HttpURLConnection conn = createConnection(req);
             Response res;
             try {
-                conn.connect();
+                conn.setUseCaches(req.useCache());
+            	conn.connect();
                 if (req.method() == Connection.Method.POST)
                     writePost(req.data(), conn.getOutputStream());
 


### PR DESCRIPTION
Adds a useCache parameter to Connection to allows user to specify if they want to use the system's URL cache. Sometimes the URL cache can cause issues with Java Web Start and Applets so specifying it can be useful. Otherwise, the sets useCache to false as is recommended. 

Issue #336 was caused by the system default value being set to true.
