### PR TITLE
Add support for quoted attribute values

### DIFF
--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -278,6 +278,9 @@ public abstract class Evaluator {
             Validate.notEmpty(value);
 
             this.key = key.trim().toLowerCase();
+            if (value.startsWith("\"") && value.endsWith("\"")) {
+                value = value.substring(1, value.length()-1);
+            }
             this.value = value.trim().toLowerCase();
         }
     }

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
  * <tr><td><code>[attr]</code></td><td>elements with an attribute named "attr" (with any value)</td><td><code>a[href]</code>, <code>[title]</code></td></tr>
  * <tr><td><code>[^attrPrefix]</code></td><td>elements with an attribute name starting with "attrPrefix". Use to find elements with HTML5 datasets</td><td><code>[^data-]</code>, <code>div[^data-]</code></td></tr>
  * <tr><td><code>[attr=val]</code></td><td>elements with an attribute named "attr", and value equal to "val"</td><td><code>img[width=500]</code>, <code>a[rel=nofollow]</code></td></tr>
+ * <tr><td><code>[attr=&quot;val&quot;]</code></td><td>elements with an attribute named "attr", and value equal to "val"</td><td><code>span[hello="Cleveland"][goodbye="Columbus"]</code>, <code>a[rel=&quot;nofollow&quot;]</code></td></tr>
  * <tr><td><code>[attr^=valPrefix]</code></td><td>elements with an attribute named "attr", and value starting with "valPrefix"</td><td><code>a[href^=http:]</code></code></td></tr>
  * <tr><td><code>[attr$=valSuffix]</code></td><td>elements with an attribute named "attr", and value ending with "valSuffix"</td><td><code>img[src$=.png]</code></td></tr>
  * <tr><td><code>[attr*=valContaining]</code></td><td>elements with an attribute named "attr", and value containing "valContaining"</td><td><code>a[href*=/search/]</code></td></tr>

--- a/src/test/java/org/jsoup/select/SelectorTest.java
+++ b/src/test/java/org/jsoup/select/SelectorTest.java
@@ -48,7 +48,8 @@ public class SelectorTest {
     }
 
     @Test public void testByAttribute() {
-        String h = "<div Title=Foo /><div Title=Bar /><div Style=Qux /><div title=Bam /><div title=SLAM /><div />";
+        String h = "<div Title=Foo /><div Title=Bar /><div Style=Qux /><div title=Bam /><div title=SLAM />" +
+                "<div data-name='with spaces'/>";
         Document doc = Jsoup.parse(h);
 
         Elements withTitle = doc.select("[title]");
@@ -56,6 +57,16 @@ public class SelectorTest {
 
         Elements foo = doc.select("[title=foo]");
         assertEquals(1, foo.size());
+
+        Elements foo2 = doc.select("[title=\"foo\"]");
+        assertEquals(1, foo2.size());
+
+        Elements foo3 = doc.select("[title=\"Foo\"]");
+        assertEquals(1, foo3.size());
+
+        Elements dataName = doc.select("[data-name=\"with spaces\"]");
+        assertEquals(1, dataName.size());
+        assertEquals("with spaces", dataName.first().attr("data-name"));
 
         Elements not = doc.select("div[title!=bar]");
         assertEquals(5, not.size());


### PR DESCRIPTION
The CSS2 (and 3) attribute selector left-hand-side permits using quoted
values. There are even some quoted examples in [section 5.8.1](http://www.w3.org/TR/CSS21/selector.html#matching-attrs) of the CSS2
spec.
