### PR TITLE
Ensure JDK5 compatibility. Fixes #392.

### DIFF
--- a/README
+++ b/README
@@ -12,4 +12,6 @@ jsoup implements the WHATWG HTML5 specification (http://whatwg.org/html), and pa
 
 jsoup is designed to deal with all varieties of HTML found in the wild; from pristine and validating, to invalid tag-soup; jsoup will create a sensible parse tree.
 
+jsoup runs on Java 1.5 and up.
+
 See http://jsoup.org/ for downloads and documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,28 @@
         </configuration>
       </plugin>
       <plugin>
+      	<!-- this plugin allows us to ensure Java 5 API compatibility -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.9</version>
+        <executions>
+          <execution>
+            <id>animal-sniffer</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <signature>
+                <groupId>org.codehaus.mojo.signature</groupId>
+                <artifactId>java15</artifactId>
+                <version>1.0</version>
+              </signature>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.6.1</version>

--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -178,7 +178,7 @@ public class DataUtil {
         if (m.find()) {
             String charset = m.group(1).trim();
             charset = charset.replace("charset=", "");
-            if (charset.isEmpty()) return null;
+            if (charset.length() == 0) return null;
             try {
                 if (Charset.isSupported(charset)) return charset;
                 charset = charset.toUpperCase(Locale.ENGLISH);


### PR DESCRIPTION
This is a minimal change for jsoup to ensure JDK5 compatibility. The addition to pom.xml ensures that even if you build it with JDK7, the build will fail when you start using JDK6/7 API. Fixes #392 .
