### PR TITLE
Update ListLinks.java

### DIFF
--- a/src/main/java/org/jsoup/examples/ListLinks.java
+++ b/src/main/java/org/jsoup/examples/ListLinks.java
@@ -26,10 +26,10 @@ public class ListLinks {
         for (Element src : media) {
             if (src.tagName().equals("img"))
                 print(" * %s: <%s> %sx%s (%s)",
-                        src.tagName(), src.attr("abs:src"), src.attr("width"), src.attr("height"),
+                        src.tagName(), src.attr("src"), src.attr("width"), src.attr("height"),
                         trim(src.attr("alt"), 20));
             else
-                print(" * %s: <%s>", src.tagName(), src.attr("abs:src"));
+                print(" * %s: <%s>", src.tagName(), src.attr("src"));
         }
 
         print("\nImports: (%d)", imports.size());


### PR DESCRIPTION
The example program fails to print the src-attributes of image-tags.

I removed the "abs:" from the attr-parameter - and now it works (for me with selected sample html's).

Didn't want to open an issue for it...

thanx for your great work!!
