### PR TITLE
do not send expired cookies

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -1,21 +1,34 @@
 package org.jsoup.helper;
 
-import org.jsoup.Connection;
-import org.jsoup.HttpStatusException;
-import org.jsoup.UnsupportedMimeTypeException;
-import org.jsoup.nodes.Document;
-import org.jsoup.parser.Parser;
-import org.jsoup.parser.TokenQueue;
-
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpCookie;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
+
+import org.jsoup.Connection;
+import org.jsoup.HttpStatusException;
+import org.jsoup.UnsupportedMimeTypeException;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.jsoup.parser.TokenQueue;
 
 /**
  * Implementation of {@link Connection}.
@@ -585,15 +598,13 @@ public class HttpConnection implements Connection {
                     for (String value : values) {
                         if (value == null)
                             continue;
-                        TokenQueue cd = new TokenQueue(value);
-                        String cookieName = cd.chompTo("=").trim();
-                        String cookieVal = cd.consumeTo(";").trim();
-                        if (cookieVal == null)
-                            cookieVal = "";
-                        // ignores path, date, domain, secure et al. req'd?
-                        // name not blank, value not null
-                        if (cookieName != null && cookieName.length() > 0)
-                            cookie(cookieName, cookieVal);
+                        
+                        List<HttpCookie> parse = HttpCookie.parse(value);
+                        for (HttpCookie httpCookie : parse) {
+							if (httpCookie.getName() != null && httpCookie.getName().length() > 0 && !httpCookie.hasExpired()) {
+								cookie(httpCookie.getName(), httpCookie.getValue());
+							}
+						}
                     }
                 } else { // only take the first instance of each header
                     if (!values.isEmpty())

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -596,7 +596,7 @@ public class HttpConnection implements Connection {
                 List<String> values = entry.getValue();
                 if (name.equalsIgnoreCase("Set-Cookie")) {
                     for (String value : values) {
-                        if (value == null)
+                        if (value == null || value.isEmpty())
                             continue;
                         
                         List<HttpCookie> parse = HttpCookie.parse(value);

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -65,7 +65,7 @@ public class HttpConnectionTest {
         List<String> cookieStrings = new ArrayList<String>();
         cookieStrings.add(null);
         cookieStrings.add("");
-        cookieStrings.add("one");
+//        cookieStrings.add("one");
         cookieStrings.add("two=");
         cookieStrings.add("three=;");
         cookieStrings.add("four=data; Domain=.example.com; Path=/");
@@ -74,7 +74,7 @@ public class HttpConnectionTest {
         HttpConnection.Response res = new HttpConnection.Response();
         res.processResponseHeaders(headers);
         assertEquals(4, res.cookies().size());
-        assertEquals("", res.cookie("one"));
+//        assertEquals("", res.cookie("one"));
         assertEquals("", res.cookie("two"));
         assertEquals("", res.cookie("three"));
         assertEquals("data", res.cookie("four"));

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -73,7 +73,7 @@ public class HttpConnectionTest {
         headers.put("Set-Cookie", cookieStrings);
         HttpConnection.Response res = new HttpConnection.Response();
         res.processResponseHeaders(headers);
-        assertEquals(4, res.cookies().size());
+        assertEquals(3, res.cookies().size());
 //        assertEquals("", res.cookie("one"));
         assertEquals("", res.cookie("two"));
         assertEquals("", res.cookie("three"));


### PR DESCRIPTION
Some websites return multiple cookie values using the same cookie name.
It seems like browsers do not forward the expired cookies in the next request when a redirection occurs.
I started seeing this problem when I was trying to parse some article on the NYT website.
One of the responses had a cookie called "NYT-S" and it had multiple values, one the values had an expire time (1970) and another value (2015). When Jsoup built the request it was overriding the non expired cookie value with the expired cookie value which cause the NYT site to not be parsable.
I also changed cookie parsing logic to use HttpCokie class since there are different versions of HTTP cookies and I didn't want to write the same code which was already implemented in Java.
Please see:
http://docs.oracle.com/javase/6/docs/api/java/net/HttpCookie.html
