### PR TITLE
Add method cssPath() to Element to get the CSS unique path of an element to fix #462.

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -445,6 +445,32 @@ public class Element extends Node {
     }
 
     /**
+     * Get this element's CSS Path. If the element has an id, returns #id,
+     * Otherwise it returns the parent (if any) css path followed by '>',
+     * followed by an unique selector for the element (tag.class.class:nth-child(n)).
+     * @return the CSS Path that can be used to retrieve the element in a selector.
+     */
+    public String cssPath() {
+        if (!id().isEmpty())
+            return "#" + id();
+
+        StringBuilder selector = new StringBuilder(tagName());
+        String classes = StringUtil.join(classNames(), ".");
+        if (!classes.isEmpty())
+            selector.append('.').append(classes);
+
+        if (parent() == null)
+            return selector.toString();
+
+        selector.insert(0, " > ");
+        if (parent().select(selector.toString()).size() > 1)
+            selector.append(String.format(
+                ":nth-child(%d)", elementSiblingIndex() + 1));
+
+        return parent().cssPath() + selector.toString();
+    }
+
+    /**
      * Get sibling elements. If the element has no sibling elements, returns an empty list. An element is not a sibling
      * of itself, so will not be included in the returned list.
      * @return sibling elements

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -680,4 +680,16 @@ public class ElementTest {
         assertEquals("<div id=\"1\">Text <p>One</p> Text <p>Two</p></div><div id=\"2\"><p>One cloned</p><p>Two</p></div>",
             TextUtil.stripNewlines(doc.body().html()));
     }
+
+    @Test
+    public void testCssPath() {
+        Document doc = Jsoup.parse("<div id=\"id1\">A</div><div>B</div><div class=\"c1 c2\">C</div>");
+        Element divA = doc.select("div").get(0);
+        Element divB = doc.select("div").get(1);
+        Element divC = doc.select("div").get(2);
+        assertEquals(divA.cssPath(), "#id1");
+        assertEquals(divB.cssPath(), "#root > html > body > div:nth-child(2)");
+        assertEquals(divC.cssPath(), "#root > html > body > div.c1.c2");
+    }
+
 }


### PR DESCRIPTION
Add method `cssPath()` to the class Element. This is used to retrieve a CSS query that selects this single element. Consider the following HTML as example:

```
<html>
    <head></head>
    <body>
        <div id="id1">A</div>
        <div>B</div>
        <div class="c1 c2">C</div>
    </body>
</html>
```

The first `div` has an id, so its CSS Path will be:

```
#id1
```

The second `div` doesn't have any id or class so its CSS Path will be:

```
#root > html > body > div:nth-child(2)
```

(the `#root` element is automatically added by Jsoup).

The third `div` has a couple of classes unique among its siblings, so its CSS Path will be:

```
#root > html > body > div.c1.c2
```

You can check more information on [this](http://stackoverflow.com/questions/25724112/find-css-path-from-jsoup-element) stackoverflow question.
