### PR TITLE
Better handle class names and the empty string

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -978,7 +978,7 @@ public class Element extends Node {
      * @return The literal class attribute, or <b>empty string</b> if no class attribute set.
      */
     public String className() {
-        return attr("class");
+        return attr("class").trim();
     }
 
     /**
@@ -991,6 +991,7 @@ public class Element extends Node {
         if (classNames == null) {
             String[] names = className().split("\\s+");
             classNames = new LinkedHashSet<String>(Arrays.asList(names));
+            classNames.remove("");
         }
         return classNames;
     }

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -182,7 +182,7 @@ public class ElementTest {
     }
     
     @Test public void testClassDomMethods() {
-        Document doc = Jsoup.parse("<div><span class='mellow yellow'>Hello <b>Yellow</b></span></div>");
+        Document doc = Jsoup.parse("<div><span class=' mellow yellow '>Hello <b>Yellow</b></span></div>");
         List<Element> els = doc.getElementsByAttribute("class");
         Element span = els.get(0);
         assertEquals("mellow yellow", span.className());
@@ -194,6 +194,8 @@ public class ElementTest {
         assertTrue(classes.contains("yellow"));
 
         assertEquals("", doc.className());
+        classes = doc.classNames();
+        assertEquals(0, classes.size());
         assertFalse(doc.hasClass("mellow"));
     }
 


### PR DESCRIPTION
This actually handles two distinct problems:
1. Elements with no class attribute at all would have a classNames Set
   that contained a single entry (the empty string); see #317
2. Elements whose class attribute contained leading or trailing
   whitespace would have an extra classNames Set entry for the empty
   string, and a className with either a leading or trailing space
