### PR TITLE
Allow case-sensitive retrieval of element and attribute names.

### DIFF
--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -18,10 +18,12 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     };
 
     private String key;
+    private String keyOrig;
     private String value;
 
     /**
      * Create a new attribute from unencoded (raw) key and value.
+     *
      * @param key attribute key
      * @param value attribute value
      * @see #createFromEncoded
@@ -29,38 +31,57 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     public Attribute(String key, String value) {
         Validate.notEmpty(key);
         Validate.notNull(value);
-        this.key = key.trim().toLowerCase();
+        this.keyOrig = key.trim();
+        this.key = this.keyOrig.toLowerCase();
         this.value = value;
     }
 
     /**
-     Get the attribute key.
-     @return the attribute key
+     * Get the attribute key, all lower-case.
+     *
+     * @return the attribute key
      */
     public String getKey() {
-        return key;
+        return getKey(false);
+    }
+    /**
+     * Get the attribute key.
+     *
+     * @param preserveCase if true, return the attribute key as it was originally parsed; otherwise, return it all lower-case
+     * @return the attribute key
+     */
+    public String getKey(boolean preserveCase) {
+        if (preserveCase) {
+            return keyOrig;
+        } else {
+            return key;
+        }
     }
 
     /**
-     Set the attribute key. Gets normalised as per the constructor method.
-     @param key the new key; must not be null
+     * Set the attribute key. Gets normalised as per the constructor method.
+     *
+     * @param key the new key; must not be null
      */
     public void setKey(String key) {
         Validate.notEmpty(key);
-        this.key = key.trim().toLowerCase();
+        this.keyOrig = key.trim();
+        this.key = this.keyOrig.toLowerCase();
     }
 
     /**
-     Get the attribute value.
-     @return the attribute value
+     * Get the attribute value.
+     *
+     * @return the attribute value
      */
     public String getValue() {
         return value;
     }
 
     /**
-     Set the attribute value.
-     @param value the new attribute value; must not be null
+     * Set the attribute value.
+     *
+     * @param value the new attribute value; must not be null
      */
     public String setValue(String value) {
         Validate.notNull(value);
@@ -70,8 +91,9 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     }
 
     /**
-     Get the HTML representation of this attribute; e.g. {@code href="index.html"}.
-     @return HTML
+     * Get the HTML representation of this attribute; e.g. {@code href="index.html"}.
+     *
+     * @return HTML
      */
     public String html() {
         StringBuilder accum = new StringBuilder();
@@ -80,7 +102,7 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     }
     
     protected void html(StringBuilder accum, Document.OutputSettings out) {
-        accum.append(key);
+        accum.append(getKey(out.preserveCase()));
         if (!shouldCollapseAttribute(out)) {
             accum.append("=\"");
             Entities.escape(accum, value, out, true, false, false);
@@ -89,8 +111,9 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     }
 
     /**
-     Get the string representation of this attribute, implemented as {@link #html()}.
-     @return string
+     * Get the string representation of this attribute, implemented as {@link #html()}.
+     *
+     * @return string
      */
     @Override
     public String toString() {
@@ -99,6 +122,7 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
 
     /**
      * Create a new Attribute from an unencoded key and a HTML attribute encoded value.
+     *
      * @param unencodedKey assumes the key is not encoded, as can be only run of simple \w chars.
      * @param encodedValue HTML attribute encoded value
      * @return attribute

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -375,6 +375,7 @@ public class Document extends Element {
         private CharsetEncoder charsetEncoder = charset.newEncoder();
         private boolean prettyPrint = true;
         private boolean outline = false;
+        private boolean preserveCase = false;
         private int indentAmount = 1;
         private Syntax syntax = Syntax.html;
 
@@ -494,6 +495,25 @@ public class Document extends Element {
          */
         public OutputSettings outline(boolean outlineMode) {
             outline = outlineMode;
+            return this;
+        }
+
+        /**
+         * Get if preserve-case mode is enabled. Default is false. If enabled, the HTML output methods will
+         * try to maintain the case of tags and attributes as originally parsed.
+         * @return if preserve-case mode is enabled.
+         */
+        public boolean preserveCase() {
+            return preserveCase;
+        }
+
+        /**
+         * Enable or disable HTML preserve-case mode.
+         * @param preserveCaseMode new preserve-case setting
+         * @return this, for chaining
+         */
+        public OutputSettings preserveCase(boolean preserveCaseMode) {
+            preserveCase = preserveCaseMode;
             return this;
         }
 

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -57,12 +57,21 @@ public class Element extends Node {
     }
 
     /**
-     * Get the name of the tag for this element. E.g. {@code div}
+     * Get the name of the tag for this element, all lower-case. E.g. {@code div}
      * 
      * @return the tag name
      */
     public String tagName() {
         return tag.getName();
+    }
+    /**
+     * Get the name of the tag for this element. E.g. {@code div}
+     *
+     * @param preserveCase if true, return the tag name as it was originally parsed; otherwise, return it all lower-case
+     * @return the tag name
+     */
+    public String tagName(boolean preserveCase) {
+        return tag.getName(preserveCase);
     }
 
     /**
@@ -1137,7 +1146,7 @@ public class Element extends Node {
             indent(accum, depth, out);
         accum
                 .append("<")
-                .append(tagName());
+                .append(tagName(out.preserveCase()));
         attributes.html(accum, out);
 
         // selfclosing includes unknown tags, isEmpty defines tags that are always empty
@@ -1157,7 +1166,7 @@ public class Element extends Node {
                     tag.formatAsBlock() || (out.outline() && (childNodes.size()>1 || (childNodes.size()==1 && !(childNodes.get(0) instanceof TextNode))))
             )))
                 indent(accum, depth, out);
-            accum.append("</").append(tagName()).append(">");
+            accum.append("</").append(tagName(out.preserveCase())).append(">");
         }
     }
 

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -179,7 +179,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
             return el;
         }
         
-        Element el = new Element(Tag.valueOf(startTag.name()), baseUri, startTag.attributes);
+        Element el = new Element(Tag.valueOf(startTag.name(true)), baseUri, startTag.attributes);
         insert(el);
         return el;
     }
@@ -196,7 +196,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     }
 
     Element insertEmpty(Token.StartTag startTag) {
-        Tag tag = Tag.valueOf(startTag.name());
+        Tag tag = Tag.valueOf(startTag.name(true));
         Element el = new Element(tag, baseUri, startTag.attributes);
         insertNode(el);
         if (startTag.isSelfClosing()) {
@@ -212,7 +212,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     }
 
     FormElement insertForm(Token.StartTag startTag, boolean onStack) {
-        Tag tag = Tag.valueOf(startTag.name());
+        Tag tag = Tag.valueOf(startTag.name(true));
         FormElement el = new FormElement(tag, baseUri, startTag.attributes);
         setFormElement(el);
         insertNode(el);

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -68,6 +68,7 @@ abstract class Token {
 
     static abstract class Tag extends Token {
         protected String tagName;
+        protected String tagNameOrig;
         private String pendingAttributeName; // attribute names are generally caught in one hop, not accumulated
         private StringBuilder pendingAttributeValue = new StringBuilder(); // but values are accumulated, from e.g. & in hrefs
         private boolean hasEmptyAttributeValue = false; // distinguish boolean attribute from empty string value
@@ -78,6 +79,7 @@ abstract class Token {
         @Override
         Tag reset() {
             tagName = null;
+            tagNameOrig = null;
             pendingAttributeName = null;
             reset(pendingAttributeValue);
             hasEmptyAttributeValue = false;
@@ -116,12 +118,20 @@ abstract class Token {
         }
 
         final String name() {
+            return name(false);
+        }
+        final String name(boolean preserveCase) {
             Validate.isFalse(tagName == null || tagName.length() == 0);
-            return tagName;
+            if (preserveCase) {
+                return tagNameOrig;
+            } else {
+                return tagName;
+            }
         }
 
         final Tag name(String name) {
-            tagName = name;
+            tagNameOrig = name;
+            tagName = name.toLowerCase();
             return this;
         }
 
@@ -136,7 +146,8 @@ abstract class Token {
 
         // these appenders are rarely hit in not null state-- caused by null chars.
         final void appendTagName(String append) {
-            tagName = tagName == null ? append : tagName.concat(append);
+            tagNameOrig = tagNameOrig == null ? append : tagNameOrig.concat(append);
+            tagName = tagNameOrig.toLowerCase();
         }
 
         final void appendTagName(char append) {
@@ -191,7 +202,8 @@ abstract class Token {
         }
 
         StartTag nameAttr(String name, Attributes attributes) {
-            this.tagName = name;
+            this.tagNameOrig = name;
+            this.tagName = name.toLowerCase();
             this.attributes = attributes;
             return this;
         }

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -185,7 +185,7 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             // previous TagOpen state did NOT consume, will have a letter char in current
             //String tagName = r.consumeToAnySorted(tagCharsSorted).toLowerCase();
-            String tagName = r.consumeTagName().toLowerCase();
+            String tagName = r.consumeTagName();
             t.tagPending.appendTagName(tagName);
 
             switch (r.consume()) {
@@ -646,7 +646,7 @@ enum TokeniserState {
         // from before attribute name
         void read(Tokeniser t, CharacterReader r) {
             String name = r.consumeToAnySorted(attributeNameCharsSorted);
-            t.tagPending.appendAttributeName(name.toLowerCase());
+            t.tagPending.appendAttributeName(name);
 
             char c = r.consume();
             switch (c) {

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -52,7 +52,7 @@ public class XmlTreeBuilder extends TreeBuilder {
     }
 
     Element insert(Token.StartTag startTag) {
-        Tag tag = Tag.valueOf(startTag.name());
+        Tag tag = Tag.valueOf(startTag.name(true));
         // todo: wonder if for xml parsing, should treat all tags as unknown? because it's not html.
         Element el = new Element(tag, baseUri, startTag.attributes);
         insertNode(el);

--- a/src/test/java/org/jsoup/parser/TagTest.java
+++ b/src/test/java/org/jsoup/parser/TagTest.java
@@ -14,6 +14,14 @@ public class TagTest {
         assertEquals(p1, p2);
     }
 
+    @Test public void isCaseInsensitiveForNonHtml() {
+        Tag p1 = Tag.valueOf("sometag");
+        Tag p2 = Tag.valueOf("someTag");
+        Tag p3 = Tag.valueOf("SOMETAG");
+        assertEquals(p1, p2);
+        assertEquals(p1, p3);
+    }
+
     @Test public void trims() {
         Tag p1 = Tag.valueOf("p");
         Tag p2 = Tag.valueOf(" p ");


### PR DESCRIPTION
Addresses #29, #272, #328, #344, #407, and #466.

`Element`s and `Attribute`s each have new getters (`tagName` and `getKey`, respectively) that take a boolean (`preserveCase`) as an argument. If true, the original string used to construct the object will be returned; otherwise, the lower-cased version will be returned, as before. Additionally, a new `preserveCase` option has been added to `OutputSettings`: this is referenced when rendering content using `outerHtml()` and the like. When rendering, the closing tags for elements will always match the casing of the opening tag.

There are two implementation details worth noting, however: First, `Tag`s, `Element`s, and `Attribute`s now retain both the original tag/attribute name and a lower-case version of it. This has some benefits at the cost of an increased memory footprint:

 1. Existing code that makes direct reference to `tagName` and `key`
    didn't need to change.
 2. Case-insensitive comparison (for end-tag matching and element
    selection, for example) is somewhat faster than repeatedly calling
    `.equalsIgnoreCase()` on the same string.

Second, HTML tags that are not already all-lower-case will be treated like unrecognized XML tags, with new `Tag` objects created for each. Like other unknown `Tag`s, these will `.equals()` but not `==` other `Tag`s with the same (case insensitive) name. Their other properties (`canContainBlock`, `canContainInline`, etc.) will be copied from the registered version. This has two downsides:

 1. The memory footprint will again increase, though it should be no
    worse than parsing a comparably-sized XML document.
 2. Existing code that relies on strict equality of HTML tags with the
    same name will break. This is unavoidable if we wish to preserve,
    for example, both `<p>` and `<P>` in a document, though we may still
    want to make `Tag.valueOf("P") == Tag.valueOf("P")`. It should be
    noted, however, that `Element` doesn't offer a comparable guarantee.