### PR TITLE
Update meta charset

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,10 @@ jsoup changelog
  * File upload support. Added the ability to specify input streams for POST data, which will upload content in
    MIME multipart/form-data encoding.
 
+ * Added ability to disable TLS (SSL) certificate validation. Helpful if you're hitting a host with a bad cert,
+   or your JDK doesn't support SNI.
+   <https://github.com/jhy/jsoup/pull/343>
+
  * Added ability to further tweak the canned Cleaner Whitelists by removing existing settings.
    <https://github.com/jhy/jsoup/pull/449>
 

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -18,6 +18,7 @@ public class Document extends Element {
     private OutputSettings outputSettings = new OutputSettings();
     private QuirksMode quirksMode = QuirksMode.noQuirks;
     private String location;
+    private boolean updateMetaCharset = false;
 
     /**
      Create a new, empty Document.
@@ -187,12 +188,6 @@ public class Document extends Element {
     }
 
     @Override
-    public String html() {
-        ensureMetaCharset();
-        return super.html();
-    }
-
-    @Override
     public String outerHtml() {
         return super.html(); // no outer wrapper tag
     }
@@ -212,6 +207,23 @@ public class Document extends Element {
     public String nodeName() {
         return "#document";
     }
+    
+    public void charset(Charset charset) {
+        outputSettings.charset(charset);
+        ensureMetaCharset();
+    }
+    
+    public Charset charset() {
+        return outputSettings.charset();
+    }
+    
+    public void updateMetaCharset(boolean update) {
+        this.updateMetaCharset = true;
+    }
+    
+    public boolean updateMetaCharset() {
+        return updateMetaCharset;
+    }
 
     @Override
     public Document clone() {
@@ -221,7 +233,7 @@ public class Document extends Element {
     }
     
     private void ensureMetaCharset() {
-        if( outputSettings.updateMetaCharset() ) {
+        if( updateMetaCharset == true ) {
             Element metaCharset = select("meta[charset]").first();
             
             if( metaCharset != null ) {
@@ -255,7 +267,6 @@ public class Document extends Element {
         private boolean outline = false;
         private int indentAmount = 1;
         private Syntax syntax = Syntax.html;
-        private boolean updateMetaCharset = false;
 
         public OutputSettings() {}
         
@@ -393,15 +404,6 @@ public class Document extends Element {
         public OutputSettings indentAmount(int indentAmount) {
             Validate.isTrue(indentAmount >= 0);
             this.indentAmount = indentAmount;
-            return this;
-        }
-        
-        public boolean updateMetaCharset() {
-            return updateMetaCharset;
-        }
-        
-        public OutputSettings updateMetaCharset(boolean updateMetaCharset) {
-            this.updateMetaCharset = updateMetaCharset;
             return this;
         }
 

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -235,7 +235,7 @@ public class Document extends Element {
      * @see OutputSettings#charset(java.nio.charset.Charset) 
      */
     public void charset(Charset charset) {
-        Document.this.updateMetaCharsetElement(true);
+        updateMetaCharsetElement(true);
         outputSettings.charset(charset);
         ensureMetaCharsetElement();
     }

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -210,19 +210,75 @@ public class Document extends Element {
         return "#document";
     }
     
+    /**
+     * Sets the charset used in this document. This method is equivalent
+     * to {@link OutputSettings#charset(java.nio.charset.Charset)
+     * OutputSettings.charset(Charset)} but in addition it updates the
+     * charset / encoding element within the document.
+     * 
+     * <p>This only applies if {@link #updateMetaCharset(boolean)
+     * updateMetaCharset} set to <tt>true</tt>; otherwise there are no elements
+     * changed and the new value is delegated to
+     * {@link OutputSettings#charset(java.nio.charset.Charset) 
+     * OutputSettings.charset(Charset)} only.</p>
+     * 
+     * <p>If there's no element with charset / encoding information yet it will
+     * be created. Obsolete charset / encoding definitions are removed!</p>
+     * 
+     * <p><b>Elements used:</b></p>
+     * 
+     * <ul>
+     * <li><b>Html:</b> <i>&lt;meta charset="CHARSET"&gt;</i></li>
+     * <li><b>Xml:</b> <i>&lt;?xml version="1.0" encoding="CHARSET"&gt;</i></li>
+     * </ul>
+     * 
+     * @param charset Charset
+     * 
+     * @see #updateMetaCharset(boolean) 
+     * @see OutputSettings#charset(java.nio.charset.Charset) 
+     */
     public void charset(Charset charset) {
         outputSettings.charset(charset);
         ensureMetaCharset();
     }
     
+    /**
+     * Returns the charset used in this document. This method is equivalent
+     * to {@link OutputSettings#charset()}.
+     * 
+     * @return Current Charset
+     * 
+     * @see OutputSettings#charset() 
+     */
     public Charset charset() {
         return outputSettings.charset();
     }
     
+    /**
+     * Sets whether the element with charset information in this document is
+     * updated on changes through {@link #charset(java.nio.charset.Charset)
+     * Document.charset(Charset)} or not.
+     * 
+     * <p>If set to <tt>false</tt> <i>(default)</i> there are no elements
+     * modified.</p>
+     * 
+     * @param update If <tt>true</tt> the element updated on charset
+     * changes, <tt>false</tt> if not
+     * 
+     * @see #charset(java.nio.charset.Charset) 
+     */
     public void updateMetaCharset(boolean update) {
         this.updateMetaCharset = true;
     }
     
+    /**
+     * Returns whether the element with charset information in this document is
+     * updated on changes through {@link #charset(java.nio.charset.Charset)
+     * Document.charset(Charset)} or not.
+     * 
+     * @return Returns <tt>true</tt> if the element is updated on charset
+     * changes, <tt>false</tt> if not
+     */
     public boolean updateMetaCharset() {
         return updateMetaCharset;
     }
@@ -234,6 +290,25 @@ public class Document extends Element {
         return clone;
     }
     
+    /**
+     * Ensures a meta charset (html) or xml declaration (xml) with the current
+     * encoding used. This only applies with {@link #updateMetaCharset(boolean)
+     * updateMetaCharset} set to <tt>true</tt>, otherwise this method does
+     * nothing.
+     * 
+     * <ul>
+     * <li>An exsiting element gets updated with the current charset</li>
+     * <li>If there's no element yet it will be inserted</li>
+     * <li>Obsolete elements are removed</li>
+     * </ul>
+     * 
+     * <p><b>Elements used:</b></p>
+     * 
+     * <ul>
+     * <li><b>Html:</b> <i>&lt;meta charset="CHARSET"&gt;</i></li>
+     * <li><b>Xml:</b> <i>&lt;?xml version="1.0" encoding="CHARSET"&gt;</i></li>
+     * </ul>
+     */
     private void ensureMetaCharset() {
         if( updateMetaCharset == true ) {
             OutputSettings.Syntax syntax = outputSettings().syntax();
@@ -353,7 +428,6 @@ public class Document extends Element {
          * @return the document's output settings, for chaining
          */
         public OutputSettings charset(Charset charset) {
-            // todo: this should probably update the doc's meta charset
             this.charset = charset;
             charsetEncoder = charset.newEncoder();
             return this;

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -187,6 +187,12 @@ public class Document extends Element {
     }
 
     @Override
+    public String html() {
+        ensureMetaCharset();
+        return super.html();
+    }
+
+    @Override
     public String outerHtml() {
         return super.html(); // no outer wrapper tag
     }
@@ -213,6 +219,25 @@ public class Document extends Element {
         clone.outputSettings = this.outputSettings.clone();
         return clone;
     }
+    
+    private void ensureMetaCharset() {
+        if( outputSettings.updateMetaCharset() ) {
+            Element metaCharset = select("meta[charset]").first();
+            
+            if( metaCharset != null ) {
+                metaCharset.attr("charset", outputSettings.charset().displayName());
+                // TODO: Remove other charset tags / handle duplicates (?)
+            }
+            else {
+                Element head = head();
+                
+                if( head != null ) {
+                    head.appendElement("meta").attr("charset", outputSettings.charset().displayName());
+                }
+            }
+        }
+    }
+    
 
     /**
      * A Document's output settings control the form of the text() and html() methods.
@@ -230,6 +255,7 @@ public class Document extends Element {
         private boolean outline = false;
         private int indentAmount = 1;
         private Syntax syntax = Syntax.html;
+        private boolean updateMetaCharset = false;
 
         public OutputSettings() {}
 
@@ -367,6 +393,15 @@ public class Document extends Element {
         public OutputSettings indentAmount(int indentAmount) {
             Validate.isTrue(indentAmount >= 0);
             this.indentAmount = indentAmount;
+            return this;
+        }
+        
+        public boolean updateMetaCharset() {
+            return updateMetaCharset;
+        }
+        
+        public OutputSettings updateMetaCharset(boolean updateMetaCharset) {
+            this.updateMetaCharset = updateMetaCharset;
             return this;
         }
 

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -216,11 +216,8 @@ public class Document extends Element {
      * OutputSettings.charset(Charset)} but in addition it updates the
      * charset / encoding element within the document.
      * 
-     * <p>This only applies if {@link #updateMetaCharset(boolean)
-     * updateMetaCharset} set to <tt>true</tt>; otherwise there are no elements
-     * changed and the new value is delegated to
-     * {@link OutputSettings#charset(java.nio.charset.Charset) 
-     * OutputSettings.charset(Charset)} only.</p>
+     * <p>This enables
+     * {@link #updateMetaCharset(boolean) meta charset update}.</p>
      * 
      * <p>If there's no element with charset / encoding information yet it will
      * be created. Obsolete charset / encoding definitions are removed!</p>
@@ -238,6 +235,7 @@ public class Document extends Element {
      * @see OutputSettings#charset(java.nio.charset.Charset) 
      */
     public void charset(Charset charset) {
+        updateMetaCharset(true);
         outputSettings.charset(charset);
         ensureMetaCharset();
     }

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -129,7 +129,7 @@ public class Document extends Element {
         normaliseStructure("head", htmlEl);
         normaliseStructure("body", htmlEl);
         
-        ensureMetaCharset();
+        ensureMetaCharsetElement();
         
         return this;
     }
@@ -217,7 +217,7 @@ public class Document extends Element {
      * charset / encoding element within the document.
      * 
      * <p>This enables
-     * {@link #updateMetaCharset(boolean) meta charset update}.</p>
+     * {@link #updateMetaCharsetElement(boolean) meta charset update}.</p>
      * 
      * <p>If there's no element with charset / encoding information yet it will
      * be created. Obsolete charset / encoding definitions are removed!</p>
@@ -231,13 +231,13 @@ public class Document extends Element {
      * 
      * @param charset Charset
      * 
-     * @see #updateMetaCharset(boolean) 
+     * @see #updateMetaCharsetElement(boolean) 
      * @see OutputSettings#charset(java.nio.charset.Charset) 
      */
     public void charset(Charset charset) {
-        updateMetaCharset(true);
+        Document.this.updateMetaCharsetElement(true);
         outputSettings.charset(charset);
-        ensureMetaCharset();
+        ensureMetaCharsetElement();
     }
     
     /**
@@ -265,7 +265,7 @@ public class Document extends Element {
      * 
      * @see #charset(java.nio.charset.Charset) 
      */
-    public void updateMetaCharset(boolean update) {
+    public void updateMetaCharsetElement(boolean update) {
         this.updateMetaCharset = true;
     }
     
@@ -277,7 +277,7 @@ public class Document extends Element {
      * @return Returns <tt>true</tt> if the element is updated on charset
      * changes, <tt>false</tt> if not
      */
-    public boolean updateMetaCharset() {
+    public boolean updateMetaCharsetElement() {
         return updateMetaCharset;
     }
 
@@ -290,9 +290,9 @@ public class Document extends Element {
     
     /**
      * Ensures a meta charset (html) or xml declaration (xml) with the current
-     * encoding used. This only applies with {@link #updateMetaCharset(boolean)
-     * updateMetaCharset} set to <tt>true</tt>, otherwise this method does
-     * nothing.
+     * encoding used. This only applies with
+     * {@link #updateMetaCharsetElement(boolean) updateMetaCharset} set to
+     * <tt>true</tt>, otherwise this method does nothing.
      * 
      * <ul>
      * <li>An exsiting element gets updated with the current charset</li>
@@ -307,7 +307,7 @@ public class Document extends Element {
      * <li><b>Xml:</b> <i>&lt;?xml version="1.0" encoding="CHARSET"&gt;</i></li>
      * </ul>
      */
-    private void ensureMetaCharset() {
+    private void ensureMetaCharsetElement() {
         if (updateMetaCharset == true) {
             OutputSettings.Syntax syntax = outputSettings().syntax();
 

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -238,7 +238,6 @@ public class Document extends Element {
             
             if( metaCharset != null ) {
                 metaCharset.attr("charset", outputSettings.charset().displayName());
-                // TODO: Remove other charset tags / handle duplicates (?)
             }
             else {
                 Element head = head();
@@ -247,6 +246,9 @@ public class Document extends Element {
                     head.appendElement("meta").attr("charset", outputSettings.charset().displayName());
                 }
             }
+            
+            // Remove obsolete elements
+            select("meta[name=charset]").remove();
         }
     }
     

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -310,58 +310,53 @@ public class Document extends Element {
      * </ul>
      */
     private void ensureMetaCharset() {
-        if( updateMetaCharset == true ) {
+        if (updateMetaCharset == true) {
             OutputSettings.Syntax syntax = outputSettings().syntax();
-            
-            if( syntax == OutputSettings.Syntax.html ) {
+
+            if (syntax == OutputSettings.Syntax.html) {
                 Element metaCharset = select("meta[charset]").first();
 
-                if( metaCharset != null ) {
+                if (metaCharset != null) {
                     metaCharset.attr("charset", charset().displayName());
-                }
-                else {
+                } else {
                     Element head = head();
 
-                    if( head != null ) {
+                    if (head != null) {
                         head.appendElement("meta").attr("charset", charset().displayName());
                     }
                 }
 
                 // Remove obsolete elements
                 select("meta[name=charset]").remove();
-            }
-            else if( syntax == OutputSettings.Syntax.xml ) {
+            } else if (syntax == OutputSettings.Syntax.xml) {
                 Node node = childNodes().get(0);
-                
-                if( node instanceof XmlDeclaration ) {
+
+                if (node instanceof XmlDeclaration) {
                     XmlDeclaration decl = (XmlDeclaration) node;
-                    
-                    if( decl.attr(XmlDeclaration.DECL_KEY).equals("xml") ) {
+
+                    if (decl.attr(XmlDeclaration.DECL_KEY).equals("xml")) {
                         decl.attr("encoding", charset().displayName());
 
                         final String version = decl.attr("version");
 
-                        if( version != null ) {
+                        if (version != null) {
                             decl.attr("version", "1.0");
                         }
-                    }
-                    else {
+                    } else {
                         decl = new XmlDeclaration("xml", baseUri, false);
                         decl.attr("version", "1.0");
                         decl.attr("encoding", charset().displayName());
-                        
+
                         prependChild(decl);
                     }
-                }
-                else {
+                } else {
                     XmlDeclaration decl = new XmlDeclaration("xml", baseUri, false);
                     decl.attr("version", "1.0");
                     decl.attr("encoding", charset().displayName());
-                    
+
                     prependChild(decl);
                 }
-            }
-            else {
+            } else {
                 // Unsupported syntax - nothing to do yet
             }
         }

--- a/src/main/java/org/jsoup/nodes/XmlDeclaration.java
+++ b/src/main/java/org/jsoup/nodes/XmlDeclaration.java
@@ -5,7 +5,7 @@ package org.jsoup.nodes;
 
  @author Jonathan Hedley, jonathan@hedley.net */
 public class XmlDeclaration extends Node {
-    private static final String DECL_KEY = "declaration";
+    static final String DECL_KEY = "declaration";
     private final boolean isProcessingInstruction; // <! if true, <? if false, declaration (and last data char should be ?)
 
     /**
@@ -29,9 +29,29 @@ public class XmlDeclaration extends Node {
      @return XML declaration
      */
     public String getWholeDeclaration() {
-        return attributes.get(DECL_KEY);
+        final String decl = attributes.get(DECL_KEY);
+        
+        if( decl.equals("xml") == true && attributes.size() > 1 ) {
+            StringBuilder sb = new StringBuilder(decl);
+            final String version = attributes.get("version");
+            
+            if( version != null ) {
+                sb.append(" version=\"").append(version).append("\"");
+            }
+            
+            final String encoding = attributes.get("encoding");
+            
+            if( encoding != null ) {
+                sb.append(" encoding=\"").append(encoding).append("\"");
+            }
+            
+            return sb.toString();
+        }
+        else {
+            return attributes.get(DECL_KEY);
+        }
     }
-
+    
     void outerHtmlHead(StringBuilder accum, int depth, Document.OutputSettings out) {
         accum
                 .append("<")

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -53,7 +53,7 @@ public class DocumentTest {
         Document doc = Jsoup.parse("<p title=π>π & < > </p>");
         // default is utf-8
         assertEquals("<p title=\"π\">π &amp; &lt; &gt; </p>", doc.body().html());
-        assertEquals("UTF-8", doc.outputSettings().charset().displayName());
+        assertEquals("UTF-8", doc.outputSettings().charset().name());
 
         doc.outputSettings().charset("ascii");
         assertEquals(Entities.EscapeMode.base, doc.outputSettings().escapeMode());

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -18,6 +18,10 @@ import static org.junit.Assert.*;
 
  @author Jonathan Hedley, jonathan@hedley.net */
 public class DocumentTest {
+    private static final String charsetUtf8 = "UTF-8";
+    private static final String charsetIso8859 = "ISO-8859-1";
+    
+    
     @Test public void setTextPreservesDocumentStructure() {
         Document doc = Jsoup.parse("<p>Hello</p>");
         doc.text("Replaced");
@@ -148,15 +152,10 @@ public class DocumentTest {
     }
     
     @Test
-    public void testMetaCharsetUpdate() {
-        // Existing meta charset tag
-        final Document doc = Document.createShell("");
+    public void testMetaCharsetUpdateUtf8() {
+        final Document doc = createHtmlDocument("changeThis");
         doc.updateMetaCharset(true);
-        doc.head().appendElement("meta").attr("charset", "changeThis");        
-        
-        final String charsetUtf8 = "UTF-8";
         doc.charset(Charset.forName(charsetUtf8));
-        Element selectedElement = doc.select("meta[charset]").first();
         
         final String htmlCharsetUTF8 = "<html>\n" +
                                         " <head>\n" +
@@ -164,16 +163,19 @@ public class DocumentTest {
                                         " </head>\n" +
                                         " <body></body>\n" +
                                         "</html>";
+        assertEquals(htmlCharsetUTF8, doc.toString());
         
-        assertNotNull(selectedElement);
+        Element selectedElement = doc.select("meta[charset]").first();
         assertEquals(charsetUtf8, doc.charset().displayName());
         assertEquals(charsetUtf8, selectedElement.attr("charset"));
-        assertEquals(htmlCharsetUTF8, doc.toString());
         assertEquals(doc.charset(), doc.outputSettings().charset());
-        
-        final String charsetIso8859 = "ISO-8859-1";
+    }
+    
+    @Test
+    public void testMetaCharsetUpdateIso8859() {
+        final Document doc = createHtmlDocument("changeThis");
+        doc.updateMetaCharset(true);
         doc.charset(Charset.forName(charsetIso8859));
-        selectedElement = doc.select("meta[charset]").first();
         
         final String htmlCharsetISO = "<html>\n" +
                                         " <head>\n" +
@@ -181,34 +183,46 @@ public class DocumentTest {
                                         " </head>\n" +
                                         " <body></body>\n" +
                                         "</html>";
+        assertEquals(htmlCharsetISO, doc.toString());
         
-        assertNotNull(selectedElement);
+        Element selectedElement = doc.select("meta[charset]").first();
         assertEquals(charsetIso8859, doc.charset().displayName());
         assertEquals(charsetIso8859, selectedElement.attr("charset"));
-        assertEquals(htmlCharsetISO, doc.toString());
         assertEquals(doc.charset(), doc.outputSettings().charset());
-        
-        
-        // No meta charset tag
+    }
+    
+    @Test
+    public void testMetaCharsetUpdateNoCharset() {
         final Document docNoCharset = Document.createShell("");
         docNoCharset.updateMetaCharset(true);
         docNoCharset.charset(Charset.forName(charsetUtf8));
         
         assertEquals(charsetUtf8, docNoCharset.select("meta[charset]").first().attr("charset"));
-        assertEquals(htmlCharsetUTF8, docNoCharset.toString());
         
-        
-        // Disabled update of meta charset tag
+        final String htmlCharsetUTF8 = "<html>\n" +
+                                        " <head>\n" +
+                                        "  <meta charset=\"" + charsetUtf8 + "\">\n" +
+                                        " </head>\n" +
+                                        " <body></body>\n" +
+                                        "</html>";
+        assertEquals(htmlCharsetUTF8, docNoCharset.toString()); 
+    }
+    
+    @Test
+    public void testMetaCharsetUpdateDisabled() {
         final Document docDisabled = Document.createShell("");
-        assertFalse(docDisabled.updateMetaCharset());
         
         final String htmlNoCharset = "<html>\n" +
                                         " <head></head>\n" +
                                         " <body></body>\n" +
                                         "</html>";
-        
         assertEquals(htmlNoCharset, docDisabled.toString());
         assertNull(docDisabled.select("meta[charset]").first());
+    }
+    
+    @Test
+    public void testMetaCharsetUpdateDisabledNoChanges() {
+        final Document doc = createHtmlDocument("dontTouch");
         
         final String htmlCharset = "<html>\n" +
                                     " <head>\n" +
@@ -217,134 +231,148 @@ public class DocumentTest {
                                     " </head>\n" +
                                     " <body></body>\n" +
                                     "</html>";
+        assertEquals(htmlCharset, doc.toString());
         
-        docDisabled.head().appendElement("meta").attr("charset", "dontTouch");
-        docDisabled.head().appendElement("meta").attr("name", "charset").attr("content", "dontTouch");
-        
-        assertEquals(htmlCharset, docDisabled.toString());
-        
-        selectedElement = docDisabled.select("meta[charset]").first();
+        Element selectedElement = doc.select("meta[charset]").first();
         assertNotNull(selectedElement);
         assertEquals("dontTouch", selectedElement.attr("charset"));
-        selectedElement = docDisabled.select("meta[name=charset]").first();
+        
+        selectedElement = doc.select("meta[name=charset]").first();
         assertNotNull(selectedElement);
         assertEquals("dontTouch", selectedElement.attr("content"));
-        
-        docDisabled.charset(Charset.forName(charsetUtf8));
-        selectedElement = docDisabled.select("meta[charset]").first();
-        assertNotNull(selectedElement);
-        assertEquals("dontTouch", selectedElement.attr("charset"));
-        selectedElement = docDisabled.select("meta[name=charset]").first();
-        assertNotNull(selectedElement);
-        assertEquals("dontTouch", selectedElement.attr("content"));
-        
-        
-        // Remove obsolete charset definitions
-        final Document docCleanup = Document.createShell("");
-        docCleanup.updateMetaCharset(true);
-        docCleanup.head().appendElement("meta").attr("charset", "dontTouch");
-        docCleanup.head().appendElement("meta").attr("name", "charset").attr("content", "dontTouch");
-        docCleanup.charset(Charset.forName(charsetUtf8));
-        
-        assertEquals(htmlCharsetUTF8, docCleanup.toString());
     }
     
     @Test
-    public void testMetaCharsetUpdateXml() {
-        // Existing encoding definition
-        final Document doc = new Document("");
-        doc.appendElement("root").text("node");
-        doc.outputSettings().syntax(Syntax.xml);
-        doc.updateMetaCharset(true);
-        
-        XmlDeclaration decl = new XmlDeclaration("xml", "", false);
-        decl.attr("version", "1.0");
-        decl.attr("encoding", "changeThis");
-        doc.prependChild(decl);
-        
-        final String charsetUtf8 = "UTF-8";
+    public void testMetaCharsetUpdateDisabledNoChangesAfterUpdate() {
+        final Document doc = createHtmlDocument("dontTouch");
         doc.charset(Charset.forName(charsetUtf8));
         
-        Node declNode = doc.childNode(0);
-        assertTrue(declNode instanceof XmlDeclaration);
-        XmlDeclaration selectedNode = (XmlDeclaration) declNode;
+        Element selectedElement = doc.select("meta[charset]").first();
+        assertEquals("dontTouch", selectedElement.attr("charset"));
+        
+        selectedElement = doc.select("meta[name=charset]").first();
+        assertEquals("dontTouch", selectedElement.attr("content"));
+    }
+            
+    @Test
+    public void testMetaCharsetUpdateCleanup() {
+        final Document doc = createHtmlDocument("dontTouch");
+        doc.updateMetaCharset(true);
+        doc.charset(Charset.forName(charsetUtf8));
+        
+        final String htmlCharsetUTF8 = "<html>\n" +
+                                        " <head>\n" +
+                                        "  <meta charset=\"" + charsetUtf8 + "\">\n" +
+                                        " </head>\n" +
+                                        " <body></body>\n" +
+                                        "</html>";
+        
+        assertEquals(htmlCharsetUTF8, doc.toString());
+    }
+    
+    @Test
+    public void testMetaCharsetUpdateXmlUtf8() {
+        final Document doc = createXmlDocument("1.0", "changeThis", true);
+        doc.updateMetaCharset(true);
+        doc.charset(Charset.forName(charsetUtf8));
         
         final String xmlCharsetUTF8 = "<?xml version=\"1.0\" encoding=\"" + charsetUtf8 + "\">\n" +
                                         "<root>\n" +
                                         " node\n" +
                                         "</root>";
+        assertEquals(xmlCharsetUTF8, doc.toString());
 
-        assertNotNull(declNode);
+        XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
         assertEquals(charsetUtf8, doc.charset().displayName());
         assertEquals(charsetUtf8, selectedNode.attr("encoding"));
-        assertEquals("1.0", selectedNode.attr("version"));
-        assertEquals(xmlCharsetUTF8, doc.toString());
         assertEquals(doc.charset(), doc.outputSettings().charset());
-        
-        final String charsetIso8859 = "ISO-8859-1";
+    }
+    
+    @Test
+    public void testMetaCharsetUpdateXmlIso8859() {
+        final Document doc = createXmlDocument("1.0", "changeThis", true);
+        doc.updateMetaCharset(true);
         doc.charset(Charset.forName(charsetIso8859));
-        
-        declNode = doc.childNode(0);
-        assertTrue(declNode instanceof XmlDeclaration);
-        selectedNode = (XmlDeclaration) declNode;
         
         final String xmlCharsetISO = "<?xml version=\"1.0\" encoding=\"" + charsetIso8859 + "\">\n" +
                                         "<root>\n" +
                                         " node\n" +
                                         "</root>";
+        assertEquals(xmlCharsetISO, doc.toString());
         
-        assertNotNull(declNode);
+        XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
         assertEquals(charsetIso8859, doc.charset().displayName());
         assertEquals(charsetIso8859, selectedNode.attr("encoding"));
-        assertEquals("1.0", selectedNode.attr("version"));
-        assertEquals(xmlCharsetISO, doc.toString());
         assertEquals(doc.charset(), doc.outputSettings().charset());
+    }
+    
+    @Test
+    public void testMetaCharsetUpdateXmlNoCharset() {
+        final Document doc = createXmlDocument("1.0", "none", false);
+        doc.updateMetaCharset(true);
+        doc.charset(Charset.forName(charsetUtf8));
         
+        final String xmlCharsetUTF8 = "<?xml version=\"1.0\" encoding=\"" + charsetUtf8 + "\">\n" +
+                                        "<root>\n" +
+                                        " node\n" +
+                                        "</root>";
+        assertEquals(xmlCharsetUTF8, doc.toString());
         
-        // No encoding definition
-        final Document docNoCharset = new Document("");
-        docNoCharset.appendElement("root").text("node");
-        docNoCharset.outputSettings().syntax(Syntax.xml);
-        docNoCharset.updateMetaCharset(true);
-        docNoCharset.charset(Charset.forName(charsetUtf8));
-        
-        declNode = docNoCharset.childNode(0);
-        assertTrue(declNode instanceof XmlDeclaration);
-        selectedNode = (XmlDeclaration) declNode;
-        
+        XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
         assertEquals(charsetUtf8, selectedNode.attr("encoding"));
-        assertEquals(xmlCharsetUTF8, docNoCharset.toString());
-        
-        
-        // Disabled update of encoding definition
-        final Document docDisabled = new Document("");
-        docDisabled.appendElement("root").text("node");
-        docDisabled.outputSettings().syntax(Syntax.xml);
-        assertFalse(docDisabled.updateMetaCharset());
+    }
+    
+    @Test
+    public void testMetaCharsetUpdateXmlDisabled() {
+        final Document doc = createXmlDocument("none", "none", false);
         
         final String xmlNoCharset = "<root>\n" +
                                     " node\n" +
                                     "</root>";
-        
-        assertEquals(xmlNoCharset, docDisabled.toString());
-        
-        decl = new XmlDeclaration("xml", "", false);
-        decl.attr("version", "dontTouch");
-        decl.attr("encoding", "dontTouch");
-        docDisabled.prependChild(decl);
+        assertEquals(xmlNoCharset, doc.toString());
+    }
+
+    @Test
+    public void testMetaCharsetUpdateXmlDisabledNoChanges() {
+        final Document doc = createXmlDocument("dontTouch", "dontTouch", true);
         
         final String xmlCharset = "<?xml version=\"dontTouch\" encoding=\"dontTouch\">\n" +
                                     "<root>\n" +
                                     " node\n" +
                                     "</root>";
+        assertEquals(xmlCharset, doc.toString());
         
-        assertEquals(xmlCharset, docDisabled.toString());
-        
-        declNode = docDisabled.childNode(0);
-        assertTrue(declNode instanceof XmlDeclaration);
-        selectedNode = (XmlDeclaration) declNode;
-        
+        XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
         assertEquals("dontTouch", selectedNode.attr("encoding"));
         assertEquals("dontTouch", selectedNode.attr("version"));
+    }
+    
+    @Test
+    public void testMetaCharsetUpdatedDisabledPerDefault() {
+        final Document doc = createHtmlDocument("none");
+        assertFalse(doc.updateMetaCharset());
+    }
+    
+    private Document createHtmlDocument(String charset) {
+        final Document doc = Document.createShell("");
+        doc.head().appendElement("meta").attr("charset", charset);
+        doc.head().appendElement("meta").attr("name", "charset").attr("content", charset);
+        
+        return doc;
+    }
+    
+    private Document createXmlDocument(String version, String charset, boolean addDecl) {
+        final Document doc = new Document("");
+        doc.appendElement("root").text("node");
+        doc.outputSettings().syntax(Syntax.xml);
+        
+        if( addDecl == true ) {
+            XmlDeclaration decl = new XmlDeclaration("xml", "", false);
+            decl.attr("version", version);
+            decl.attr("encoding", charset);
+            doc.prependChild(decl);
+        }
+        
+        return doc;
     }
 }

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -163,7 +163,7 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdateUtf8() {
         final Document doc = createHtmlDocument("changeThis");
-        doc.updateMetaCharset(true);
+        doc.updateMetaCharsetElement(true);
         doc.charset(Charset.forName(charsetUtf8));
         
         final String htmlCharsetUTF8 = "<html>\n" +
@@ -183,7 +183,7 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdateIso8859() {
         final Document doc = createHtmlDocument("changeThis");
-        doc.updateMetaCharset(true);
+        doc.updateMetaCharsetElement(true);
         doc.charset(Charset.forName(charsetIso8859));
         
         final String htmlCharsetISO = "<html>\n" +
@@ -203,7 +203,7 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdateNoCharset() {
         final Document docNoCharset = Document.createShell("");
-        docNoCharset.updateMetaCharset(true);
+        docNoCharset.updateMetaCharsetElement(true);
         docNoCharset.charset(Charset.forName(charsetUtf8));
         
         assertEquals(charsetUtf8, docNoCharset.select("meta[charset]").first().attr("charset"));
@@ -264,7 +264,7 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdateCleanup() {
         final Document doc = createHtmlDocument("dontTouch");
-        doc.updateMetaCharset(true);
+        doc.updateMetaCharsetElement(true);
         doc.charset(Charset.forName(charsetUtf8));
         
         final String htmlCharsetUTF8 = "<html>\n" +
@@ -280,7 +280,7 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdateXmlUtf8() {
         final Document doc = createXmlDocument("1.0", "changeThis", true);
-        doc.updateMetaCharset(true);
+        doc.updateMetaCharsetElement(true);
         doc.charset(Charset.forName(charsetUtf8));
         
         final String xmlCharsetUTF8 = "<?xml version=\"1.0\" encoding=\"" + charsetUtf8 + "\">\n" +
@@ -298,7 +298,7 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdateXmlIso8859() {
         final Document doc = createXmlDocument("1.0", "changeThis", true);
-        doc.updateMetaCharset(true);
+        doc.updateMetaCharsetElement(true);
         doc.charset(Charset.forName(charsetIso8859));
         
         final String xmlCharsetISO = "<?xml version=\"1.0\" encoding=\"" + charsetIso8859 + "\">\n" +
@@ -316,7 +316,7 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdateXmlNoCharset() {
         final Document doc = createXmlDocument("1.0", "none", false);
-        doc.updateMetaCharset(true);
+        doc.updateMetaCharsetElement(true);
         doc.charset(Charset.forName(charsetUtf8));
         
         final String xmlCharsetUTF8 = "<?xml version=\"1.0\" encoding=\"" + charsetUtf8 + "\">\n" +
@@ -357,7 +357,7 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdatedDisabledPerDefault() {
         final Document doc = createHtmlDocument("none");
-        assertFalse(doc.updateMetaCharset());
+        assertFalse(doc.updateMetaCharsetElement());
     }
     
     private Document createHtmlDocument(String charset) {

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -7,10 +7,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
 import org.jsoup.integration.ParseTest;
 import org.jsoup.nodes.Document.OutputSettings.Syntax;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -255,15 +252,13 @@ public class DocumentTest {
     }
     
     @Test
-    public void testMetaCharsetUpdateDisabledNoChangesAfterUpdate() {
+    public void testMetaCharsetUpdateEnabledAfterCharsetChange() {
         final Document doc = createHtmlDocument("dontTouch");
         doc.charset(Charset.forName(charsetUtf8));
         
         Element selectedElement = doc.select("meta[charset]").first();
-        assertEquals("dontTouch", selectedElement.attr("charset"));
-        
-        selectedElement = doc.select("meta[name=charset]").first();
-        assertEquals("dontTouch", selectedElement.attr("content"));
+        assertEquals(charsetUtf8, selectedElement.attr("charset"));
+        assertTrue(doc.select("meta[name=charset]").isEmpty());
     }
             
     @Test

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -149,26 +149,84 @@ public class DocumentTest {
     
     @Test
     public void testMetaCharsetUpdate() {
-        Document doc = Document.createShell("");
-        doc.head().appendElement("meta").attr("charset", "changeThis");
-        doc.body().appendElement("div").text("aaa");
-        
+        // Existing meta charset tag
+        final Document doc = Document.createShell("");
+        doc.updateMetaCharset(true);
+        doc.head().appendElement("meta").attr("charset", "changeThis");        
         
         final String charsetUtf8 = "UTF-8";
-        doc.outputSettings().charset(charsetUtf8);
+        doc.charset(Charset.forName(charsetUtf8));
         Element metaCharset = doc.select("meta[charset]").first();
         
-        assertNotNull(metaCharset);
-        assertEquals(doc.outputSettings().charset().displayName(), charsetUtf8);
-        assertEquals(metaCharset.attr("charset"), charsetUtf8);
+        final String htmlCharsetUTF8 = "<html>\n" +
+                                        " <head>\n" +
+                                        "  <meta charset=\"" + charsetUtf8 + "\">\n" +
+                                        " </head>\n" +
+                                        " <body></body>\n" +
+                                        "</html>";
         
+        assertNotNull(metaCharset);
+        assertEquals(charsetUtf8, doc.charset().displayName());
+        assertEquals(charsetUtf8, metaCharset.attr("charset"));
+        assertEquals(htmlCharsetUTF8, doc.toString());
+        assertEquals(doc.charset(), doc.outputSettings().charset());
         
         final String charsetIso8859 = "ISO-8859-1";
-        doc.outputSettings().charset(Charset.forName(charsetIso8859));
+        doc.charset(Charset.forName(charsetIso8859));
         metaCharset = doc.select("meta[charset]").first();
         
+        final String htmlCharsetISO = "<html>\n" +
+                                        " <head>\n" +
+                                        "  <meta charset=\"" + charsetIso8859 + "\">\n" +
+                                        " </head>\n" +
+                                        " <body></body>\n" +
+                                        "</html>";
+        
         assertNotNull(metaCharset);
-        assertEquals(doc.outputSettings().charset().displayName(), charsetIso8859);
-        assertEquals(metaCharset.attr("charset"), charsetIso8859);
+        assertEquals(charsetIso8859, doc.charset().displayName());
+        assertEquals(charsetIso8859, metaCharset.attr("charset"));
+        assertEquals(htmlCharsetISO, doc.toString());
+        assertEquals(doc.charset(), doc.outputSettings().charset());
+        
+        
+        // No meta charset tag
+        final Document docNoCharset = Document.createShell("");
+        docNoCharset.updateMetaCharset(true);
+        doc.charset(Charset.forName(charsetUtf8));
+        
+        assertEquals(charsetUtf8, doc.select("meta[charset]").first().attr("charset"));
+        assertEquals(htmlCharsetUTF8, doc.toString());
+        
+        
+        // Disabled update of meta charset tag
+        final Document docDisabled = Document.createShell("");
+        assertFalse(docDisabled.updateMetaCharset());
+        
+        final String htmlNoCharset = "<html>\n" +
+                                        " <head></head>\n" +
+                                        " <body></body>\n" +
+                                        "</html>";
+        
+        assertEquals(htmlNoCharset, docDisabled.toString());
+        assertNull(docDisabled.select("meta[charset]").first());
+        
+        final String htmlCharset = "<html>\n" +
+                                    " <head>\n" +
+                                    "  <meta charset=\"dontTouch\">\n" +
+                                    " </head>\n" +
+                                    " <body></body>\n" +
+                                    "</html>";
+        
+        docDisabled.head().appendElement("meta").attr("charset", "dontTouch");
+        assertEquals(htmlCharset, docDisabled.toString());
+        
+        metaCharset = docDisabled.select("meta[charset]").first();
+        assertNotNull(metaCharset);
+        assertEquals("dontTouch", metaCharset.attr("charset"));
+        
+        doc.charset(Charset.forName(charsetUtf8));
+        metaCharset = docDisabled.select("meta[charset]").first();
+        assertNotNull(metaCharset);
+        assertEquals("dontTouch", metaCharset.attr("charset"));
     }
 }

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -178,7 +178,7 @@ public class DocumentTest {
         assertEquals(htmlCharsetUTF8, doc.toString());
         
         Element selectedElement = doc.select("meta[charset]").first();
-        assertEquals(charsetUtf8, doc.charset().displayName());
+        assertEquals(charsetUtf8, doc.charset().name());
         assertEquals(charsetUtf8, selectedElement.attr("charset"));
         assertEquals(doc.charset(), doc.outputSettings().charset());
     }
@@ -198,7 +198,7 @@ public class DocumentTest {
         assertEquals(htmlCharsetISO, doc.toString());
         
         Element selectedElement = doc.select("meta[charset]").first();
-        assertEquals(charsetIso8859, doc.charset().displayName());
+        assertEquals(charsetIso8859, doc.charset().name());
         assertEquals(charsetIso8859, selectedElement.attr("charset"));
         assertEquals(doc.charset(), doc.outputSettings().charset());
     }
@@ -295,7 +295,7 @@ public class DocumentTest {
         assertEquals(xmlCharsetUTF8, doc.toString());
 
         XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
-        assertEquals(charsetUtf8, doc.charset().displayName());
+        assertEquals(charsetUtf8, doc.charset().name());
         assertEquals(charsetUtf8, selectedNode.attr("encoding"));
         assertEquals(doc.charset(), doc.outputSettings().charset());
     }
@@ -313,7 +313,7 @@ public class DocumentTest {
         assertEquals(xmlCharsetISO, doc.toString());
         
         XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
-        assertEquals(charsetIso8859, doc.charset().displayName());
+        assertEquals(charsetIso8859, doc.charset().name());
         assertEquals(charsetIso8859, selectedNode.attr("encoding"));
         assertEquals(doc.charset(), doc.outputSettings().charset());
     }

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -156,7 +156,7 @@ public class DocumentTest {
         
         final String charsetUtf8 = "UTF-8";
         doc.charset(Charset.forName(charsetUtf8));
-        Element metaCharset = doc.select("meta[charset]").first();
+        Element selectedElement = doc.select("meta[charset]").first();
         
         final String htmlCharsetUTF8 = "<html>\n" +
                                         " <head>\n" +
@@ -165,15 +165,15 @@ public class DocumentTest {
                                         " <body></body>\n" +
                                         "</html>";
         
-        assertNotNull(metaCharset);
+        assertNotNull(selectedElement);
         assertEquals(charsetUtf8, doc.charset().displayName());
-        assertEquals(charsetUtf8, metaCharset.attr("charset"));
+        assertEquals(charsetUtf8, selectedElement.attr("charset"));
         assertEquals(htmlCharsetUTF8, doc.toString());
         assertEquals(doc.charset(), doc.outputSettings().charset());
         
         final String charsetIso8859 = "ISO-8859-1";
         doc.charset(Charset.forName(charsetIso8859));
-        metaCharset = doc.select("meta[charset]").first();
+        selectedElement = doc.select("meta[charset]").first();
         
         final String htmlCharsetISO = "<html>\n" +
                                         " <head>\n" +
@@ -182,9 +182,9 @@ public class DocumentTest {
                                         " <body></body>\n" +
                                         "</html>";
         
-        assertNotNull(metaCharset);
+        assertNotNull(selectedElement);
         assertEquals(charsetIso8859, doc.charset().displayName());
-        assertEquals(charsetIso8859, metaCharset.attr("charset"));
+        assertEquals(charsetIso8859, selectedElement.attr("charset"));
         assertEquals(htmlCharsetISO, doc.toString());
         assertEquals(doc.charset(), doc.outputSettings().charset());
         
@@ -213,20 +213,38 @@ public class DocumentTest {
         final String htmlCharset = "<html>\n" +
                                     " <head>\n" +
                                     "  <meta charset=\"dontTouch\">\n" +
+                                    "  <meta name=\"charset\" content=\"dontTouch\">\n" +
                                     " </head>\n" +
                                     " <body></body>\n" +
                                     "</html>";
         
         docDisabled.head().appendElement("meta").attr("charset", "dontTouch");
+        docDisabled.head().appendElement("meta").attr("name", "charset").attr("content", "dontTouch");
+        
         assertEquals(htmlCharset, docDisabled.toString());
         
-        metaCharset = docDisabled.select("meta[charset]").first();
-        assertNotNull(metaCharset);
-        assertEquals("dontTouch", metaCharset.attr("charset"));
+        selectedElement = docDisabled.select("meta[charset]").first();
+        assertNotNull(selectedElement);
+        assertEquals("dontTouch", selectedElement.attr("charset"));
+        selectedElement = docDisabled.select("meta[name=charset]").first();
+        assertNotNull(selectedElement);
+        assertEquals("dontTouch", selectedElement.attr("content"));
         
         doc.charset(Charset.forName(charsetUtf8));
-        metaCharset = docDisabled.select("meta[charset]").first();
-        assertNotNull(metaCharset);
-        assertEquals("dontTouch", metaCharset.attr("charset"));
+        selectedElement = docDisabled.select("meta[charset]").first();
+        assertNotNull(selectedElement);
+        assertEquals("dontTouch", selectedElement.attr("charset"));
+        selectedElement = docDisabled.select("meta[name=charset]").first();
+        assertNotNull(selectedElement);
+        assertEquals("dontTouch", selectedElement.attr("content"));
+        
+        
+        // Remove obsolete charset definitions
+        final Document docCleanup = Document.createShell("");
+        docCleanup.updateMetaCharset(true);
+        docCleanup.head().appendElement("meta").attr("charset", "dontTouch");
+        docCleanup.head().appendElement("meta").attr("name", "charset").attr("content", "dontTouch");
+        
+        assertEquals(htmlCharsetUTF8, doc.toString());
     }
 }


### PR DESCRIPTION
This pull request attends the todo-comment according the update of documents meta charset tag.

If the charset is changed, the charset meta-tag of the document is slected and updated (if existing).

An improvement could be an overload `charset()` method, where the caller can choose if the meta tag will be updated too.

A test is included.