### PR TITLE
Update to allow for specification of form post data charset.

### DIFF
--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -211,6 +211,13 @@ public interface Connection {
     public Connection parser(Parser parser);
 
     /**
+     * Sets the default post data character set for x-www-form-urlencoded post data
+     * @param charset character set to encode post data
+     * @return this Connection, for chaining
+     */
+    public Connection postDataCharset(String charset);
+
+    /**
      * Execute the request as a GET, and parse the result.
      * @return parsed Document
      * @throws java.net.MalformedURLException if the request URL is not a HTTP or HTTPS URL, or is otherwise malformed
@@ -497,6 +504,20 @@ public interface Connection {
          * @return current Parser
          */
         public Parser parser();
+
+        /**
+         * Sets the post data character set for x-www-form-urlencoded post data
+         * @param charset character set to encode post data
+         * @return this Request, for chaining
+         */
+        public Request postDataCharset(String charset);
+
+        /**
+         * Gets the post data character set for x-www-form-urlencoded post data
+         * @return character set to encode post data
+         */
+        public String postDataCharset();
+
     }
 
     /**

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -15,6 +15,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
@@ -223,6 +224,11 @@ public class HttpConnection implements Connection {
         return this;
     }
 
+    public Connection postDataCharset(String charset) {
+        req.postDataCharset(charset);
+        return this;
+    }
+
     @SuppressWarnings({"unchecked"})
     private static abstract class Base<T extends Connection.Base> implements Connection.Base<T> {
         URL url;
@@ -352,6 +358,7 @@ public class HttpConnection implements Connection {
         private boolean ignoreContentType = false;
         private Parser parser;
         private boolean validateTSLCertificates = true;
+        private String postDataCharset = DataUtil.defaultCharset;
 
         private Request() {
             timeoutMilliseconds = 3000;
@@ -435,6 +442,17 @@ public class HttpConnection implements Connection {
 
         public Parser parser() {
             return parser;
+        }
+
+        public Connection.Request postDataCharset(String charset) {
+            Validate.notNull(charset, "Charset must not be null");
+            if (!Charset.isSupported(charset)) throw new IllegalCharsetNameException(charset);
+            this.postDataCharset = charset;
+            return this;
+        }
+
+        public String postDataCharset() {
+            return postDataCharset;
         }
     }
 
@@ -739,7 +757,7 @@ public class HttpConnection implements Connection {
                 bound = DataUtil.mimeBoundary();
                 req.header(CONTENT_TYPE, MULTIPART_FORM_DATA + "; boundary=" + bound);
             } else {
-                req.header(CONTENT_TYPE, FORM_URL_ENCODED);
+                req.header(CONTENT_TYPE, FORM_URL_ENCODED + "; charset=" + req.postDataCharset());
             }
             return bound;
         }
@@ -782,9 +800,9 @@ public class HttpConnection implements Connection {
                     else
                         first = false;
 
-                    w.write(URLEncoder.encode(keyVal.key(), DataUtil.defaultCharset));
+                    w.write(URLEncoder.encode(keyVal.key(), req.postDataCharset()));
                     w.write('=');
-                    w.write(URLEncoder.encode(keyVal.value(), DataUtil.defaultCharset));
+                    w.write(URLEncoder.encode(keyVal.value(), req.postDataCharset()));
                 }
             }
             w.close();


### PR DESCRIPTION
Updates to Connection and Request interfaces and HttpConnection implementation.   This allows for the specification of the charset used for application/x-www-form-urlencoded post data character set, which is needed for more robust support.   The implementation was done by adding a postDataCharset method to the request object with the default value still maintaining the DataUtils.defaultCharset.   This implementation should have minimum effect on current applications as the default is still UTF-8 but allows the setting of ISO-8859-1 which appears frequently in use on the web.  I've also added the charset= parameter to the header setting to allow the server to be aware of the charset used, although I've found this isn't always honored...

Fixes issue #155