### PR TITLE
Double quotes in text nodes does not get escaped when using XHTML escaping mode

### DIFF
--- a/src/main/java/org/jsoup/nodes/Entities.java
+++ b/src/main/java/org/jsoup/nodes/Entities.java
@@ -129,7 +129,7 @@ public class Entities {
                             accum.append(c);
                         break;
                     case '"':
-                        if (inAttribute)
+                        if (!inAttribute)
                             accum.append("&quot;");
                         else
                             accum.append(c);

--- a/src/main/java/org/jsoup/nodes/Entities.java
+++ b/src/main/java/org/jsoup/nodes/Entities.java
@@ -129,10 +129,7 @@ public class Entities {
                             accum.append(c);
                         break;
                     case '"':
-                        if (!inAttribute)
-                            accum.append("&quot;");
-                        else
-                            accum.append(c);
+                        accum.append("&quot;");
                         break;
                     default:
                         if (encoder.canEncode(c))

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -60,7 +60,7 @@ public class DocumentTest {
     @Test public void testXhtmlReferences() {
         Document doc = Jsoup.parse("&lt; &gt; &amp; &quot; &apos; &times;");
         doc.outputSettings().escapeMode(Entities.EscapeMode.xhtml);
-        assertEquals("&lt; &gt; &amp; \" ' ×", doc.body().html());
+        assertEquals("&lt; &gt; &amp; &quot; ' ×", doc.body().html());
     }
 
     @Test public void testNormalisesStructure() {
@@ -112,7 +112,7 @@ public class DocumentTest {
                 "<html>\n" +
                 " <head></head>\n" +
                 " <body>\n" +
-                "  <img async checked src=\"&amp;<>&quot;\">&lt;&gt;&amp;\"\n" +
+                "  <img async checked src=\"&amp;<>&quot;\">&lt;&gt;&amp;&quot;\n" +
                 "  <foo />bar\n" +
                 " </body>\n" +
                 "</html>", doc.html());
@@ -122,7 +122,7 @@ public class DocumentTest {
                 "<html>\n" +
                 " <head></head>\n" +
                 " <body>\n" +
-                "  <img async=\"\" checked=\"checked\" src=\"&amp;<>&quot;\" />&lt;&gt;&amp;\"\n" +
+                "  <img async=\"\" checked=\"checked\" src=\"&amp;<>&quot;\" />&lt;&gt;&amp;&quot;\n" +
                 "  <foo />bar\n" +
                 " </body>\n" +
                 "</html>", doc.html());

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -751,7 +751,7 @@ public class HtmlParserTest {
         String html = "&amp &quot &reg &icy &hopf &icy; &hopf;";
         Document doc = Jsoup.parse(html);
         doc.outputSettings().escapeMode(Entities.EscapeMode.extended).charset("ascii"); // modifies output only to clarify test
-        assertEquals("&amp; \" &reg; &amp;icy &amp;hopf &icy; &hopf;", doc.body().html());
+        assertEquals("&amp; &quot; &reg; &amp;icy &amp;hopf &icy; &hopf;", doc.body().html());
     }
 
     @Test public void handlesXmlDeclarationAsBogusComment() {


### PR DESCRIPTION
I think this is a simple typo. Double quotes are not escaped when using XHTML mode. &<> characters are fine.