### PR TITLE
Fixed JavaDoc errors and warnings for JDK8 with stricter doc rules

### DIFF
--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -11,13 +11,15 @@ import java.util.Map;
 
 /**
  * A Connection provides a convenient interface to fetch content from the web, and parse them into Documents.
- * <p/>
+ * <p>
  * To get a new Connection, use {@link org.jsoup.Jsoup#connect(String)}. Connections contain {@link Connection.Request}
  * and {@link Connection.Response} objects. The request objects are reusable as prototype requests.
- * <p/>
+ * </p>
+ * <p>
  * Request configuration can be made using either the shortcut methods in Connection (e.g. {@link #userAgent(String)}),
  * or by methods in the Connection.Request object directly. All request configuration must be made before the request is
  * executed.
+ * </p>
  */
 public interface Connection {
 
@@ -122,14 +124,18 @@ public interface Connection {
 
     /**
      * Disable/enable TSL certificates validation for HTTPS requests.
-     * <p/>
+     * <p>
      * By default this is <b>true</b>; all
      * connections over HTTPS perform normal validation of certificates, and will abort requests if the provided
      * certificate does not validate.
-     * <p/>
+     * </p>
+     * <p>
      * Some servers use expired, self-generated certificates; or your JDK may not
      * support SNI hosts. In which case, you may want to enable this setting.
-     * <p/> <b>Be careful</b> and understand why you need to disable these validations.
+     * </p>
+     * <p>
+     * <b>Be careful</b> and understand why you need to disable these validations.
+     * </p>
      * @param value if should validate TSL (SSL) certificates. <b>true</b> by default.
      * @return this Connection, for chaining
      */
@@ -173,7 +179,7 @@ public interface Connection {
     /**
      * Add a number of request data parameters. Multiple parameters may be set at once, e.g.: <code>.data("name",
      * "jsoup", "language", "Java", "language", "English");</code> creates a query string like:
-     * <code>?name=jsoup&language=Java&language=English</code>
+     * <code>{@literal ?name=jsoup&language=Java&language=English}</code>
      * @param keyvals a set of key value pairs.
      * @return this Connection, for chaining
      */
@@ -198,7 +204,7 @@ public interface Connection {
 
     /**
      * Adds each of the supplied cookies to the request.
-     * @param cookies map of cookie name -> value pairs
+     * @param cookies map of cookie name {@literal ->} value pairs
      * @return this Connection, for chaining
      */
     public Connection cookies(Map<String, String> cookies);
@@ -303,8 +309,9 @@ public interface Connection {
 
         /**
          * Get the value of a header. This is a simplified header model, where a header may only have one value.
-         * <p/>
+         * <p>
          * Header names are case insensitive.
+         * </p>
          * @param name name of header (case insensitive)
          * @return value of header, or null if not set.
          * @see #hasHeader(String)
@@ -350,9 +357,10 @@ public interface Connection {
 
         /**
          * Get a cookie value by name from this request/response.
-         * <p/>
+         * <p>
          * Response objects have a simplified cookie model. Each cookie set in the response is added to the response
          * object's cookie key=value map. The cookie's path, domain, and expiry date are ignored.
+         * </p>
          * @param name name of cookie to retrieve.
          * @return value of cookie, or null if not set
          */

--- a/src/main/java/org/jsoup/examples/HtmlToPlainText.java
+++ b/src/main/java/org/jsoup/examples/HtmlToPlainText.java
@@ -17,12 +17,14 @@ import java.io.IOException;
  * HTML to plain-text. This example program demonstrates the use of jsoup to convert HTML input to lightly-formatted
  * plain-text. That is divergent from the general goal of jsoup's .text() methods, which is to get clean data from a
  * scrape.
- * <p/>
+ * <p>
  * Note that this is a fairly simplistic formatter -- for real world use you'll want to embrace and extend.
- * <p/>
- * To invoke from the command line, assuming you've downloaded the jsoup jar to your current directory:<br/>
- * <code>java -cp jsoup.jar org.jsoup.examples.HtmlToPlainText url [selector]</code><br/>
+ * </p>
+ * <p>
+ * To invoke from the command line, assuming you've downloaded the jsoup jar to your current directory:</p>
+ * <p><code>java -cp jsoup.jar org.jsoup.examples.HtmlToPlainText url [selector]</code></p>
  * where <i>url</i> is the URL to fetch, and <i>selector</i> is an optional CSS selector.
+ * 
  * @author Jonathan Hedley, jonathan@hedley.net
  */
 public class HtmlToPlainText {

--- a/src/main/java/org/jsoup/helper/W3CDom.java
+++ b/src/main/java/org/jsoup/helper/W3CDom.java
@@ -21,8 +21,9 @@ import javax.xml.transform.TransformerException;
 /**
  * Helper class to transform a {@link org.jsoup.nodes.Document} to a {@link org.w3c.dom.Document org.w3c.dom.Document},
  * for integration with toolsets that use the W3C DOM.
- * <p/>
+ * <p>
  * This class is currently <b>experimental</b>, please provide feedback on utility and any problems experienced.
+ * </p>
  */
 public class W3CDom {
     protected DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -114,6 +114,9 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
 
     /**
      * Collapsible if it's a boolean attribute and value is empty or same as name
+     * 
+     * @param out Outputsettings
+     * @return  Returns whether collapsible or not
      */
     protected final boolean shouldCollapseAttribute(Document.OutputSettings out) {
         return ("".equals(value) || value.equalsIgnoreCase(key))

--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -6,11 +6,13 @@ import java.util.*;
 
 /**
  * The attributes of an Element.
- * <p/>
+ * <p>
  * Attributes are treated as a map: there can be only one value associated with an attribute key.
- * <p/>
+ * </p>
+ * <p>
  * Attribute key and value comparisons are done case insensitively, and keys are normalised to
  * lower-case.
+ * </p>
  * 
  * @author Jonathan Hedley, jonathan@hedley.net
  */

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -361,7 +361,7 @@ public class Document extends Element {
 
         /**
          * Set the indent amount for pretty printing
-         * @param indentAmount number of spaces to use for indenting each level. Must be >= 0.
+         * @param indentAmount number of spaces to use for indenting each level. Must be {@literal >=} 0.
          * @return this, for chaining
          */
         public OutputSettings indentAmount(int indentAmount) {

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -157,9 +157,10 @@ public class Element extends Node {
 
     /**
      * Get a child element of this element, by its 0-based index number.
-     * <p/>
+     * <p>
      * Note that an element can have both mixed Nodes and Elements as children. This method inspects
      * a filtered list of children that are elements, and the index is based on that filtered list.
+     * </p>
      * 
      * @param index the index number of the element to retrieve
      * @return the child element, if it exists, otherwise throws an {@code IndexOutOfBoundsException}
@@ -171,8 +172,9 @@ public class Element extends Node {
 
     /**
      * Get this element's child elements.
-     * <p/>
+     * <p>
      * This is effectively a filter on {@link #childNodes()} to get Element nodes.
+     * </p>
      * @return child elements. If this element has no children, returns an
      * empty list.
      * @see #childNodes()
@@ -189,11 +191,11 @@ public class Element extends Node {
 
     /**
      * Get this element's child text nodes. The list is unmodifiable but the text nodes may be manipulated.
-     * <p/>
+     * <p>
      * This is effectively a filter on {@link #childNodes()} to get Text nodes.
      * @return child text nodes. If this element has no text nodes, returns an
      * empty list.
-     * <p/>
+     * </p>
      * For example, with the input HTML: {@code <p>One <span>Two</span> Three <br> Four</p>} with the {@code p} element selected:
      * <ul>
      *     <li>{@code p.text()} = {@code "One Two Three Four"}</li>
@@ -214,8 +216,9 @@ public class Element extends Node {
 
     /**
      * Get this element's child data nodes. The list is unmodifiable but the data nodes may be manipulated.
-     * <p/>
+     * <p>
      * This is effectively a filter on {@link #childNodes()} to get Data nodes.
+     * </p>
      * @return child data nodes. If this element has no data nodes, returns an
      * empty list.
      * @see #data()
@@ -232,16 +235,18 @@ public class Element extends Node {
     /**
      * Find elements that match the {@link Selector} CSS query, with this element as the starting context. Matched elements
      * may include this element, or any of its children.
-     * <p/>
+     * <p>
      * This method is generally more powerful to use than the DOM-type {@code getElementBy*} methods, because
      * multiple filters can be combined, e.g.:
+     * </p>
      * <ul>
      * <li>{@code el.select("a[href]")} - finds links ({@code a} tags with {@code href} attributes)
      * <li>{@code el.select("a[href*=example.com]")} - finds links pointing to example.com (loosely)
      * </ul>
-     * <p/>
+     * <p>
      * See the query syntax documentation in {@link org.jsoup.select.Selector}.
-     *
+     * </p>
+     * 
      * @param cssQuery a {@link Selector} CSS-like query
      * @return elements that match the query (empty if none match)
      * @see org.jsoup.select.Selector
@@ -447,9 +452,11 @@ public class Element extends Node {
 
     /**
      * Get a CSS selector that will uniquely select this element.
-     * <p/>If the element has an ID, returns #id;
-     * otherwise returns the parent (if any) CSS selector, followed by '>',
+     * <p>
+     * If the element has an ID, returns #id;
+     * otherwise returns the parent (if any) CSS selector, followed by {@literal '>'},
      * followed by a unique selector for the element (tag.class.class:nth-child(n)).
+     * </p>
      *
      * @return the CSS Path that can be used to retrieve the element in a selector.
      */
@@ -493,8 +500,9 @@ public class Element extends Node {
     /**
      * Gets the next sibling element of this element. E.g., if a {@code div} contains two {@code p}s, 
      * the {@code nextElementSibling} of the first {@code p} is the second {@code p}.
-     * <p/>
+     * <p>
      * This is similar to {@link #nextSibling()}, but specifically finds only Elements
+     * </p>
      * @return the next element, or null if there is no next element
      * @see #previousElementSibling()
      */
@@ -975,7 +983,7 @@ public class Element extends Node {
 
     /**
      * Gets the literal value of this element's "class" attribute, which may include multiple class names, space
-     * separated. (E.g. on <code>&lt;div class="header gray"></code> returns, "<code>header gray</code>")
+     * separated. (E.g. on <code>&lt;div class="header gray"&gt;</code> returns, "<code>header gray</code>")
      * @return The literal class attribute, or <b>empty string</b> if no class attribute set.
      */
     public String className() {
@@ -983,7 +991,7 @@ public class Element extends Node {
     }
 
     /**
-     * Get all of the element's class names. E.g. on element {@code <div class="header gray"}>},
+     * Get all of the element's class names. E.g. on element {@code <div class="header gray">},
      * returns a set of two elements {@code "header", "gray"}. Note that modifications to this set are not pushed to
      * the backing {@code class} attribute; use the {@link #classNames(java.util.Set)} method to persist them.
      * @return set of classnames, empty if no class attribute

--- a/src/main/java/org/jsoup/nodes/Entities.java
+++ b/src/main/java/org/jsoup/nodes/Entities.java
@@ -63,7 +63,7 @@ public class Entities {
     /**
      * Get the Character value of the named entity
      * @param name named entity (e.g. "lt" or "amp")
-     * @return the Character value of the named entity (e.g. '<' or '&')
+     * @return the Character value of the named entity (e.g. '{@literal <}' or '{@literal &}')
      */
     public static Character getCharacterByName(String name) {
         return full.get(name);

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -58,10 +58,13 @@ public abstract class Node implements Cloneable {
 
     /**
      * Get an attribute's value by its key.
-     * <p/>
+     * <p>
      * To get an absolute URL from an attribute that may be a relative URL, prefix the key with <code><b>abs</b></code>,
      * which is a shortcut to the {@link #absUrl} method.
-     * E.g.: <blockquote><code>String url = a.attr("abs:href");</code></blockquote>
+     * </p>
+     * E.g.:
+     * <blockquote><code>String url = a.attr("abs:href");</code></blockquote>
+     * 
      * @param attributeKey The attribute key.
      * @return The attribute, or empty string if not present (to avoid nulls).
      * @see #attributes()
@@ -150,19 +153,22 @@ public abstract class Node implements Cloneable {
     }
 
     /**
-     * Get an absolute URL from a URL attribute that may be relative (i.e. an <code>&lt;a href></code> or
-     * <code>&lt;img src></code>).
-     * <p/>
+     * Get an absolute URL from a URL attribute that may be relative (i.e. an <code>&lt;a href&gt;</code> or
+     * <code>&lt;img src&gt;</code>).
+     * <p>
      * E.g.: <code>String absUrl = linkEl.absUrl("href");</code>
-     * <p/>
+     * </p>
+     * <p>
      * If the attribute value is already absolute (i.e. it starts with a protocol, like
      * <code>http://</code> or <code>https://</code> etc), and it successfully parses as a URL, the attribute is
      * returned directly. Otherwise, it is treated as a URL relative to the element's {@link #baseUri}, and made
      * absolute using that.
-     * <p/>
+     * </p>
+     * <p>
      * As an alternate, you can use the {@link #attr} method with the <code>abs:</code> prefix, e.g.:
      * <code>String absUrl = linkEl.attr("abs:href");</code>
-     *
+     * </p>
+     * 
      * @param attributeKey The attribute key
      * @return An absolute URL if one could be made, or an empty string (not null) if the attribute was missing or
      * could not be made successfully into a URL.
@@ -368,12 +374,14 @@ public abstract class Node implements Cloneable {
     /**
      * Removes this node from the DOM, and moves its children up into the node's parent. This has the effect of dropping
      * the node but keeping its children.
-     * <p/>
-     * For example, with the input html:<br/>
-     * {@code <div>One <span>Two <b>Three</b></span></div>}<br/>
-     * Calling {@code element.unwrap()} on the {@code span} element will result in the html:<br/>
-     * {@code <div>One Two <b>Three</b></div>}<br/>
+     * <p>
+     * For example, with the input html:
+     * </p>
+     * <p>{@code <div>One <span>Two <b>Three</b></span></div>}</p>
+     * Calling {@code element.unwrap()} on the {@code span} element will result in the html:
+     * <p>{@code <div>One Two <b>Three</b></div>}</p>
      * and the {@code "Two "} {@link TextNode} being returned.
+     * 
      * @return the first child of this node, after the node has been unwrapped. Null if the node had no children.
      * @see #remove()
      * @see #wrap(String)

--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -39,9 +39,10 @@ public class Tag {
 
     /**
      * Get a Tag by name. If not previously defined (unknown), returns a new generic tag, that can do anything.
-     * <p/>
+     * <p>
      * Pre-defined tags (P, DIV etc) will be ==, but unknown tags are not registered and will only .equals().
-     *
+     * </p>
+     * 
      * @param tagName Name of tag, e.g. "p". Case insensitive.
      * @return The tag, either defined or new generic.
      */

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -10,14 +10,17 @@ import org.jsoup.select.NodeVisitor;
 /**
  The whitelist based HTML cleaner. Use to ensure that end-user provided HTML contains only the elements and attributes
  that you are expecting; no junk, and no cross-site scripting attacks!
- <p/>
+ <p>
  The HTML cleaner parses the input as HTML and then runs it through a white-list, so the output HTML can only contain
  HTML that is allowed by the whitelist.
- <p/>
+ </p>
+ <p>
  It is assumed that the input HTML is a body fragment; the clean methods only pull from the source's body, and the
  canned white-lists only allow body contained tags.
- <p/>
+ </p>
+ <p>
  Rather than interacting directly with a Cleaner object, generally see the {@code clean} methods in {@link org.jsoup.Jsoup}.
+ </p>
  */
 public class Cleaner {
     private Whitelist whitelist;
@@ -50,10 +53,11 @@ public class Cleaner {
     /**
      Determines if the input document is valid, against the whitelist. It is considered valid if all the tags and attributes
      in the input HTML are allowed by the whitelist.
-     <p/>
+     <p>
      This method can be used as a validator for user input forms. An invalid document will still be cleaned successfully
      using the {@link #clean(Document)} document. If using as a validator, it is recommended to still clean the document
      to ensure enforced attributes are set correctly, and that the output is tidied.
+     </p>
      @param dirtyDocument document to test
      @return true if no tags or attributes need to be removed; false if they do
      */

--- a/src/main/java/org/jsoup/safety/Whitelist.java
+++ b/src/main/java/org/jsoup/safety/Whitelist.java
@@ -18,8 +18,9 @@ import java.util.Set;
 
 /**
  Whitelists define what HTML (elements and attributes) to allow through the cleaner. Everything else is removed.
- <p/>
+ <p>
  Start with one of the defaults:
+ </p>
  <ul>
  <li>{@link #none}
  <li>{@link #simpleText}
@@ -27,31 +28,36 @@ import java.util.Set;
  <li>{@link #basicWithImages}
  <li>{@link #relaxed}
  </ul>
- <p/>
+ <p>
  If you need to allow more through (please be careful!), tweak a base whitelist with:
+ </p>
  <ul>
  <li>{@link #addTags}
  <li>{@link #addAttributes}
  <li>{@link #addEnforcedAttribute}
  <li>{@link #addProtocols}
  </ul>
- <p/>
+ <p>
  You can remove any setting from an existing whitelist with:
+ </p>
  <ul>
  <li>{@link #removeTags}
  <li>{@link #removeAttributes}
  <li>{@link #removeEnforcedAttribute}
  <li>{@link #removeProtocols}
  </ul>
- <p/>
+ 
+ <p>
  The cleaner and these whitelists assume that you want to clean a <code>body</code> fragment of HTML (to add user
  supplied HTML into a templated page), and not to clean a full HTML document. If the latter is the case, either wrap the
  document HTML around the cleaned body HTML, or create a whitelist that allows <code>html</code> and <code>head</code>
  elements as appropriate.
- <p/>
+ </p>
+ <p>
  If you are going to extend a whitelist, please be very careful. Make sure you understand what attributes may lead to
  XSS attack vectors. URL attributes are particularly vulnerable and require careful validation. See 
  http://ha.ckers.org/xss.html for some XSS attack examples.
+ </p>
 
  @author Jonathan Hedley
  */
@@ -84,13 +90,17 @@ public class Whitelist {
     }
 
     /**
+     <p>
      This whitelist allows a fuller range of text nodes: <code>a, b, blockquote, br, cite, code, dd, dl, dt, em, i, li,
      ol, p, pre, q, small, span, strike, strong, sub, sup, u, ul</code>, and appropriate attributes.
-     <p/>
+     </p>
+     <p>
      Links (<code>a</code> elements) can point to <code>http, https, ftp, mailto</code>, and have an enforced
      <code>rel=nofollow</code> attribute.
-     <p/>
+     </p>
+     <p>
      Does not allow images.
+     </p>
 
      @return whitelist
      */
@@ -132,8 +142,9 @@ public class Whitelist {
      This whitelist allows a full range of text and structural body HTML: <code>a, b, blockquote, br, caption, cite,
      code, col, colgroup, dd, div, dl, dt, em, h1, h2, h3, h4, h5, h6, i, img, li, ol, p, pre, q, small, span, strike, strong, sub,
      sup, table, tbody, td, tfoot, th, thead, tr, u, ul</code>
-     <p/>
+     <p>
      Links do not have an enforced <code>rel=nofollow</code> attribute, but you can add that if desired.
+     </p>
 
      @return whitelist
      */
@@ -224,12 +235,14 @@ public class Whitelist {
 
     /**
      Add a list of allowed attributes to a tag. (If an attribute is not allowed on an element, it will be removed.)
-     <p/>
+     <p>
      E.g.: <code>addAttributes("a", "href", "class")</code> allows <code>href</code> and <code>class</code> attributes
      on <code>a</code> tags.
-     <p/>
+     </p>
+     <p>
      To make an attribute valid for <b>all tags</b>, use the pseudo tag <code>:all</code>, e.g.
      <code>addAttributes(":all", "class")</code>.
+     </p>
 
      @param tag  The tag the attributes are for. The tag will be added to the allowed tag list if necessary.
      @param keys List of valid attributes for the tag
@@ -259,12 +272,14 @@ public class Whitelist {
 
     /**
      Remove a list of allowed attributes from a tag. (If an attribute is not allowed on an element, it will be removed.)
-     <p/>
+     <p>
      E.g.: <code>removeAttributes("a", "href", "class")</code> disallows <code>href</code> and <code>class</code>
      attributes on <code>a</code> tags.
-     <p/>
+     </p>
+     <p>
      To make an attribute invalid for <b>all tags</b>, use the pseudo tag <code>:all</code>, e.g.
      <code>removeAttributes(":all", "class")</code>.
+     </p>
 
      @param tag  The tag the attributes are for.
      @param keys List of invalid attributes for the tag
@@ -302,9 +317,10 @@ public class Whitelist {
     /**
      Add an enforced attribute to a tag. An enforced attribute will always be added to the element. If the element
      already has the attribute set, it will be overridden.
-     <p/>
+     <p>
      E.g.: <code>addEnforcedAttribute("a", "rel", "nofollow")</code> will make all <code>a</code> tags output as
-     <code>&lt;a href="..." rel="nofollow"></code>
+     <code>&lt;a href="..." rel="nofollow"&gt;</code>
+     </p>
 
      @param tag   The tag the enforced attribute is for. The tag will be added to the allowed tag list if necessary.
      @param key   The attribute key
@@ -359,11 +375,12 @@ public class Whitelist {
      * Configure this Whitelist to preserve relative links in an element's URL attribute, or convert them to absolute
      * links. By default, this is <b>false</b>: URLs will be  made absolute (e.g. start with an allowed protocol, like
      * e.g. {@code http://}.
-     * <p />
+     * <p>
      * Note that when handling relative links, the input document must have an appropriate {@code base URI} set when
      * parsing, so that the link's protocol can be confirmed. Regardless of the setting of the {@code preserve relative
      * links} option, the link must be resolvable against the base URI to an allowed protocol; otherwise the attribute
      * will be removed.
+     * </p>
      *
      * @param preserve {@code true} to allow relative links, {@code false} (default) to deny
      * @return this Whitelist, for chaining.
@@ -377,11 +394,13 @@ public class Whitelist {
     /**
      Add allowed URL protocols for an element's URL attribute. This restricts the possible values of the attribute to
      URLs with the defined protocol.
-     <p/>
+     <p>
      E.g.: <code>addProtocols("a", "href", "ftp", "http", "https")</code>
-     <p/>
+     </p>
+     <p>
      To allow a link to an in-page URL anchor (i.e. <code>&lt;a href="#anchor"&gt;</code>, add a <code>#</code>:<br>
      E.g.: <code>addProtocols("a", "href", "#")</code>
+     </p>
 
      @param tag       Tag the URL protocol is for
      @param key       Attribute key
@@ -420,8 +439,9 @@ public class Whitelist {
 
     /**
      Remove allowed URL protocols for an element's URL attribute.
-     <p/>
+     <p>
      E.g.: <code>removeProtocols("a", "href", "ftp")</code>
+     </p>
 
      @param tag       Tag the URL protocol is for
      @param key       Attribute key

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -9,8 +9,9 @@ import java.util.*;
 
 /**
  A list of {@link Element}s, with methods that act on every element in the list.
- <p/>
+ <p>
  To get an {@code Elements} object, use the {@link Element#select(String)} method.
+ </p>
 
  @author Jonathan Hedley, jonathan@hedley.net */
 public class Elements implements List<Element>, Cloneable {
@@ -352,12 +353,13 @@ public class Elements implements List<Element>, Cloneable {
     /**
      * Removes the matched elements from the DOM, and moves their children up into their parents. This has the effect of
      * dropping the elements but keeping their children.
-     * <p/>
+     * <p>
      * This is useful for e.g removing unwanted formatting elements but keeping their contents.
-     * <p/>
-     * E.g. with HTML: {@code <div><font>One</font> <font><a href="/">Two</a></font></div>}<br/>
-     * {@code doc.select("font").unwrap();}<br/>
-     * HTML = {@code <div>One <a href="/">Two</a></div>}
+     * </p>
+     * 
+     * E.g. with HTML: <p>{@code <div><font>One</font> <font><a href="/">Two</a></font></div>}</p>
+     * <p>{@code doc.select("font").unwrap();}</p>
+     * <p>HTML = {@code <div>One <a href="/">Two</a></div>}</p>
      *
      * @return this (for chaining)
      * @see Node#unwrap

--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -25,6 +25,8 @@ public abstract class Evaluator {
      *
      * @param root    Root of the matching subtree
      * @param element tested element
+     * @return Returns <tt>true</tt> if the requirements are met or
+     * <tt>false</tt> otherwise
      */
     public abstract boolean matches(Element root, Element element);
 
@@ -302,7 +304,7 @@ public abstract class Evaluator {
     }
 
     /**
-     * Evaluator for matching by sibling index number (e < idx)
+     * Evaluator for matching by sibling index number (e {@literal <} idx)
      */
     public static final class IndexLessThan extends IndexEvaluator {
         public IndexLessThan(int index) {
@@ -322,7 +324,7 @@ public abstract class Evaluator {
     }
 
     /**
-     * Evaluator for matching by sibling index number (e > idx)
+     * Evaluator for matching by sibling index number (e {@literal >} idx)
      */
     public static final class IndexGreaterThan extends IndexEvaluator {
         public IndexGreaterThan(int index) {

--- a/src/main/java/org/jsoup/select/NodeTraversor.java
+++ b/src/main/java/org/jsoup/select/NodeTraversor.java
@@ -4,8 +4,9 @@ import org.jsoup.nodes.Node;
 
 /**
  * Depth-first node traversor. Use to iterate through all nodes under and including the specified root node.
- * <p/>
+ * <p>
  * This implementation does not use recursion, so a deep DOM does not risk blowing the stack.
+ * </p>
  */
 public class NodeTraversor {
     private NodeVisitor visitor;

--- a/src/main/java/org/jsoup/select/NodeVisitor.java
+++ b/src/main/java/org/jsoup/select/NodeVisitor.java
@@ -4,10 +4,11 @@ import org.jsoup.nodes.Node;
 
 /**
  * Node visitor interface. Provide an implementing class to {@link NodeTraversor} to iterate through nodes.
- * <p/>
+ * <p>
  * This interface provides two methods, {@code head} and {@code tail}. The head method is called when the node is first
  * seen, and the tail method when all of the node's children have been visited. As an example, head can be used to
  * create a start tag for a node, and tail to create the end tag.
+ * </p>
  */
 public interface NodeVisitor {
     /**

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -8,19 +8,21 @@ import java.util.LinkedHashSet;
 
 /**
  * CSS-like element selector, that finds elements matching a query.
- * <p/>
+ * 
  * <h2>Selector syntax</h2>
+ * <p>
  * A selector is a chain of simple selectors, separated by combinators. Selectors are case insensitive (including against
  * elements, attributes, and attribute values).
- * <p/>
+ * </p>
+ * <p>
  * The universal selector (*) is implicit when no element selector is supplied (i.e. {@code *.header} and {@code .header}
  * is equivalent).
- * <p/>
- * <table>
+ * </p>
+ * <table summary="">
  * <tr><th align="left">Pattern</th><th align="left">Matches</th><th align="left">Example</th></tr>
  * <tr><td><code>*</code></td><td>any element</td><td><code>*</code></td></tr>
  * <tr><td><code>tag</code></td><td>elements with the given tag name</td><td><code>div</code></td></tr>
- * <tr><td><code>ns|E</code></td><td>elements of type E in the namespace <i>ns</i></td><td><code>fb|name</code> finds <code>&lt;fb:name></code> elements</td></tr>
+ * <tr><td><code>ns|E</code></td><td>elements of type E in the namespace <i>ns</i></td><td><code>fb|name</code> finds <code>&lt;fb:name&gt;</code> elements</td></tr>
  * <tr><td><code>#id</code></td><td>elements with attribute ID of "id"</td><td><code>div#wrap</code>, <code>#logo</code></td></tr>
  * <tr><td><code>.class</code></td><td>elements with a class name of "class"</td><td><code>div.left</code>, <code>.result</code></td></tr>
  * <tr><td><code>[attr]</code></td><td>elements with an attribute named "attr" (with any value)</td><td><code>a[href]</code>, <code>[title]</code></td></tr>
@@ -34,7 +36,7 @@ import java.util.LinkedHashSet;
  * <tr><td></td><td>The above may be combined in any order</td><td><code>div.header[title]</code></td></tr>
  * <tr><td><td colspan="3"><h3>Combinators</h3></td></tr>
  * <tr><td><code>E F</code></td><td>an F element descended from an E element</td><td><code>div a</code>, <code>.logo h1</code></td></tr>
- * <tr><td><code>E > F</code></td><td>an F direct child of E</td><td><code>ol > li</code></td></tr>
+ * <tr><td><code>E {@literal >} F</code></td><td>an F direct child of E</td><td><code>ol {@literal >} li</code></td></tr>
  * <tr><td><code>E + F</code></td><td>an F element immediately preceded by sibling E</td><td><code>li + li</code>, <code>div.head + div</code></td></tr>
  * <tr><td><code>E ~ F</code></td><td>an F element preceded by sibling E</td><td><code>h1 ~ p</code></td></tr>
  * <tr><td><code>E, F, G</code></td><td>all matching elements E, F, or G</td><td><code>a[href], div, h3</code></td></tr>
@@ -43,7 +45,7 @@ import java.util.LinkedHashSet;
  * <tr><td><code>:gt(<em>n</em>)</code></td><td>elements whose sibling index is greater than <em>n</em></td><td><code>td:gt(1)</code> finds cells after skipping the first two</td></tr>
  * <tr><td><code>:eq(<em>n</em>)</code></td><td>elements whose sibling index is equal to <em>n</em></td><td><code>td:eq(0)</code> finds the first cell of each row</td></tr>
  * <tr><td><code>:has(<em>selector</em>)</code></td><td>elements that contains at least one element matching the <em>selector</em></td><td><code>div:has(p)</code> finds divs that contain p elements </td></tr>
- * <tr><td><code>:not(<em>selector</em>)</code></td><td>elements that do not match the <em>selector</em>. See also {@link Elements#not(String)}</td><td><code>div:not(.logo)</code> finds all divs that do not have the "logo" class.<br /><code>div:not(:has(div))</code> finds divs that do not contain divs.</td></tr>
+ * <tr><td><code>:not(<em>selector</em>)</code></td><td>elements that do not match the <em>selector</em>. See also {@link Elements#not(String)}</td><td><code>div:not(.logo)</code> finds all divs that do not have the "logo" class.<p><code>div:not(:has(div))</code> finds divs that do not contain divs.</p></td></tr>
  * <tr><td><code>:contains(<em>text</em>)</code></td><td>elements that contains the specified text. The search is case insensitive. The text may appear in the found element, or any of its descendants.</td><td><code>p:contains(jsoup)</code> finds p elements containing the text "jsoup".</td></tr>
  * <tr><td><code>:matches(<em>regex</em>)</code></td><td>elements whose text matches the specified regular expression. The text may appear in the found element, or any of its descendants.</td><td><code>td:matches(\\d+)</code> finds table cells containing digits. <code>div:matches((?i)login)</code> finds divs containing the text, case insensitively.</td></tr>
  * <tr><td><code>:containsOwn(<em>text</em>)</code></td><td>elements that directly contain the specified text. The search is case insensitive. The text must appear in the found element, not any of its descendants.</td><td><code>p:containsOwn(jsoup)</code> finds p elements with own text "jsoup".</td></tr>
@@ -56,15 +58,15 @@ import java.util.LinkedHashSet;
  * <tr><td><code>:nth-last-child(<em>a</em>n+<em>b</em>)</code></td><td>elements that have <code><em>a</em>n+<em>b</em>-1</code> siblings <b>after</b> it in the document tree. Otherwise like <code>:nth-child()</code></td><td><code>tr:nth-last-child(-n+2)</code> the last two rows of a table</td></tr>
  * <tr><td><code>:nth-of-type(<em>a</em>n+<em>b</em>)</code></td><td>pseudo-class notation represents an element that has <code><em>a</em>n+<em>b</em>-1</code> siblings with the same expanded element name <em>before</em> it in the document tree, for any zero or positive integer value of n, and has a parent element</td><td><code>img:nth-of-type(2n+1)</code></td></tr>
  * <tr><td><code>:nth-last-of-type(<em>a</em>n+<em>b</em>)</code></td><td>pseudo-class notation represents an element that has <code><em>a</em>n+<em>b</em>-1</code> siblings with the same expanded element name <em>after</em> it in the document tree, for any zero or positive integer value of n, and has a parent element</td><td><code>img:nth-last-of-type(2n+1)</code></td></tr>
- * <tr><td><code>:first-child</code></td><td>elements that are the first child of some other element.</td><td><code>div > p:first-child</code></td></tr>
- * <tr><td><code>:last-child</code></td><td>elements that are the last child of some other element.</td><td><code>ol > li:last-child</code></td></tr>
+ * <tr><td><code>:first-child</code></td><td>elements that are the first child of some other element.</td><td><code>div {@literal >} p:first-child</code></td></tr>
+ * <tr><td><code>:last-child</code></td><td>elements that are the last child of some other element.</td><td><code>ol {@literal >} li:last-child</code></td></tr>
  * <tr><td><code>:first-of-type</code></td><td>elements that are the first sibling of its type in the list of children of its parent element</td><td><code>dl dt:first-of-type</code></td></tr>
- * <tr><td><code>:last-of-type</code></td><td>elements that are the last sibling of its type in the list of children of its parent element</td><td><code>tr > td:last-of-type</code></td></tr>
+ * <tr><td><code>:last-of-type</code></td><td>elements that are the last sibling of its type in the list of children of its parent element</td><td><code>tr {@literal >} td:last-of-type</code></td></tr>
  * <tr><td><code>:only-child</code></td><td>elements that have a parent element and whose parent element hasve no other element children</td><td></td></tr>
  * <tr><td><code>:only-of-type</code></td><td> an element that has a parent element and whose parent element has no other element children with the same expanded element name</td><td></td></tr>
  * <tr><td><code>:empty</code></td><td>elements that have no children at all</td><td></td></tr>
  * </table>
- *
+ * 
  * @author Jonathan Hedley, jonathan@hedley.net
  * @see Element#select(String)
  */


### PR DESCRIPTION
Building Jsoup with JDK8 causes a long list of JavaDoc *warnings (5)* and *errors (86)*. Maven reports a failed build for Javadoc, however it's still working and correct. The reason is, that JDK8 introduced stricter rules for html formating.

This pull request fixes *all* of these errors / warnings so a clean and successful build is possible with JDK8. The documentation's formating itself is kept.