### PR TITLE
Add option to configure Jsoup's attribute normilization.

### DIFF
--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -1,11 +1,11 @@
 package org.jsoup;
 
+import org.jsoup.helper.DataUtil;
+import org.jsoup.helper.HttpConnection;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Whitelist;
-import org.jsoup.helper.DataUtil;
-import org.jsoup.helper.HttpConnection;
 
 import java.io.File;
 import java.io.IOException;
@@ -241,12 +241,37 @@ public class Jsoup {
      @param bodyHtml HTML to test
      @param whitelist whitelist to test against
      @return true if no tags or attributes were removed; false otherwise
-     @see #clean(String, org.jsoup.safety.Whitelist) 
+     @see #clean(String, org.jsoup.safety.Whitelist)
      */
     public static boolean isValid(String bodyHtml, Whitelist whitelist) {
         Document dirty = parseBodyFragment(bodyHtml, "");
         Cleaner cleaner = new Cleaner(whitelist);
         return cleaner.isValid(dirty);
     }
-    
+
+    private static Object lock = new Object();
+    private static JsoupOptions options;
+
+    /**
+     * Get the current active options for Jsoup, see: {@link JsoupOptions}.
+     * @return options object.
+     */
+    public static JsoupOptions options() {
+      synchronized (lock) {
+        if (options == null) {
+          return JsoupOptions.DEFAULT_OPTIONS;
+        }
+        return options;
+      }
+    }
+
+    /**
+     * Change the current active options object that Jsoup uses.
+     * @param jsoupOptions the new options object to use
+     */
+    public static void options(JsoupOptions jsoupOptions) {
+      synchronized (lock) {
+        options = jsoupOptions;
+      }
+    }
 }

--- a/src/main/java/org/jsoup/JsoupOptions.java
+++ b/src/main/java/org/jsoup/JsoupOptions.java
@@ -1,0 +1,42 @@
+package org.jsoup;
+
+/**
+ The Jsoup options.
+
+ @author Daniel Kurka */
+public class JsoupOptions {
+
+  public static final JsoupOptions DEFAULT_OPTIONS =
+      new Builder().normalizeAttributes(true).build();
+
+  private boolean normalizeAttributes;
+
+  /**
+   Should Jsoup normalize attributes. This will turn all attribute keys into
+   lowercase.
+   */
+  public boolean shouldNormalizeAttributes() {
+    return normalizeAttributes;
+  }
+
+  /**
+   A builder to create a JsoupOptions object.
+  */
+  public static class Builder {
+    private JsoupOptions options = new JsoupOptions();
+
+    /**
+     Should we normalize attributes:
+
+     This would turn an uppercase attribute key into all lowercase.
+     */
+    public Builder normalizeAttributes(boolean normalize) {
+      options.normalizeAttributes = normalize;
+      return this;
+    }
+
+    public JsoupOptions build() {
+      return options;
+    }
+  }
+}

--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -1,5 +1,6 @@
 package org.jsoup.nodes;
 
+import org.jsoup.Jsoup;
 import org.jsoup.helper.Validate;
 
 import java.util.Arrays;
@@ -29,7 +30,11 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     public Attribute(String key, String value) {
         Validate.notEmpty(key);
         Validate.notNull(value);
-        this.key = key.trim().toLowerCase();
+        if (Jsoup.options().shouldNormalizeAttributes()) {
+          this.key = key.trim().toLowerCase();
+        } else {
+          this.key = key.trim();
+        }
         this.value = value;
     }
 
@@ -47,7 +52,11 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
      */
     public void setKey(String key) {
         Validate.notEmpty(key);
-        this.key = key.trim().toLowerCase();
+        if (Jsoup.options().shouldNormalizeAttributes()) {
+          this.key = key.trim().toLowerCase();
+        } else {
+          this.key = key.trim();
+        }
     }
 
     /**
@@ -78,7 +87,7 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
         html(accum, (new Document("")).outputSettings());
         return accum.toString();
     }
-    
+
     protected void html(StringBuilder accum, Document.OutputSettings out) {
         accum.append(key);
         if (!shouldCollapseAttribute(out)) {

--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -1,5 +1,7 @@
 package org.jsoup.nodes;
 
+import org.jsoup.Jsoup;
+import org.jsoup.JsoupOptions;
 import org.jsoup.helper.Validate;
 
 import java.util.*;
@@ -11,12 +13,12 @@ import java.util.*;
  * <p/>
  * Attribute key and value comparisons are done case insensitively, and keys are normalised to
  * lower-case.
- * 
+ *
  * @author Jonathan Hedley, jonathan@hedley.net
  */
 public class Attributes implements Iterable<Attribute>, Cloneable {
     protected static final String dataPrefix = "data-";
-    
+
     private LinkedHashMap<String, Attribute> attributes = null;
     // linked hash map to preserve insertion order.
     // null be default as so many elements have no attributes -- saves a good chunk of memory
@@ -33,7 +35,10 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         if (attributes == null)
             return "";
 
-        Attribute attr = attributes.get(key.toLowerCase());
+        if (Jsoup.options().shouldNormalizeAttributes()) {
+          key = key.toLowerCase();
+        }
+        Attribute attr = attributes.get(key);
         return attr != null ? attr.getValue() : "";
     }
 
@@ -66,7 +71,11 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         Validate.notEmpty(key);
         if (attributes == null)
             return;
-        attributes.remove(key.toLowerCase());
+
+        if (Jsoup.options().shouldNormalizeAttributes()) {
+          key = key.toLowerCase();
+        }
+        attributes.remove(key);
     }
 
     /**
@@ -75,7 +84,10 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
      @return true if key exists, false otherwise
      */
     public boolean hasKey(String key) {
-        return attributes != null && attributes.containsKey(key.toLowerCase());
+        if (Jsoup.options().shouldNormalizeAttributes()) {
+          key = key.toLowerCase();
+        }
+        return attributes != null && attributes.containsKey(key);
     }
 
     /**
@@ -99,7 +111,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
             attributes = new LinkedHashMap<String, Attribute>(incoming.size());
         attributes.putAll(incoming.attributes);
     }
-    
+
     public Iterator<Attribute> iterator() {
         return asList().iterator();
     }
@@ -138,33 +150,33 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         html(accum, (new Document("")).outputSettings()); // output settings a bit funky, but this html() seldom used
         return accum.toString();
     }
-    
+
     void html(StringBuilder accum, Document.OutputSettings out) {
         if (attributes == null)
             return;
-        
+
         for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
             Attribute attribute = entry.getValue();
             accum.append(" ");
             attribute.html(accum, out);
         }
     }
-    
+
     @Override
     public String toString() {
         return html();
     }
-    
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Attributes)) return false;
-        
+
         Attributes that = (Attributes) o;
-        
+
         return !(attributes != null ? !attributes.equals(that.attributes) : that.attributes != null);
     }
-    
+
     @Override
     public int hashCode() {
         return attributes != null ? attributes.hashCode() : 0;

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -1,5 +1,8 @@
 package org.jsoup.parser;
 
+import org.jsoup.Jsoup;
+import org.jsoup.JsoupOptions;
+
 import java.util.Arrays;
 
 /**
@@ -646,7 +649,11 @@ enum TokeniserState {
         // from before attribute name
         void read(Tokeniser t, CharacterReader r) {
             String name = r.consumeToAnySorted(attributeNameCharsSorted);
-            t.tagPending.appendAttributeName(name.toLowerCase());
+
+            if (Jsoup.options().shouldNormalizeAttributes()) {
+              name = name.toLowerCase();
+            }
+            t.tagPending.appendAttributeName(name);
 
             char c = r.consume();
             switch (c) {

--- a/src/test/java/org/jsoup/nodes/AttributeTest.java
+++ b/src/test/java/org/jsoup/nodes/AttributeTest.java
@@ -1,5 +1,7 @@
 package org.jsoup.nodes;
 
+import org.jsoup.Jsoup;
+import org.jsoup.JsoupOptions;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -16,5 +18,19 @@ public class AttributeTest {
         Attribute attr = new Attribute(s, "A" + s + "B");
         assertEquals(s + "=\"A" + s + "B\"", attr.html());
         assertEquals(attr.html(), attr.toString());
+    }
+
+    @Test public void testNotNormalizingAttributes() {
+        JsoupOptions oldOptions = Jsoup.options();
+        try {
+          Jsoup.options(new JsoupOptions.Builder().normalizeAttributes(false).build());
+          String s = "showCenterMarker";
+          Attribute attr = new Attribute(s, "somevalue");
+          assertEquals(s + "=\"somevalue\"", attr.html());
+          assertEquals(attr.html(), attr.toString());
+        } finally {
+          // Make sure we reset normalizing attributes even if the test fails
+          Jsoup.options(oldOptions);
+        }
     }
 }


### PR DESCRIPTION
Currently Jsoup turns all keys of attributes into lowercase.
This breaks Jsoup when being used with many modern web projects
such as Polymer (https://www.polymer-project.org/) since these
projects use camel case attributes in their code.

This patch adds an option to Jsoup so that users can disable
this kind of normaliztion.

fix #328, #272, #29
