### PR TITLE
Addressing slow Element.outerHtml() on Android 4.4 and 5

### DIFF
--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -191,6 +191,11 @@ public class Document extends Element {
         return super.html(); // no outer wrapper tag
     }
 
+    @Override
+    public String outerHtml(int initLength) {
+        return super.html(initLength);
+    }
+
     /**
      Set the text of the {@code body} of this document. Any existing nodes within the body will be cleared.
      @param text unencoded text

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1143,6 +1143,12 @@ public class Element extends Node {
         return getOutputSettings().prettyPrint() ? accum.toString().trim() : accum.toString();
     }
 
+    public String html(int initLength) {
+        StringBuilder accum = new StringBuilder(initLength);
+        html(accum);
+        return getOutputSettings().prettyPrint() ? accum.toString().trim() : accum.toString();
+    }
+
     private void html(StringBuilder accum) {
         for (Node node : childNodes)
             node.outerHtml(accum);

--- a/src/main/java/org/jsoup/nodes/Entities.java
+++ b/src/main/java/org/jsoup/nodes/Entities.java
@@ -83,6 +83,7 @@ public class Entities {
         boolean reachedNonWhite = false;
         EscapeMode escapeMode = out.escapeMode();
         CharsetEncoder encoder = out.encoder();
+        boolean encIsUnicode = encoder.charset().name().toUpperCase().startsWith("UTF-");
         Map<Character, String> map = escapeMode.getMap();
         final int length = string.length();
 
@@ -135,7 +136,7 @@ public class Entities {
                             accum.append(c);
                         break;
                     default:
-                        if (encoder.canEncode(c))
+                        if (encIsUnicode || encoder.canEncode(c))
                             accum.append(c);
                         else if (map.containsKey(c))
                             accum.append('&').append(map.get(c)).append(';');
@@ -144,7 +145,7 @@ public class Entities {
                 }
             } else {
                 final String c = new String(Character.toChars(codePoint));
-                if (encoder.canEncode(c))
+                if (encIsUnicode || encoder.canEncode(c))
                     accum.append(c);
                 else
                     accum.append("&#x").append(Integer.toHexString(codePoint)).append(';');

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -499,10 +499,9 @@ public abstract class Node implements Cloneable {
             return null; // root
         
         List<Node> siblings = parentNode.childNodes;
-        Integer index = siblingIndex();
-        Validate.notNull(index);
-        if (siblings.size() > index+1)
-            return siblings.get(index+1);
+        int index = siblingIndex();
+        if (siblings.size() > ++index)
+            return siblings.get(index);
         else
             return null;
     }
@@ -516,8 +515,7 @@ public abstract class Node implements Cloneable {
             return null; // root
 
         List<Node> siblings = parentNode.childNodes;
-        Integer index = siblingIndex();
-        Validate.notNull(index);
+        int index = siblingIndex();
         if (index > 0)
             return siblings.get(index-1);
         else
@@ -555,7 +553,11 @@ public abstract class Node implements Cloneable {
      @return HTML
      */
     public String outerHtml() {
-        StringBuilder accum = new StringBuilder(128);
+        return outerHtml(128);
+    }
+
+    public String outerHtml(int initLength) {
+        StringBuilder accum = new StringBuilder(initLength);
         outerHtml(accum);
         return accum.toString();
     }


### PR DESCRIPTION
The big slowdown on Android 4.4 and 5 is the call to canEncode(c) in Entities.escape() method. Assuming that virtually any codepoint can be encoded in Unicode (e.g. UTF-8, UTF-16), added a check for encoder being Unicode and skipping this costly call. Speeds up Android 4.4 and 5 calls about 10 times.
Added some small other optimizations in a few other modules.

Greg