### PR TITLE
Add custom boolean attribute support #503

### DIFF
--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -121,7 +121,11 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     protected final boolean shouldCollapseAttribute(Document.OutputSettings out) {
         return ("".equals(value) || value.equalsIgnoreCase(key))
                 && out.syntax() == Document.OutputSettings.Syntax.html
-                && Arrays.binarySearch(booleanAttributes, key) >= 0;
+                && isBooleanAttribute();
+    }
+
+    protected boolean isBooleanAttribute() {
+        return Arrays.binarySearch(booleanAttributes, key) >= 0;
     }
 
     @Override

--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -48,6 +48,18 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         Attribute attr = new Attribute(key, value);
         put(attr);
     }
+    
+    /**
+    Set a new boolean attribute, remove attribute if value is false.
+    @param key attribute key
+    @param value attribute value
+    */
+    public void put(String key, boolean value) {
+        if (value)
+            put(new BooleanAttribute(key));
+        else
+            remove(key);
+    }
 
     /**
      Set a new attribute, or replace an existing one by key.

--- a/src/main/java/org/jsoup/nodes/BooleanAttribute.java
+++ b/src/main/java/org/jsoup/nodes/BooleanAttribute.java
@@ -1,0 +1,19 @@
+package org.jsoup.nodes;
+
+/**
+ * A boolean attribute that is written out without any value.
+ */
+public class BooleanAttribute extends Attribute {
+    /**
+     * Create a new boolean attribute from unencoded (raw) key.
+     * @param key attribute key
+     */
+    public BooleanAttribute(String key) {
+        super(key, "");
+    }
+
+    @Override
+    protected boolean isBooleanAttribute() {
+        return true;
+    }
+}

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -116,6 +116,21 @@ public class Element extends Node {
         super.attr(attributeKey, attributeValue);
         return this;
     }
+    
+    /**
+     * Set a boolean attribute value on this element. Setting to <code>true</code> sets the attribute value to "" and
+     * marks the attribute as boolean so no value is written out. Setting to <code>false</code> removes the attribute
+     * with the same key if it exists.
+     * 
+     * @param attributeKey the attribute key
+     * @param attributeValue the attribute value
+     * 
+     * @return this element
+     */
+    public Element attr(String attributeKey, boolean attributeValue) {
+        attributes.put(attributeKey, attributeValue);
+        return this;
+    }
 
     /**
      * Get this element's HTML5 custom data attributes. Each attribute in the element that has a key

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -782,6 +782,8 @@ enum TokeniserState {
             String value = r.consumeToAnySorted(attributeDoubleValueCharsSorted);
             if (value.length() > 0)
                 t.tagPending.appendAttributeValue(value);
+            else
+                t.tagPending.setEmptyAttributeValue();
 
             char c = r.consume();
             switch (c) {
@@ -812,6 +814,8 @@ enum TokeniserState {
             String value = r.consumeToAnySorted(attributeSingleValueCharsSorted);
             if (value.length() > 0)
                 t.tagPending.appendAttributeValue(value);
+            else
+                t.tagPending.setEmptyAttributeValue();
 
             char c = r.consume();
             switch (c) {

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -294,6 +294,22 @@ public class ElementTest {
             assertEquals(i, ps.get(i).siblingIndex);
         }
     }
+    
+    @Test public void testAddBooleanAttribute() {
+        Element div = new Element(Tag.valueOf("div"), "");
+        
+        div.attr("true", true);
+        
+        div.attr("false", "value");
+        div.attr("false", false);
+        
+        assertTrue(div.hasAttr("true"));
+        assertEquals("", div.attr("true"));
+        
+        assertFalse(div.hasAttr("false"));
+ 
+        assertEquals("<div true></div>", div.outerHtml());
+    }    
 
     @Test public void testAppendRowToTable() {
         Document doc = Jsoup.parse("<table><tr><td>1</td></tr></table>");

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -306,6 +306,10 @@ public class ElementTest {
         assertTrue(div.hasAttr("true"));
         assertEquals("", div.attr("true"));
         
+        List<Attribute> attributes = div.attributes().asList();
+        assertEquals("There should be one attribute", 1, attributes.size());
+		assertTrue("Attribute should be boolean", attributes.get(0) instanceof BooleanAttribute);
+        
         assertFalse(div.hasAttr("false"));
  
         assertEquals("<div true></div>", div.outerHtml());

--- a/src/test/java/org/jsoup/parser/AttributeParseTest.java
+++ b/src/test/java/org/jsoup/parser/AttributeParseTest.java
@@ -1,7 +1,11 @@
 package org.jsoup.parser;
 
+import java.util.List;
+
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.BooleanAttribute;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.junit.Test;
@@ -74,6 +78,14 @@ public class AttributeParseTest {
         assertEquals("123", el.attr("normal"));
         assertEquals("", el.attr("boolean"));
         assertEquals("", el.attr("empty"));
+        
+        List<Attribute> attributes = el.attributes().asList();
+        assertEquals("There should be 3 attribute present", 3, attributes.size());
+        
+        // Assuming the list order always follows the parsed html
+		assertFalse("'normal' attribute should not be boolean", attributes.get(0) instanceof BooleanAttribute);        
+		assertTrue("'boolean' attribute should be boolean", attributes.get(1) instanceof BooleanAttribute);        
+		assertFalse("'empty' attribute should not be boolean", attributes.get(2) instanceof BooleanAttribute);        
         
         assertEquals(html, el.outerHtml());
     }

--- a/src/test/java/org/jsoup/parser/AttributeParseTest.java
+++ b/src/test/java/org/jsoup/parser/AttributeParseTest.java
@@ -66,4 +66,16 @@ public class AttributeParseTest {
         Elements els = Jsoup.parse(html).select("a");
         assertEquals("&wr_id=123&mid-size=true&ok=&wr", els.first().attr("href"));
     }
+    
+    @Test public void parsesBooleanAttributes() {
+        String html = "<a normal=\"123\" boolean empty=\"\"></a>";
+        Element el = Jsoup.parse(html).select("a").first();
+        
+        assertEquals("123", el.attr("normal"));
+        assertEquals("", el.attr("boolean"));
+        assertEquals("", el.attr("empty"));
+        
+        assertEquals(html, el.outerHtml());
+    }
+    
 }

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -43,11 +43,11 @@ public class HtmlParserTest {
         String html = "<p =a>One<a <p>Something</p>Else";
         // this gets a <p> with attr '=a' and an <a tag with an attribue named '<p'; and then auto-recreated
         Document doc = Jsoup.parse(html);
-        assertEquals("<p =a=\"\">One<a <p=\"\">Something</a></p>\n" +
-                "<a <p=\"\">Else</a>", doc.body().html());
+        assertEquals("<p =a>One<a <p>Something</a></p>\n" +
+                "<a <p>Else</a>", doc.body().html());
 
         doc = Jsoup.parse("<p .....>");
-        assertEquals("<p .....=\"\"></p>", doc.body().html());
+        assertEquals("<p .....></p>", doc.body().html());
     }
 
     @Test public void parsesComments() {


### PR DESCRIPTION
* Adds BooleanAttribute that writes out itself without a value
* Adds API in Element for setting boolean attributes
* Update parser to distinguish between no value and empty value