### PR TITLE
Add support of domain validation for "href" and "src" attributes

### DIFF
--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -86,7 +86,7 @@ public class Cleaner {
             if (source instanceof Element) {
                 Element sourceEl = (Element) source;
 
-                if (whitelist.isSafeTag(sourceEl.tagName())) { // safe, clone and copy safe attrs
+                if (whitelist.isSafeTag(sourceEl)) { // safe, clone and copy safe attrs
                     ElementMeta meta = createSafeElement(sourceEl);
                     Element destChild = meta.el;
                     destination.appendChild(destChild);
@@ -110,7 +110,7 @@ public class Cleaner {
         }
 
         public void tail(Node source, int depth) {
-            if (source instanceof Element && whitelist.isSafeTag(source.nodeName())) {
+            if (source instanceof Element && whitelist.isSafeTag((Element)source)) {
                 destination = destination.parent(); // would have descended, so pop destination stack
             }
         }

--- a/src/main/java/org/jsoup/safety/Whitelist.java
+++ b/src/main/java/org/jsoup/safety/Whitelist.java
@@ -451,10 +451,10 @@ public class Whitelist {
     Add allowed URL domain for an element's URL attribute. This restricts the possible values of the attribute to
     URLs with the defined protocol.
     <p>
-    E.g.: <code>addDomains("a", "href", "knowings.fr")</code>
+    E.g.: <code>addDomains("a", "href", "jsoup.org")</code>
     </p>
 
-    @param tag       Tag the URL domain is for
+    @param tag       Tag the allowed domain is for
     @param key       Attribute key
     @param domains List of valid domains
     @return this, for chaining
@@ -529,7 +529,7 @@ public class Whitelist {
     }
     
     /**
-     Remove allowed URL protocols for an element's URL attribute.
+     Remove allowed domains for an element's URL attribute.
      <p>
      E.g.: <code>removeDomains("a", "href", "knowings.fr")</code>
      </p>
@@ -670,21 +670,18 @@ public class Whitelist {
     	_url = el.absUrl(attrKey.toString());
     	if (_url.length() == 0) {
     		_url = el.attr(attrKey.toString());
-    		if (_url.startsWith("//")) {
-    			_url = "http:" + _url; 
-    		} else {
-    			_url = "http://" + _url;
-    		}
+    		_url = ((_url.startsWith("//"))? "http:" : "http://"  ) + _url;
     	}
     	try {
     		URL url = new URL(_url);
     		String host = url.getHost();
-    		if (host != null) {
+    		if (!StringUtil.isBlank(host)) {
+    			host = host.toLowerCase();
     			Iterator<UrlDomain> it = domains.iterator();
     			boolean isValid = false;
     			while (it.hasNext() && !isValid) {
-    				UrlDomain domain = it.next();
-    				isValid = host.toLowerCase().endsWith(domain.toString().toLowerCase()); 
+    				String domain = it.next().toString().toLowerCase();
+    				isValid = host.equals(domain) || host.endsWith("."+domain); 
     			}
     			return isValid;
     		}

--- a/src/test/java/org/jsoup/nodes/NodeTest.java
+++ b/src/test/java/org/jsoup/nodes/NodeTest.java
@@ -2,6 +2,7 @@ package org.jsoup.nodes;
 
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
+import org.jsoup.helper.StringUtil;
 import org.jsoup.parser.Tag;
 import org.jsoup.select.NodeVisitor;
 import org.junit.Test;
@@ -101,15 +102,18 @@ public class NodeTest {
     public void handlesAbsOnProtocolessAbsoluteUris() {
         Document doc1 = Jsoup.parse("<a href='//example.net/foo'>One</a>", "http://example.com/");
         Document doc2 = Jsoup.parse("<a href='//example.net/foo'>One</a>", "https://example.com/");
-
+        Document doc3 = Jsoup.parse("<a href='//example.net/foo'>One</a>");
+        
         Element one = doc1.select("a").first();
         Element two = doc2.select("a").first();
-
+        Element three = doc3.select("a").first();
+        
         assertEquals("http://example.net/foo", one.absUrl("href"));
         assertEquals("https://example.net/foo", two.absUrl("href"));
-
-        Document doc3 = Jsoup.parse("<img src=//www.google.com/images/errors/logo_sm.gif alt=Google>", "https://google.com");
-        assertEquals("https://www.google.com/images/errors/logo_sm.gif", doc3.select("img").attr("abs:src"));
+        assertTrue(StringUtil.isBlank(three.absUrl("href")));
+        
+        Document doc4 = Jsoup.parse("<img src=//www.google.com/images/errors/logo_sm.gif alt=Google>", "https://google.com");
+        assertEquals("https://www.google.com/images/errors/logo_sm.gif", doc4.select("img").attr("abs:src"));
     }
 
     /*

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -248,15 +248,18 @@ public class CleanerTest {
     	Whitelist whitelist = Whitelist.relaxed();
     	
     	// Tests upon href attribute
-    	whitelist.addDomains("a", "href", "knowings.fr");
+    	whitelist.addDomains("a", "href", "jsoup.org");
     	assertTrue(Jsoup.isValid("<a>Success</a>", whitelist));
     	assertTrue(Jsoup.isValid("<a title=\"success\">Success</a>", whitelist));
     	// Anchor aren't supported by default
     	assertFalse(Jsoup.isValid("<a href=\"#success\">Success</a>", whitelist));
     	// Subdomain should be accepted
-    	assertTrue(Jsoup.isValid("<a href=\"http://cdn.knowings.fr:8080/resources/success.html\">Success</a>", whitelist));
+    	assertTrue(Jsoup.isValid("<a href=\"http://jsoup.org:8080/resources/success.html\">Success</a>", whitelist));
+    	assertTrue(Jsoup.isValid("<a href=\"http://cdn.jsoup.org:8080/resources/success.html\">Success</a>", whitelist));
+    	assertFalse(Jsoup.isValid("<a href=\"http://eviljsoup.org:8080/resources/success.html\">Success</a>", whitelist));
+    	assertFalse(Jsoup.isValid("<a href=\"http://cdn.eviljsoup.org:8080/resources/success.html\">Success</a>", whitelist));
     	// Without proper protocol it should behave as usual
-    	assertFalse(Jsoup.isValid("<a href=\"//cdn.knowings.fr:8080/resources/success.html\">Success</a>", whitelist));
+    	assertFalse(Jsoup.isValid("<a href=\"//cdn.jsoup.org:8080/resources/success.html\">Success</a>", whitelist));
     	// Empty url should allways be invalid against the whitelist
     	assertFalse(Jsoup.isValid("<a href=\"\">Success</a>", whitelist));
     	// Domain constraint should be met to be valid against the whitelist.
@@ -266,25 +269,25 @@ public class CleanerTest {
     	assertTrue(Jsoup.isValid("<a href=\"#success\">Success</a>", whitelist));
     	// After removing support of a protocol, it should behave as usual. 
     	whitelist.removeProtocols("a", "href", "http");
-    	assertFalse(Jsoup.isValid("<a href=\"http://cdn.knowings.fr:8080/resources/success.html\">Success</a>", whitelist));
+    	assertFalse(Jsoup.isValid("<a href=\"http://cdn.jsoup.org:8080/resources/success.html\">Success</a>", whitelist));
     	
     	// Tests upon src attribute
     	whitelist.addTags("iframe");
     	whitelist.addAttributes("iframe", "src", "title");
     	whitelist.addProtocols("iframe", "src", "http", "https");
-    	whitelist.addDomains("iframe", "src", "knowings.fr");
+    	whitelist.addDomains("iframe", "src", "jsoup.org");
     	assertTrue(Jsoup.isValid("<iframe>Success</iframe>", whitelist));
     	assertTrue(Jsoup.isValid("<iframe title=\"success\">Success</iframe>", whitelist));
     	// Subdomain should be accepted
-    	assertTrue(Jsoup.isValid("<iframe src=\"http://cdn.knowings.fr:8080/resources/success.html\"></iframe>", whitelist));
+    	assertTrue(Jsoup.isValid("<iframe src=\"http://cdn.jsoup.org:8080/resources/success.html\"></iframe>", whitelist));
     	// Without proper protocol it should behave as usual
-    	assertFalse(Jsoup.isValid("<iframe src=\"//cdn.knowings.fr:8080/resources/success.html\"></iframe>", whitelist));
+    	assertFalse(Jsoup.isValid("<iframe src=\"//cdn.jsoup.org:8080/resources/success.html\"></iframe>", whitelist));
     	// Empty url should allways be invalid against the whitelist
     	assertFalse(Jsoup.isValid("<iframe src=\"\"></iframe>", whitelist));
     	// Domain constraint should be met to be valid against the whitelist.
     	assertFalse(Jsoup.isValid("<iframe src=\"http://www.knowings.com\"></iframe>", whitelist));
     	// After removing support of a protocol, it should behave as usual. 
     	whitelist.removeProtocols("iframe", "src", "http");
-    	assertFalse(Jsoup.isValid("<iframe src=\"http://cdn.knowings.fr:8080/resources/success.html\"></iframe>", whitelist));
+    	assertFalse(Jsoup.isValid("<iframe src=\"http://cdn.jsoup.org:8080/resources/success.html\"></iframe>", whitelist));
     }
 }

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -242,4 +242,49 @@ public class CleanerTest {
         whitelist.addTags( "script" );
         assertTrue( Jsoup.isValid("Hello<script>alert('Doh')</script>World !", whitelist ) );
     }
+    
+    @Test
+    public void testCleanAgainstDomains() {
+    	Whitelist whitelist = Whitelist.relaxed();
+    	
+    	// Tests upon href attribute
+    	whitelist.addDomains("a", "href", "knowings.fr");
+    	assertTrue(Jsoup.isValid("<a>Success</a>", whitelist));
+    	assertTrue(Jsoup.isValid("<a title=\"success\">Success</a>", whitelist));
+    	// Anchor aren't supported by default
+    	assertFalse(Jsoup.isValid("<a href=\"#success\">Success</a>", whitelist));
+    	// Subdomain should be accepted
+    	assertTrue(Jsoup.isValid("<a href=\"http://cdn.knowings.fr:8080/resources/success.html\">Success</a>", whitelist));
+    	// Without proper protocol it should behave as usual
+    	assertFalse(Jsoup.isValid("<a href=\"//cdn.knowings.fr:8080/resources/success.html\">Success</a>", whitelist));
+    	// Empty url should allways be invalid against the whitelist
+    	assertFalse(Jsoup.isValid("<a href=\"\">Success</a>", whitelist));
+    	// Domain constraint should be met to be valid against the whitelist.
+    	assertFalse(Jsoup.isValid("<a href=\"http://www.knowings.com\">Success</a>", whitelist));
+    	// After adding support for anchor, it should behave as usual
+    	whitelist.addProtocols("a", "href", "#");
+    	assertTrue(Jsoup.isValid("<a href=\"#success\">Success</a>", whitelist));
+    	// After removing support of a protocol, it should behave as usual. 
+    	whitelist.removeProtocols("a", "href", "http");
+    	assertFalse(Jsoup.isValid("<a href=\"http://cdn.knowings.fr:8080/resources/success.html\">Success</a>", whitelist));
+    	
+    	// Tests upon src attribute
+    	whitelist.addTags("iframe");
+    	whitelist.addAttributes("iframe", "src", "title");
+    	whitelist.addProtocols("iframe", "src", "http", "https");
+    	whitelist.addDomains("iframe", "src", "knowings.fr");
+    	assertTrue(Jsoup.isValid("<iframe>Success</iframe>", whitelist));
+    	assertTrue(Jsoup.isValid("<iframe title=\"success\">Success</iframe>", whitelist));
+    	// Subdomain should be accepted
+    	assertTrue(Jsoup.isValid("<iframe src=\"http://cdn.knowings.fr:8080/resources/success.html\"></iframe>", whitelist));
+    	// Without proper protocol it should behave as usual
+    	assertFalse(Jsoup.isValid("<iframe src=\"//cdn.knowings.fr:8080/resources/success.html\"></iframe>", whitelist));
+    	// Empty url should allways be invalid against the whitelist
+    	assertFalse(Jsoup.isValid("<iframe src=\"\"></iframe>", whitelist));
+    	// Domain constraint should be met to be valid against the whitelist.
+    	assertFalse(Jsoup.isValid("<iframe src=\"http://www.knowings.com\"></iframe>", whitelist));
+    	// After removing support of a protocol, it should behave as usual. 
+    	whitelist.removeProtocols("iframe", "src", "http");
+    	assertFalse(Jsoup.isValid("<iframe src=\"http://cdn.knowings.fr:8080/resources/success.html\"></iframe>", whitelist));
+    }
 }


### PR DESCRIPTION
Hello,

In the following PR, I'm proposing to support the ability of managing domain constraints on "href" and "src" attributes in the whitelist.

Basically, it is available like protocols. Developers can add or remove domains on a given tag and attributes.

Feel free to comments or suggests improvements and/or fixes.

Best regards.
