### PR TITLE
Use the XML parser if the MIME-type matches an XML type

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -547,6 +547,9 @@ public class HttpConnection implements Connection {
                     throw new UnsupportedMimeTypeException("Unhandled content type. Must be text/*, application/xml, or application/xhtml+xml",
                             contentType, req.url().toString());
 
+                if (contentType.startsWith("application/xml") || xmlContentTypeRxp.matcher(contentType).matches())
+                       req.parser(Parser.xmlParser());
+
                 res.charset = DataUtil.getCharsetFromContentType(res.contentType); // may be null, readInputStream deals with it
                 if (conn.getContentLength() != 0) { // -1 means unknown, chunked. sun throws an IO exception on 500 response with no content when trying to read body
                     InputStream bodyStream = null;


### PR DESCRIPTION
Currently, jsoup just uses the HTML parser unless otherwise specified. However, the MIME-type is checked to see if it's an XML, so to prevent issues with parsing, jsoup should use the XML parser when the MIME-type matches an XML type.