### PR TITLE
Keep tag that have not been closed by > before reaching EOF.

### DIFF
--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -757,6 +757,7 @@ enum TokeniserState {
                     break;
                 case eof:
                     t.eofError(this);
+                    t.emitTagPending();
                     t.transition(Data);
                     break;
                 case '>':

--- a/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
@@ -121,4 +121,11 @@ public class XmlTreeBuilderTest {
         Document doc = Jsoup.parse("x", "", Parser.xmlParser());
         assertEquals(Syntax.xml, doc.outputSettings().syntax());
     }
+
+    @Test
+    public void testDoesHandleEOFInTag() {
+        String html = "<img src=asdf onerror=\"alert(1)\" x=";
+        Document xmlDoc = Jsoup.parse(html, "", Parser.xmlParser());
+        assertEquals("<img src=\"asdf\" onerror=\"alert(1)\" x=\"\" />", xmlDoc.html());
+    }
 }


### PR DESCRIPTION
We use Hibernate Validator (HV) and the @SafeHtlm annotation to validate input from users. During a security review we discovered that an unsafe XSS vector slipped by the validator. During debugging HV we discovered that the source of the problem was related to how Jsoup handled tags without a closing > when reaching EOF.

[Code reference to SafeHtmlValidator in HV](https://github.com/hibernate/hibernate-validator/blob/dfa65141d63cbfbb33f79522f6ba40a6d2b29b5c/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java#L75)