### PR TITLE
Changed 'relative redirect with dot' test to show failing use case

### DIFF
--- a/src/test/java/org/jsoup/integration/UrlConnectTest.java
+++ b/src/test/java/org/jsoup/integration/UrlConnectTest.java
@@ -184,8 +184,8 @@ public class UrlConnectTest {
 
     @Test
     public void followsRelativeDotRedirect() throws IOException {
-        // redirects to "./ok.html", should resolve to http://direct.infohound.net/tools/ok.html
-        Connection con = Jsoup.connect("http://direct.infohound.net/tools/302-rel-dot.pl"); // to ./ok.html
+        //redirects to "esportspenedes.cat/./ep/index.php", should resolve to "esportspenedes.cat/ep/index.php"
+        Connection con = Jsoup.connect("http://esportspenedes.cat"); // to /tidy/
         Document doc = con.post();
         assertTrue(doc.title().contains("OK"));
     }


### PR DESCRIPTION
Changed the test URL to show a use case where it fails to redirect to a URL which includes a relative dot.