### PR TITLE
Add mode to no escape entities and new setting to preserve attribute's quote

### DIFF
--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -98,9 +98,16 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     protected void html(StringBuilder accum, Document.OutputSettings out) {
         accum.append(key);
         if (!shouldCollapseAttribute(out)) {
-            accum.append("=").append(quote);
+            accum.append("=");
+            if (out.preserveQuote()) 
+                accum.append(quote); 
+            else 
+                accum.append('"');
             Entities.escape(accum, value, out, true, false, false);
-            accum.append(quote);
+            if (out.preserveQuote()) 
+                accum.append(quote); 
+            else 
+                accum.append('"');
         }
     }
 

--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -19,6 +19,7 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
 
     private String key;
     private String value;
+    private char quote = '"';
 
     /**
      * Create a new attribute from unencoded (raw) key and value.
@@ -32,6 +33,21 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
         this.key = key.trim().toLowerCase();
         this.value = value;
     }
+    
+    /**
+     * Create a new attribute from unencoded (raw) key and value.
+     * @param key attribute key
+     * @param value attribute value
+     * @param quote attribute quote
+     * @see #createFromEncoded
+     */
+    public Attribute(String key, String value, char quote) {
+        super();
+        this.key = key;
+        this.value = value;
+        this.quote = quote;
+    }
+
 
     /**
      Get the attribute key.
@@ -82,9 +98,9 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
     protected void html(StringBuilder accum, Document.OutputSettings out) {
         accum.append(key);
         if (!shouldCollapseAttribute(out)) {
-            accum.append("=\"");
+            accum.append("=").append(quote);
             Entities.escape(accum, value, out, true, false, false);
-            accum.append('"');
+            accum.append(quote);
         }
     }
 

--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -85,6 +85,14 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
         return old;
     }
 
+    public char getQuote() {
+        return quote;
+    }
+
+    public void setQuote(char quote) {
+        this.quote = quote;
+    }
+
     /**
      Get the HTML representation of this attribute; e.g. {@code href="index.html"}.
      @return HTML

--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -45,8 +45,17 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
      @param value attribute value
      */
     public void put(String key, String value) {
-        Attribute attr = new Attribute(key, value);
-        put(attr);
+        Attribute attr = null;
+        if (attributes != null && !attributes.isEmpty()) 
+            attr = attributes.get(key.toLowerCase());
+        
+        if (attr != null) {      
+            attr.setValue(value);
+            attr.setKey(key);
+        } else {
+            attr = new Attribute(key, value);
+            put(attr);
+        }
     }
     
     /**
@@ -60,7 +69,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         else
             remove(key);
     }
-
+    
     /**
      Set a new attribute, or replace an existing one by key.
      @param attribute attribute

--- a/src/main/java/org/jsoup/nodes/BooleanAttribute.java
+++ b/src/main/java/org/jsoup/nodes/BooleanAttribute.java
@@ -11,7 +11,16 @@ public class BooleanAttribute extends Attribute {
     public BooleanAttribute(String key) {
         super(key, "");
     }
-
+    
+    /**
+     * Create a new boolean attribute from unencoded (raw) key.
+     * @param key attribute key
+     * @paran quote attribute quote
+     */
+    public BooleanAttribute(String key, char quote) {
+        super(key, "", quote);
+    }
+    
     @Override
     protected boolean isBooleanAttribute() {
         return true;

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -375,6 +375,7 @@ public class Document extends Element {
         private CharsetEncoder charsetEncoder = charset.newEncoder();
         private boolean prettyPrint = true;
         private boolean outline = false;
+        private boolean preserveQuote = false;
         private int indentAmount = 1;
         private Syntax syntax = Syntax.html;
 
@@ -494,6 +495,25 @@ public class Document extends Element {
          */
         public OutputSettings outline(boolean outlineMode) {
             outline = outlineMode;
+            return this;
+        }
+        
+        /**
+         * Get if Quote preserve Quote mode is enabled. Default is false. If enabled, the HTML output will keep attributes
+         * with original quotes.
+         * @return this, for chaining
+         */
+        public boolean preserveQuote() {
+            return preserveQuote;
+        }
+
+        /**
+         * Enable or disable HTML Quote preserve mode
+         * @param preserveQuote Keep same quotes
+         * @return this, for chaining
+         */
+        public OutputSettings preserveQuote(boolean preserveQuote) {
+            this.preserveQuote = preserveQuote;
             return this;
         }
 

--- a/src/main/java/org/jsoup/nodes/Entities.java
+++ b/src/main/java/org/jsoup/nodes/Entities.java
@@ -20,7 +20,9 @@ public class Entities {
         /** Default HTML output entities. */
         base(baseByVal),
         /** Complete HTML entities. */
-        extended(fullByVal);
+        extended(fullByVal),
+        /** No html entities */
+        none(null);
 
         private Map<Character, String> map;
 
@@ -79,9 +81,16 @@ public class Entities {
     static void escape(StringBuilder accum, String string, Document.OutputSettings out,
                        boolean inAttribute, boolean normaliseWhite, boolean stripLeadingWhite) {
 
+        
         boolean lastWasWhite = false;
         boolean reachedNonWhite = false;
         final EscapeMode escapeMode = out.escapeMode();
+        
+        if (escapeMode == EscapeMode.none) {
+            accum.append(string);
+            return;
+        }
+        
         final CharsetEncoder encoder = out.encoder();
         final CoreCharset coreCharset = CoreCharset.byName(encoder.charset().name());
         final Map<Character, String> map = escapeMode.getMap();
@@ -105,7 +114,8 @@ public class Entities {
             }
             // surrogate pairs, split implementation for efficiency on single char common case (saves creating strings, char[]):
             if (codePoint < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
-                final char c = (char) codePoint;
+
+                final char c = (char) codePoint;                
                 // html specific and required escapes:
                 switch (c) {
                     case '&':

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -6,8 +6,6 @@ import org.jsoup.parser.Parser;
 import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -100,7 +98,6 @@ public abstract class Node implements Cloneable {
         attributes.put(attributeKey, attributeValue);
         return this;
     }
-
     /**
      * Test if this element has an attribute.
      * @param attributeKey The attribute key to check.

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -70,6 +70,7 @@ abstract class Token {
         protected String tagName;
         private String pendingAttributeName; // attribute names are generally caught in one hop, not accumulated
         private StringBuilder pendingAttributeValue = new StringBuilder(); // but values are accumulated, from e.g. & in hrefs
+        private char pendingAttributeQuote;
         private boolean hasEmptyAttributeValue = false; // distinguish boolean attribute from empty string value
         private boolean hasPendingAttributeValue = false;
         boolean selfClosing = false;
@@ -80,6 +81,7 @@ abstract class Token {
             tagName = null;
             pendingAttributeName = null;
             reset(pendingAttributeValue);
+            pendingAttributeQuote = '"';
             hasEmptyAttributeValue = false;
             hasPendingAttributeValue = false;
             selfClosing = false;
@@ -94,11 +96,11 @@ abstract class Token {
             if (pendingAttributeName != null) {
                 Attribute attribute;
                 if (hasPendingAttributeValue)
-                    attribute = new Attribute(pendingAttributeName, pendingAttributeValue.toString());
+                    attribute = new Attribute(pendingAttributeName, pendingAttributeValue.toString(), pendingAttributeQuote);
                 else if (hasEmptyAttributeValue)
-                    attribute = new Attribute(pendingAttributeName, "");
+                    attribute = new Attribute(pendingAttributeName, "", pendingAttributeQuote);
                 else
-                    attribute = new BooleanAttribute(pendingAttributeName);
+                    attribute = new BooleanAttribute(pendingAttributeName, pendingAttributeQuote);
                 attributes.put(attribute);
             }
             pendingAttributeName = null;
@@ -164,6 +166,10 @@ abstract class Token {
         final void appendAttributeValue(char[] append) {
             ensureAttributeValue();
             pendingAttributeValue.append(append);
+        }
+        
+        final void appendAttributeQuote(char quote) {
+            pendingAttributeQuote = quote;
         }
         
         final void setEmptyAttributeValue() {

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -790,6 +790,7 @@ enum TokeniserState {
             switch (c) {
                 case '"':
                     t.transition(AfterAttributeValue_quoted);
+                    t.tagPending.appendAttributeQuote('"');
                     break;
                 case '&':
                     char[] ref = t.consumeCharacterReference('"', true);
@@ -822,6 +823,7 @@ enum TokeniserState {
             switch (c) {
                 case '\'':
                     t.transition(AfterAttributeValue_quoted);
+                    t.tagPending.appendAttributeQuote('\'');
                     break;
                 case '&':
                     char[] ref = t.consumeCharacterReference('\'', true);

--- a/src/test/java/org/jsoup/nodes/AttributeTest.java
+++ b/src/test/java/org/jsoup/nodes/AttributeTest.java
@@ -17,4 +17,10 @@ public class AttributeTest {
         assertEquals(s + "=\"A" + s + "B\"", attr.html());
         assertEquals(attr.html(), attr.toString());
     }
+    
+    @Test public void testPreserverQuote() {
+        Attribute attr = new Attribute("key", "value &", '\'');
+        assertEquals("key='value &amp;'", attr.html());
+        assertEquals(attr.html(), attr.toString());
+    }
 }

--- a/src/test/java/org/jsoup/nodes/AttributeTest.java
+++ b/src/test/java/org/jsoup/nodes/AttributeTest.java
@@ -20,7 +20,9 @@ public class AttributeTest {
     
     @Test public void testPreserverQuote() {
         Attribute attr = new Attribute("key", "value &", '\'');
-        assertEquals("key='value &amp;'", attr.html());
+        StringBuilder accum = new StringBuilder();
+        attr.html(accum, new Document.OutputSettings().preserveQuote(true));
+        assertEquals("key='value &amp;'", accum.toString());
         assertEquals(attr.html(), attr.toString());
     }
 }

--- a/src/test/java/org/jsoup/nodes/EntitiesTest.java
+++ b/src/test/java/org/jsoup/nodes/EntitiesTest.java
@@ -16,12 +16,14 @@ public class EntitiesTest {
         String escapedAsciiXhtml = Entities.escape(text, new OutputSettings().charset("ascii").escapeMode(xhtml));
         String escapedUtfFull = Entities.escape(text, new OutputSettings().charset("UTF-8").escapeMode(extended));
         String escapedUtfMin = Entities.escape(text, new OutputSettings().charset("UTF-8").escapeMode(xhtml));
+        String silencedUtfMin = Entities.escape(text, new OutputSettings().charset("UTF-8").escapeMode(none));
 
         assertEquals("Hello &amp;&lt;&gt; &Aring; &aring; &#x3c0; &#x65b0; there &frac34; &copy; &raquo;", escapedAscii);
         assertEquals("Hello &amp;&lt;&gt; &angst; &aring; &pi; &#x65b0; there &frac34; &copy; &raquo;", escapedAsciiFull);
         assertEquals("Hello &amp;&lt;&gt; &#xc5; &#xe5; &#x3c0; &#x65b0; there &#xbe; &#xa9; &#xbb;", escapedAsciiXhtml);
         assertEquals("Hello &amp;&lt;&gt; Å å π 新 there ¾ © »", escapedUtfFull);
         assertEquals("Hello &amp;&lt;&gt; Å å π 新 there ¾ © »", escapedUtfMin);
+        assertEquals("Hello &<> Å å π 新 there ¾ © »", silencedUtfMin);
         // odd that it's defined as aring in base but angst in full
 
         // round trip

--- a/src/test/java/org/jsoup/parser/AttributeParseTest.java
+++ b/src/test/java/org/jsoup/parser/AttributeParseTest.java
@@ -6,6 +6,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.BooleanAttribute;
+import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.junit.Test;
@@ -90,4 +91,10 @@ public class AttributeParseTest {
         assertEquals(html, el.outerHtml());
     }
     
+    @Test public void testPreserveQuotes() {
+        String html = "<a id=\"123\" class=\"baz = 'bar'\" style = 'border: 2px'qux zim foo = '12' mux=\"18\" />";
+        Document doc = Jsoup.parse(html, "http://uri.org", Parser.xmlParser());
+        doc.outputSettings().preserveQuote(true);
+        assertEquals("<a id=\"123\" class=\"baz = 'bar'\" style='border: 2px' qux='' zim='' foo='12' mux=\"18\"></a>", doc.toString());
+    }
 }


### PR DESCRIPTION
Two basic changes:
- Support the preserve of the quote used in any HTML Attribute, by enabling the outputsettings of "preserveQuote"
- Support the ability to not escape any HTML entity into its entity code. 

This is just trying to help keep the html code untouched when not expected. 

For example when HTML is used in combination with freemarker code (or custom tags) so you get some code inside attributes that you don't want escaped, or you don't want the quote of the attribute change from single quotes to double quotes because you have another code inside that has double quotes.

`<a href="${myURL!'default'}">test</a>`
