### PR TITLE
Enable Attribute Value Validation

### DIFF
--- a/src/main/java/org/jsoup/safety/BaseValueValidator.java
+++ b/src/main/java/org/jsoup/safety/BaseValueValidator.java
@@ -1,0 +1,14 @@
+package org.jsoup.safety;
+
+public abstract class BaseValueValidator implements ValueValidator {
+
+    private final boolean required;
+
+    protected BaseValueValidator(boolean required) {
+        this.required = required;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+}

--- a/src/main/java/org/jsoup/safety/PatternValueValidator.java
+++ b/src/main/java/org/jsoup/safety/PatternValueValidator.java
@@ -1,0 +1,28 @@
+package org.jsoup.safety;
+
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Element;
+
+public final class PatternValueValidator extends BaseValueValidator {
+
+    private final Pattern pattern;
+
+    public PatternValueValidator(String regex) {
+        this(regex, false);
+    }
+
+    public PatternValueValidator(String pattern, boolean ignoreCase) {
+        this(pattern, ignoreCase, false);
+    }
+
+    public PatternValueValidator(String pattern, boolean ignoreCase, boolean required) {
+        super(required);
+        this.pattern = ignoreCase ? Pattern.compile(pattern, Pattern.CASE_INSENSITIVE) : Pattern.compile(pattern);
+    }
+
+    public boolean isSafe(Element el, Attribute attr) {
+        return pattern.matcher(attr.getValue()).matches();
+    }
+}

--- a/src/main/java/org/jsoup/safety/SimpleValueValidator.java
+++ b/src/main/java/org/jsoup/safety/SimpleValueValidator.java
@@ -1,0 +1,41 @@
+package org.jsoup.safety;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Element;
+
+public final class SimpleValueValidator extends BaseValueValidator {
+
+    private final boolean ignoreCase;
+
+    private final Set<String> allowedValues = new HashSet<String>();
+
+    public SimpleValueValidator(String... allowedValues) {
+
+        this(false, allowedValues);
+    }
+
+    public SimpleValueValidator(boolean ignoreCase, String... allowedValues) {
+        this(ignoreCase, false, allowedValues);
+    }
+
+    public SimpleValueValidator(boolean ignoreCase, boolean required, String... allowedValues) {
+        super(required);
+        this.ignoreCase = ignoreCase;
+        if (ignoreCase) {
+            for (String allowedValue : allowedValues) {
+                this.allowedValues.add(allowedValue.toUpperCase());
+            }
+        } else {
+            this.allowedValues.addAll(Arrays.asList(allowedValues));
+        }
+    }
+
+    public boolean isSafe(Element el, Attribute attr) {
+        String value = attr.getValue();
+        return allowedValues.contains(ignoreCase ? value.toUpperCase() : value);
+    }
+}

--- a/src/main/java/org/jsoup/safety/ValueValidator.java
+++ b/src/main/java/org/jsoup/safety/ValueValidator.java
@@ -1,0 +1,11 @@
+package org.jsoup.safety;
+
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Element;
+
+public interface ValueValidator {
+
+	boolean isRequired();
+
+	boolean isSafe(Element el, Attribute attr);
+}

--- a/src/main/java/org/jsoup/safety/package-info.java
+++ b/src/main/java/org/jsoup/safety/package-info.java
@@ -1,4 +1,4 @@
 /**
- Contains the jsoup HTML cleaner, and whitelist definitions.
+ Contains the jsoup HTML cleaner, whitelist definitions, and attribute validators.
  */
 package org.jsoup.safety;


### PR DESCRIPTION
### Summary
This pull request adds validation for attribute values and refactors the existing protocol handling to make use of the new validation framework.

### Motivation
The last 2 projects that I have worked on have used Jsoup but also required me to perform further validation to restrict the content users could submit. For example in my current project we must permit the `onclick` attribute for `<a>` tags but we also have to support untrusted content so this clearly requires extra validation. This request provides a flexible framework to allow bespoke validation of attribute values and also provides two out-of-the-box validators for simple values and regular expressions.

The `onclick` use case clearly has anti-XSS uses but moreover I think this request is very much in keeping with the following motivation behind Jsoup as it provides much more control over attributes as well as elements:
> The cleaner is useful not only for avoiding XSS, but also in **limiting the range of elements the user can provide**: you may be OK with textual `a`, `strong` elements, but not structural `div` or `table` elements.

### Possible Improvement
On one of the projects I also implemented a specific style validator that parsed the semi-colon separated `style` value and cleaned/validated specific css styles. If you like and merge this request then I would work on that next.