### PR TITLE
#650 Cannot use single quotes in selectors

### DIFF
--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -280,7 +280,8 @@ public abstract class Evaluator {
             Validate.notEmpty(value);
 
             this.key = key.trim().toLowerCase();
-            if (value.startsWith("\"") && value.endsWith("\"")) {
+            if (value.startsWith("\"") && value.endsWith("\"")
+                    || value.startsWith("'") && value.endsWith("'")) {
                 value = value.substring(1, value.length()-1);
             }
             this.value = value.trim().toLowerCase();

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -876,4 +876,11 @@ public class HtmlParserTest {
         Document doc = Jsoup.parse(body);
         assertEquals(1, doc.body().children().size());
     }
+
+    @Test public void testUsingSingleQuotesInQueries() {
+        String body = "<body> <div class='main'>hello</div></body>";
+        Document doc = Jsoup.parse(body);
+        Elements main = doc.select("div[class='main']");
+        assertEquals("hello", main.text());
+    }
 }


### PR DESCRIPTION
This small change makes it possible to use single quotes in queries like this one: 

```java
Document doc = Jsoup.parse(responseContent());
Elements main = doc.select("a[data-file='123']");
```
Before this fix, you could only use double quotes, even if single quotes were actually used in HTML. 