### PR TITLE
Add appendTo method to Element.

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -291,6 +291,25 @@ public class Element extends Node {
     }
 
     /**
+	 * Add this node as a child node to the given parent
+	 * 
+	 * @param parent node in which this node will be appended
+	 * @return this element, so that you can continue modifying the element
+	 */
+	public Element appendTo(Node parent) {
+		Validate.notNull(parent);
+		if (this.parentNode != null) {
+			this.parentNode.removeChild(this);
+		}
+
+		parent.ensureChildNodes();
+		parent.childNodes.add(this);
+		setSiblingIndex(parent.childNodes.size() - 1);
+		setParentNode(parent);
+		return this;
+	}
+
+    /**
      * Add a node to the start of this element's children.
      * 
      * @param child node to add.

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -2,11 +2,12 @@ package org.jsoup.nodes;
 
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
-import org.jsoup.helper.StringUtil;
 import org.jsoup.parser.Tag;
 import org.jsoup.select.Elements;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
@@ -850,4 +851,21 @@ public class ElementTest {
         assertEquals("http://example2.com/four/", els.get(3).absUrl("href"));
         assertEquals("https://example2.com/five/", els.get(4).absUrl("href"));
     }
+
+	@Test
+	public void testAppendTo() {
+		String parentHtml = "<div class='a'></div>";
+		String childHtml = "<div class='b'></div>";
+
+		Element parentElement = Jsoup.parse(parentHtml).getElementsByClass("a").first();
+		Element childElement = Jsoup.parse(childHtml).getElementsByClass("b").first();
+
+		childElement.attr("class", "test-class").appendTo(parentElement).attr("id", "testId");
+		assertEquals("test-class", childElement.attr("class"));
+		assertEquals("testId", childElement.attr("id"));
+		assertThat(parentElement.attr("id"), not(equalTo("testId")));
+		assertThat(parentElement.attr("class"), not(equalTo("test-class")));
+		assertSame(childElement, parentElement.children().first());
+		assertSame(parentElement, childElement.parent());
+	}
 }


### PR DESCRIPTION
appendTo method appends the element to a given parent element and returns itself, instead of the parent. See jQuery's appendTo method for further information.
    As an example, use the code below;

```
element.appendTo(parentElement).attr('class', 'text-danger').text('Alert!!');
```

Instead of the code below;

```
element.attr('class', 'text-danger').text('Alert!!');
parentElement.appendChild(element);
```
