### PR TITLE
Modified to save memory when creating many unknown (custom) tags, plus option to format inline

### DIFF
--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -12,6 +12,7 @@ import java.util.Map;
  */
 public class Tag {
     private static final Map<String, Tag> tags = new HashMap<String, Tag>(); // map of known tags
+    private static final Map<String, Tag> customTags = new HashMap<String, Tag>(); // map of unknown (custom) tags
 
     private String tagName;
     private boolean isBlock = true; // block or inline
@@ -39,14 +40,24 @@ public class Tag {
 
     /**
      * Get a Tag by name. If not previously defined (unknown), returns a new generic tag, that can do anything.
-     * <p>
-     * Pre-defined tags (P, DIV etc) will be ==, but unknown tags are not registered and will only .equals().
-     * </p>
-     * 
+     *
      * @param tagName Name of tag, e.g. "p". Case insensitive.
      * @return The tag, either defined or new generic.
      */
     public static Tag valueOf(String tagName) {
+        return valueOf(tagName, true);
+    }
+
+    /**
+     * Get a Tag by name. If not previously defined (unknown), returns a new generic tag, that can do anything,
+     * including being formatted inline, instead of the default to always "formatAsBlock".
+     *
+     * @param tagName Name of tag, e.g. "p". Case insensitive.
+     * @param formatAsBlock for custom (unknown) tags only -
+     *                      how to format HTML code of the nodes with this tag
+     * @return The tag, either defined or new generic.
+     */
+    public static Tag valueOf(String tagName, boolean formatAsBlock) {
         Validate.notNull(tagName);
         Tag tag = tags.get(tagName);
 
@@ -56,10 +67,16 @@ public class Tag {
             tag = tags.get(tagName);
 
             if (tag == null) {
-                // not defined: create default; go anywhere, do anything! (incl be inside a <p>)
-                tag = new Tag(tagName);
-                tag.isBlock = false;
-                tag.canContainBlock = true;
+                if (tag == null)
+                    tag = customTags.get(tagName);
+                if (tag == null) {
+                    // not defined: create default; go anywhere, do anything! (incl be inside a <p>)
+                    tag = new Tag(tagName);
+                    tag.isBlock = false;
+                    tag.formatAsBlock = formatAsBlock;
+                    tag.canContainBlock = true;
+                    customTags.put(tagName, tag);  // save memory if creating new tags
+                }
             }
         }
         return tag;


### PR DESCRIPTION
Currently a new Tag instance is created each time a tag with previously used tagName is needed, sometimes creating thousands of unnecessary Tag instance duplicates. This pull request proposes to fix this by maintaining a map of customTags, similar to the 'tags' map maintained for known tags, and returning a tag from this list, if the tagName is already there.

Also, for a custom tag that can "do anything", a choice is needed to decide if it should be formatted as block or not. For this the pull request provids a new variant of Tag valueOf(String tagName, boolean formatAsBlock).

LONG RATIONALE: custom, unknown tags may be used if the HTML and DOM are manipulated only for internal consumption in an app, and not for publishing on the web. For example, in my case I wrap words and sentences in HTML pages or long ebook chapters for the purpose of sending entire sentences to TTS engine for reading aloud with correct intonation, while being able also to highlight the currently read sentence. A long page or ebook chapter may have thousands of words, and I wrap them into &lt;w&gt; tags to have them short, instead of &lt;span class="wordFindSomeUniqueClassName"&gt;. I also need my words (and &lt;snt&gt; tags for sentences) formatted as inline elements, not blocks.

I also developed code for extracting and wrapping equivalents of JavaScript Range objects and "DocumentFragments". Maybe it could be part of jsoup as well - let me know if interested, see more at
 http://stackoverflow.com/questions/34301276/jsoup-equivalent-of-dom-range-operations-like-extractcontents-etc

This small pull request does not contain that code.

Greg Kochaniak, Hyperionics
