### PR TITLE
Fix for bug 671: namespace is included in W3CDom.fromJsoup

### DIFF
--- a/src/main/java/org/jsoup/select/NodeTraversor.java
+++ b/src/main/java/org/jsoup/select/NodeTraversor.java
@@ -22,8 +22,9 @@ public class NodeTraversor {
     /**
      * Start a depth-first traverse of the root and all of its descendants.
      * @param root the root node point to traverse.
+     * @param namespace the namespace of the document
      */
-    public void traverse(Node root) {
+    public void traverse(Node root, String namespace) {
         Node node = root;
         int depth = 0;
         
@@ -44,5 +45,10 @@ public class NodeTraversor {
                 node = node.nextSibling();
             }
         }
+    }
+    
+    public void traverse (Node root)
+    {
+    	traverse (root, null);
     }
 }

--- a/src/test/java/org/jsoup/helper/W3CDomTest.java
+++ b/src/test/java/org/jsoup/helper/W3CDomTest.java
@@ -48,5 +48,27 @@ public class W3CDomTest {
         String out = w3c.asString(wDoc);
         assertTrue(out.contains("ipod"));
     }
+    
+    @Test
+    public void namespacePreservation()
+    {
+    	File in = ParseTest.getFile("/htmltests/cover.xhtml");
+    	org.jsoup.nodes.Document jsoupDoc = null;
+    	Document doc = null;
+		try {
+			jsoupDoc = Jsoup.parse(in, "UTF-8");
+			//then, convert it back into a WC3 Dom document
+	    	org.jsoup.helper.W3CDom jDom = new org.jsoup.helper.W3CDom();
+	    	doc = jDom.fromJsoup(jsoupDoc);
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+    	if (doc != null)
+    	{
+    		assertEquals(doc.getChildNodes().item(0).getNamespaceURI(), "http://www.w3.org/1999/xhtml");
+    		assertEquals(doc.getChildNodes().item(0).getLocalName(), "html");
+    	}
+    }
 }
 

--- a/src/test/resources/htmltests/cover.xhtml
+++ b/src/test/resources/htmltests/cover.xhtml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="en" lang="en">
+	<head>
+		<title>Cover</title>
+		<style type="text/css">
+			img{
+				max-width:100%;
+			}
+		</style>
+	</head>
+	<body>
+		<figure id="cover-image">
+			<img src="covers/9781449328030_lrg.jpg" alt="First Edition" />
+		</figure>
+	</body>
+</html>


### PR DESCRIPTION
Added code to parse the namespace, if exists, and pass it to the NodeTraversor constructor and traverse() methods.  createElementNS() is used instead of createElement() when creating nodes in the W3C Dom document.
Added a unit test to validate that getNamespaceURI() and getLocalName() calls work on elements of the created W3C Dom document.
Added a sample XHTML file.