### PR TITLE
Added another list in Tag for tags that should be formatted as block.…

### DIFF
--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -238,6 +238,9 @@ public class Tag {
             "meta", "link", "base", "frame", "img", "br", "wbr", "embed", "hr", "input", "keygen", "col", "command",
             "device", "area", "basefont", "bgsound", "menuitem", "param", "source", "track"
     };
+    private static final String[] formatAsBlockTags = {
+            "select"
+    };
     private static final String[] formatAsInlineTags = {
             "title", "a", "p", "h1", "h2", "h3", "h4", "h5", "h6", "pre", "address", "li", "th", "td", "script", "style",
             "ins", "del", "s"
@@ -275,6 +278,12 @@ public class Tag {
             tag.canContainBlock = false;
             tag.canContainInline = false;
             tag.empty = true;
+        }
+
+        for (String tagName : formatAsBlockTags) {
+            Tag tag = tags.get(tagName);
+            Validate.notNull(tag);
+            tag.formatAsBlock = true;
         }
 
         for (String tagName : formatAsInlineTags) {

--- a/src/test/java/org/jsoup/parser/TagTest.java
+++ b/src/test/java/org/jsoup/parser/TagTest.java
@@ -64,4 +64,12 @@ public class TagTest {
     @Test(expected = IllegalArgumentException.class) public void valueOfChecksNotEmpty() {
         Tag.valueOf(" ");
     }
+
+    @Test public void selectSemantics() {
+        Tag select = Tag.valueOf("select");
+        assertTrue(select.isInline());
+        assertFalse(select.isBlock());
+        assertFalse(select.canContainBlock());
+        assertTrue(select.formatAsBlock());
+    }
 }


### PR DESCRIPTION
The select tag was pretty-printed as an inline element (select and all option tags on same line). Added a new list of tags that should be formatted as block elements and added select to the list. Wrote unit test to verify behavior.
