### PR TITLE
Tag namespaces cause cssSelector() to fail

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -498,7 +498,9 @@ public class Element extends Node {
         if (id().length() > 0)
             return "#" + id();
 
-        StringBuilder selector = new StringBuilder(tagName());
+        // Translate HTML namespace ns:tag to CSS namespace syntax ns|tag
+        String tagName = tagName().replace(':', '|');
+        StringBuilder selector = new StringBuilder(tagName);
         String classes = StringUtil.join(classNames(), ".");
         if (classes.length() > 0)
             selector.append('.').append(classes);

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -891,4 +891,14 @@ public class ElementTest {
         root.appendChild(new Element(Tag.valueOf("a"), ""));
         assertTrue(set.contains(root));
     }
+
+    @Test
+    public void testNamespacedElements() {
+        // Namespaces with ns:tag in HTML must be translated to ns|tag in CSS.
+        String html = "<html><body><fb:comments /></body></html>";
+        Document doc = Jsoup.parse(html, "http://example.com/bar/");
+        Elements els = doc.select("fb|comments");
+        assertEquals(1, els.size());
+        assertEquals("html > body > fb|comments", els.get(0).cssSelector());
+    }
 }


### PR DESCRIPTION
I have been seeing the following error parsing a huffingtonpost site:
```
Exception in thread "main" org.jsoup.select.Selector$SelectorParseException: Could not parse query 'fb:comments': unexpected token at ':comments'
	at org.jsoup.select.QueryParser.findElements(QueryParser.java:196)
	at org.jsoup.select.QueryParser.parse(QueryParser.java:65)
	at org.jsoup.select.QueryParser.parse(QueryParser.java:39)
	at org.jsoup.select.QueryParser.combinator(QueryParser.java:81)
	at org.jsoup.select.QueryParser.parse(QueryParser.java:51)
	at org.jsoup.select.QueryParser.parse(QueryParser.java:39)
	at org.jsoup.select.Selector.<init>(Selector.java:83)
	at org.jsoup.select.Selector.select(Selector.java:105)
	at org.jsoup.nodes.Element.select(Element.java:273)
	at org.jsoup.nodes.Element.cssSelector(Element.java:495)
```
There is a tag "<fb:comments>" in this site; which by XML is not totally nonsense, but of course does not work well with CSS.
Namespaces supposedly are supported by CSS, but with a pipe instead of a colon.

Note: I have not tested this change - feel free to solve this differently.