### PR TITLE
Exclude examples from artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,9 @@
         <artifactId>maven-source-plugin</artifactId>
         <version>2.1.1</version>
         <configuration>
+	  <excludes>
+	    <exclude>org/jsoup/examples/**</exclude>
+	  </excludes>
         </configuration>
         <executions>
           <execution>
@@ -106,6 +109,9 @@
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
+	  <excludes>
+	    <exclude>org/jsoup/examples/**</exclude>
+	  </excludes>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
I noticed that the examples from the main source tree appear in the release artifacts. Assuming that this is not intended, I have setup a patch that prevents the classes from the org.jsoup.examples package from being included in the *.jar and *-sources.jar artifacts.

I think an alternative approach would be to move the examples to a separate source tree (or different project). What do you think?
