### PR TITLE
Text within an element to be queried without doing normalization as is

### DIFF
--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -181,13 +181,27 @@ public class Elements extends ArrayList<Element> {
      * children, as the Element.text() method returns the combined text of a parent and all its children.
      * @return string of all text: unescaped and no HTML.
      * @see Element#text()
+     * @see Elements#text(Boolean)
      */
     public String text() {
+        return text(true);
+    }
+
+    /**
+     * Get the combined text of all the matched elements.
+     * <p>
+     * @param normalize - whether to normalize or not., aka, remove irrelevant whitespaces
+     * Note that it is possible to get repeats if the matched elements contain both parent elements and their own
+     * children, as the Element.text() method returns the combined text of a parent and all its children.
+     * @return string of all text: unescaped and no HTML.
+     * @see Element#text()
+     */
+    public String text(final Boolean normalize) {
         StringBuilder sb = new StringBuilder();
         for (Element element : this) {
             if (sb.length() != 0)
                 sb.append(" ");
-            sb.append(element.text());
+            sb.append(element.text(normalize));
         }
         return sb.toString();
     }

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -66,6 +66,11 @@ public class ElementTest {
         assertEquals("Another element", doc.getElementsByTag("p").get(1).text());
     }
 
+    @Test public void testGetTextWithoutNormalizing() {
+        Document doc = Jsoup.parse("<p>\n\nHello <b>\nhere</b>\n</p>");
+        assertEquals("\n\nHello \nhere\n", doc.text(false));
+    }
+
     @Test public void testGetChildText() {
         Document doc = Jsoup.parse("<p>Hello <b>there</b> now");
         Element p = doc.select("p").first();

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -98,6 +98,12 @@ public class ElementsTest {
         assertEquals("Hello there world", doc.select("div > *").text());
     }
 
+    @Test public void textWithoutNormalizing() {
+        String h = "<span><div>\n\nHello<p> world\n</div><div>Hey there</div></span>";
+        Document doc = Jsoup.parse(h);
+        assertEquals("\n\nHello  world\n Hey there", doc.select("div").text(false));
+    }
+
     @Test public void hasText() {
         Document doc = Jsoup.parse("<div><p>Hello</p></div><div><p></p></div>");
         Elements divs = doc.select("div");


### PR DESCRIPTION
There were use-cases where we wanted text to be queried with normalizing the text inside (Not removing whitespace).

This seem to be a legit use-case with jsoup, there were lot of stackoverflow questions for doing the same

http://stackoverflow.com/questions/5454172/prevent-jsoup-from-discarding-extra-whitespace
http://stackoverflow.com/questions/20295098/how-to-parse-html-and-keep-all-line-breaks

If there is a better way to handle the same please let me know @jhy 
