### PR TITLE
Allow setting custom content-type with POST request

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -547,6 +547,7 @@ public class HttpConnection implements Connection {
                 throw new MalformedURLException("Only http & https protocols supported");
             final boolean methodHasBody = req.method().hasBody();
             final boolean hasRequestBody = req.requestBody() != null;
+            final boolean hasContentType = req.header(CONTENT_TYPE) != null;
             if (!methodHasBody)
                 Validate.isFalse(hasRequestBody, "Cannot set a request body for HTTP method " + req.method());
 
@@ -554,7 +555,7 @@ public class HttpConnection implements Connection {
             String mimeBoundary = null;
             if (req.data().size() > 0 && (!methodHasBody || hasRequestBody))
                 serialiseRequestUrl(req);
-            else if (methodHasBody)
+            else if (methodHasBody && !hasContentType)
                 mimeBoundary = setOutputContentType(req);
 
             HttpURLConnection conn = createConnection(req);


### PR DESCRIPTION
Fix #627 
Currenty, regardless of whether the user has set the content-type header or not, it will always be changed to either 'multipart' or 'x-www-form-urlencoded' with POST request. 
This pull will allow user to set a custom content-type for POST request. If the header is not set, then change it to either 'multipart' or 'x-www-form-urlencoded' as before.