### PR TITLE
optimize Element#hasClass

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1067,15 +1067,49 @@ public class Element extends Node {
     */
     public boolean hasClass(String className) {
         String classAttr = attributes.get("class");
-        if (classAttr.equals("") || classAttr.length() < className.length())
-            return false;
+        final int end = classAttr.length();
+        final int classNameLength = className.length();
 
-        final String[] classes = classSplit.split(classAttr);
-        for (String name : classes) {
-            if (className.equalsIgnoreCase(name))
-                return true;
+        // class attribute is empty or the requested class name is 'too' long
+        if (end == 0 || end < classNameLength) {
+            return false;
+        }
+        
+        // if both length are equals, just compare the className with the attribute
+        if(end == classNameLength) {
+            return className.equalsIgnoreCase(classAttr);
         }
 
+        // manually split the different class names in the class attibute
+        // DO NOT allocate the string but use regionMatches and length comparaison to make the check
+        boolean inClass = false;
+        int start = 0;
+        for (int i = 0; i < end; i ++) {
+            if (Character.isWhitespace(classAttr.charAt(i))) {
+                if(inClass) {
+                    // the white space ends a class name
+                    // compare it with the requested one
+                    if(i-start == classNameLength && classAttr.regionMatches(true, start, className, 0, classNameLength)) {
+                        return true;
+                    }
+                    inClass = false;
+                }
+            }
+            else {
+                if(!inClass) {
+                    // we're in a class name : keep the start of the substring
+                    inClass = true;
+                    start = i;
+                }
+            }
+        }
+        
+        // the attribute may not end by a white space
+        // check the current class name
+        if(inClass && end-start == classNameLength) {
+            return classAttr.regionMatches(true, start, className, 0, classNameLength);  
+        }
+        
         return false;
     }
 

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -214,7 +214,62 @@ public class ElementTest {
         assertEquals(0, classes.size());
         assertFalse(doc.hasClass("mellow"));
     }
+    
+    @Test public void testHasClassDomMethods() {
+        Tag tag = Tag.valueOf("a");
+        Attributes attribs = new Attributes();
+        Element el = new Element(tag, "", attribs);
+        
+        attribs.put("class", "toto");
+        boolean hasClass = el.hasClass("toto");
+        assertTrue(hasClass);
+        
+        attribs.put("class", " toto");
+        hasClass = el.hasClass("toto");
+        assertTrue(hasClass);
+        
+        attribs.put("class", "toto ");
+        hasClass = el.hasClass("toto");
+        assertTrue(hasClass);
+        
+        attribs.put("class", "\ttoto ");
+        hasClass = el.hasClass("toto");
+        assertTrue(hasClass);
+        
+        attribs.put("class", "  toto ");
+        hasClass = el.hasClass("toto");
+        assertTrue(hasClass);
+        
+        attribs.put("class", "ab");
+        hasClass = el.hasClass("toto");
+        assertFalse(hasClass);
+        
+        attribs.put("class", "     ");
+        hasClass = el.hasClass("toto");
+        assertFalse(hasClass);
+        
+        attribs.put("class", "tototo");
+        hasClass = el.hasClass("toto");
+        assertFalse(hasClass);
+        
+        attribs.put("class", "raulpismuth  ");
+        hasClass = el.hasClass("raulpismuth");
+        assertTrue(hasClass);
+        
+        attribs.put("class", " abcd  raulpismuth efgh ");
+        hasClass = el.hasClass("raulpismuth");
+        assertTrue(hasClass);
+        
+        attribs.put("class", " abcd efgh raulpismuth");
+        hasClass = el.hasClass("raulpismuth");
+        assertTrue(hasClass);
+        
+        attribs.put("class", " abcd efgh raulpismuth ");
+        hasClass = el.hasClass("raulpismuth");
+        assertTrue(hasClass);
+    }
 
+    
     @Test public void testClassUpdates() {
         Document doc = Jsoup.parse("<div class='mellow yellow'></div>");
         Element div = doc.select("div").first();


### PR DESCRIPTION
this method is perf sensitive (CPU and memoryallocations)
This replaces the regexp split with a custom implementation that do not
allocate unneeded memory.
With this patch a simple test calling Element#select in a loop for
several selector went from 3Gb allocated to 10Mb.
GC times were reduced.
Fixes #752