### PR TITLE
Optimize Attribute#iterator

### DIFF
--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -172,7 +172,11 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
     }
 
     public Iterator<Attribute> iterator() {
-        return asList().iterator();
+        if (attributes == null || attributes.isEmpty()) {
+            return Collections.<Attribute>emptyList().iterator();
+        }
+        
+        return new AttributesReadOnlyIterator(attributes.values().iterator());
     }
 
     /**
@@ -333,5 +337,27 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
 
     private static String dataKey(String key) {
         return dataPrefix + key;
+    }
+    
+    private static class AttributesReadOnlyIterator implements Iterator<Attribute> {
+
+        private Iterator<Attribute> iterator;
+
+        public AttributesReadOnlyIterator(Iterator<Attribute> iterator) {
+            this.iterator = iterator;
+        }
+
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        public Attribute next() {
+            return iterator.next();
+        }
+
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+        
     }
 }

--- a/src/test/java/org/jsoup/nodes/AttributesTest.java
+++ b/src/test/java/org/jsoup/nodes/AttributesTest.java
@@ -2,6 +2,8 @@ package org.jsoup.nodes;
 
 import static org.junit.Assert.*;
 
+import java.util.Iterator;
+
 import org.junit.Test;
 
 /**
@@ -10,6 +12,7 @@ import org.junit.Test;
  * @author Jonathan Hedley
  */
 public class AttributesTest {
+    
     @Test public void html() {
         Attributes a = new Attributes();
         a.put("Tot", "a&p");
@@ -32,6 +35,47 @@ public class AttributesTest {
 
         assertEquals(" Tot=\"a&amp;p\" Hello=\"There\" data-name=\"Jsoup\"", a.html());
         assertEquals(a.html(), a.toString());
+    }
+    
+    @Test(expected=UnsupportedOperationException.class)
+    public void testIteratorReadOnly() {
+        Attributes a = new Attributes();
+        a.put("Tot", "a&p");
+        a.put("Hello", "There");
+        a.put("data-name", "Jsoup");
+
+        Iterator<Attribute> iterator = a.iterator();
+        iterator.remove();
+    }
+    
+    @Test
+    public void testIterator() {
+        Attributes a = new Attributes();
+        String[][] datas = {{"Tot", "raul"},
+                {"Hello", "pismuth"},
+                {"data-name", "Jsoup"}};
+        for (String[] atts : datas) {
+            a.put(atts[0], atts[1]);
+        }
+        
+        Iterator<Attribute> iterator = a.iterator();
+        assertTrue(iterator.hasNext());
+        int i = 0;
+        for (Attribute attribute : a) {
+            assertEquals(datas[i][0], attribute.getKey());
+            assertEquals(datas[i][1], attribute.getValue());
+            i++;
+        }
+        assertEquals(datas.length, i);
+    }
+    
+    @Test
+    public void testIteratorEmpty() {
+        Attributes a = new Attributes();
+        
+
+        Iterator<Attribute> iterator = a.iterator();
+        assertFalse(iterator.hasNext());
     }
 
 }


### PR DESCRIPTION
It allocates a lot of memory during the parsing through
ParseSettings#normalizeAttributes.
this new implementation just wrap the LinkedHashMap values iterator in a
read-only iterator.

Iterating 1000 times over an internal html file (~800Kb) was allocating
970Mb, with this optimization it's now 350Mb

Fixes #754