### PR TITLE
Change OuterHtmlVisitor visibility, reduce stream reading on startup

### DIFF
--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -644,7 +644,7 @@ public abstract class Node implements Cloneable {
      * Return a clone of the node using the given parent (which can be null).
      * Not a deep copy of children.
      */
-    protected Node doClone(Node parent) {
+    private Node doClone(Node parent) {
         Node clone;
 
         try {
@@ -665,7 +665,10 @@ public abstract class Node implements Cloneable {
         return clone;
     }
 
-    private static class OuterHtmlVisitor implements NodeVisitor {
+    /**
+     * Created by kirillf on 9/14/16.
+     */
+    public static class OuterHtmlVisitor implements NodeVisitor {
         private Appendable accum;
         private Document.OutputSettings out;
 
@@ -676,19 +679,19 @@ public abstract class Node implements Cloneable {
 
         public void head(Node node, int depth) {
             try {
-				node.outerHtmlHead(accum, depth, out);
-			} catch (IOException exception) {
-				throw new SerializationException(exception);
-			}
+                node.outerHtmlHead(accum, depth, out);
+            } catch (IOException exception) {
+                throw new SerializationException(exception);
+            }
         }
 
         public void tail(Node node, int depth) {
             if (!node.nodeName().equals("#text")) { // saves a void hit.
-				try {
-					node.outerHtmlTail(accum, depth, out);
-				} catch (IOException exception) {
-					throw new SerializationException(exception);
-				}
+                try {
+                    node.outerHtmlTail(accum, depth, out);
+                } catch (IOException exception) {
+                    throw new SerializationException(exception);
+                }
             }
         }
     }

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -672,7 +672,7 @@ public abstract class Node implements Cloneable {
         private Appendable accum;
         private Document.OutputSettings out;
 
-        OuterHtmlVisitor(Appendable accum, Document.OutputSettings out) {
+        public OuterHtmlVisitor(Appendable accum, Document.OutputSettings out) {
             this.accum = accum;
             this.out = out;
         }

--- a/src/test/java/org/jsoup/nodes/BuildEntities.java
+++ b/src/test/java/org/jsoup/nodes/BuildEntities.java
@@ -21,7 +21,7 @@ import java.util.Map;
  * only to be complete.
  */
 class BuildEntities {
-    private static final String projectDir = "/Users/jhy/projects/jsoup";
+    private static final String projectDir = "PROJECT_DIR_HERE";
 
     public static void main(String[] args) throws IOException {
         String url = "https://www.w3.org/TR/2012/WD-html5-20121025/entities.json";


### PR DESCRIPTION
Move xhtml and base html charsets to memory from .properties to reduce stream reading on startup (Android sensitive). Change OuterHtmlVisitor visibility to public. Helps to modify nodes and construct outer HTML in single tree traverse.
