### PR TITLE
CI: Building against JDK6 - 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: java
+
+jdk:
+    - openjdk6
+    - openjdk7
+    - oraclejdk7
+    - oraclejdk8
+
 cache:
-  directories:
-  - $HOME/.m2
+    directories:
+        - $HOME/.m2


### PR DESCRIPTION
Extends the CI builds to following JDK's:

- OpenJDK 6
- OpenJDK 7
- Oracle JDK 7
- Oracle JDK 8