### PR TITLE
Workaround for #772: Downgrade maven-bundle-plugin to v2.x.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>2.5.4</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>


### PR DESCRIPTION
Workaround for #772: Downgrade **maven-bundle-plugin** to **v2.x**. This enables JDK6 builds.