### PR TITLE
Don't use default locale when lowercasing

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 import static org.jsoup.Connection.Method.HEAD;
+import static org.jsoup.internal.Normalizer.lowerCase;
 
 /**
  * Implementation of {@link Connection}.
@@ -412,7 +413,7 @@ public class HttpConnection implements Connection {
             // quick evals for common case of title case, lower case, then scan for mixed
             String value = headers.get(name);
             if (value == null)
-                value = headers.get(name.toLowerCase());
+                value = headers.get(lowerCase(name));
             if (value == null) {
                 Map.Entry<String, String> entry = scanHeaders(name);
                 if (entry != null)
@@ -422,9 +423,9 @@ public class HttpConnection implements Connection {
         }
 
         private Map.Entry<String, String> scanHeaders(String name) {
-            String lc = name.toLowerCase();
+            String lc = lowerCase(name);
             for (Map.Entry<String, String> entry : headers.entrySet()) {
-                if (entry.getKey().toLowerCase().equals(lc))
+                if (lowerCase(entry.getKey()).equals(lc))
                     return entry;
             }
             return null;

--- a/src/main/java/org/jsoup/internal/Normalizer.java
+++ b/src/main/java/org/jsoup/internal/Normalizer.java
@@ -1,0 +1,13 @@
+package org.jsoup.internal;
+
+import java.util.Locale;
+
+public class Normalizer {
+    public static String lowerCase(String input) {
+        return input.toLowerCase(Locale.ENGLISH);
+    }
+
+    public static String normalize(String input) {
+        return lowerCase(input).trim();
+    }
+}

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import static org.jsoup.internal.Normalizer.normalize;
+
 /**
  * A HTML element consists of a tag name, attributes, and child nodes (including text nodes and
  * other elements).
@@ -647,7 +649,7 @@ public class Element extends Node {
      */
     public Elements getElementsByTag(String tagName) {
         Validate.notEmpty(tagName);
-        tagName = tagName.toLowerCase().trim();
+        tagName = normalize(tagName);
 
         return Collector.collect(new Evaluator.Tag(tagName), this);
     }

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+import static org.jsoup.internal.Normalizer.lowerCase;
+
 /**
  The base, abstract Node model. Elements, Documents, Comments etc are all Node instances.
 
@@ -78,7 +80,7 @@ public abstract class Node implements Cloneable {
         String val = attributes.getIgnoreCase(attributeKey);
         if (val.length() > 0)
             return val;
-        else if (attributeKey.toLowerCase().startsWith("abs:"))
+        else if (lowerCase(attributeKey).startsWith("abs:"))
             return absUrl(attributeKey.substring("abs:".length()));
         else return "";
     }

--- a/src/main/java/org/jsoup/parser/ParseSettings.java
+++ b/src/main/java/org/jsoup/parser/ParseSettings.java
@@ -3,6 +3,8 @@ package org.jsoup.parser;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Attributes;
 
+import static org.jsoup.internal.Normalizer.lowerCase;
+
 /**
  * Controls parser settings, to optionally preserve tag and/or attribute name case.
  */
@@ -37,21 +39,21 @@ public class ParseSettings {
     String normalizeTag(String name) {
         name = name.trim();
         if (!preserveTagCase)
-            name = name.toLowerCase();
+            name = lowerCase(name);
         return name;
     }
 
     String normalizeAttribute(String name) {
         name = name.trim();
         if (!preserveAttributeCase)
-            name = name.toLowerCase();
+            name = lowerCase(name);
         return name;
     }
 
     Attributes normalizeAttributes(Attributes attributes) {
         if (!preserveAttributeCase) {
             for (Attribute attr : attributes) {
-                attr.setKey(attr.getKey().toLowerCase());
+                attr.setKey(lowerCase(attr.getKey()));
             }
         }
         return attributes;

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -5,6 +5,8 @@ import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.BooleanAttribute;
 
+import static org.jsoup.internal.Normalizer.lowerCase;
+
 /**
  * Parse tokens for the Tokeniser.
  */
@@ -142,7 +144,7 @@ abstract class Token {
 
         final Tag name(String name) {
             tagName = name;
-            normalName = name.toLowerCase();
+            normalName = lowerCase(name);
             return this;
         }
 
@@ -158,7 +160,7 @@ abstract class Token {
         // these appenders are rarely hit in not null state-- caused by null chars.
         final void appendTagName(String append) {
             tagName = tagName == null ? append : tagName.concat(append);
-            normalName = tagName.toLowerCase();
+            normalName = lowerCase(tagName);
         }
 
         final void appendTagName(char append) {
@@ -231,7 +233,7 @@ abstract class Token {
         StartTag nameAttr(String name, Attributes attributes) {
             this.tagName = name;
             this.attributes = attributes;
-            normalName = tagName.toLowerCase();
+            normalName = lowerCase(tagName);
             return this;
         }
 

--- a/src/main/java/org/jsoup/safety/Whitelist.java
+++ b/src/main/java/org/jsoup/safety/Whitelist.java
@@ -15,6 +15,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.jsoup.internal.Normalizer.lowerCase;
+
 
 /**
  Whitelists define what HTML (elements and attributes) to allow through the cleaner. Everything else is removed.
@@ -542,7 +544,7 @@ public class Whitelist {
 
             prot += ":";
 
-            if (value.toLowerCase().startsWith(prot)) {
+            if (lowerCase(value).startsWith(prot)) {
                 return true;
             }
         }

--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -12,6 +12,9 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.jsoup.internal.Normalizer.lowerCase;
+import static org.jsoup.internal.Normalizer.normalize;
+
 
 /**
  * Evaluates that an element matches the selector.
@@ -147,14 +150,14 @@ public abstract class Evaluator {
 
         public AttributeStarting(String keyPrefix) {
             Validate.notEmpty(keyPrefix);
-            this.keyPrefix = keyPrefix.toLowerCase();
+            this.keyPrefix = lowerCase(keyPrefix);
         }
 
         @Override
         public boolean matches(Element root, Element element) {
             List<org.jsoup.nodes.Attribute> values = element.attributes().asList();
             for (org.jsoup.nodes.Attribute attribute : values) {
-                if (attribute.getKey().toLowerCase().startsWith(keyPrefix))
+                if (lowerCase(attribute.getKey()).startsWith(keyPrefix))
                     return true;
             }
             return false;
@@ -217,7 +220,7 @@ public abstract class Evaluator {
 
         @Override
         public boolean matches(Element root, Element element) {
-            return element.hasAttr(key) && element.attr(key).toLowerCase().startsWith(value); // value is lower case already
+            return element.hasAttr(key) && lowerCase(element.attr(key)).startsWith(value); // value is lower case already
         }
 
         @Override
@@ -237,7 +240,7 @@ public abstract class Evaluator {
 
         @Override
         public boolean matches(Element root, Element element) {
-            return element.hasAttr(key) && element.attr(key).toLowerCase().endsWith(value); // value is lower case
+            return element.hasAttr(key) && lowerCase(element.attr(key)).endsWith(value); // value is lower case
         }
 
         @Override
@@ -257,7 +260,7 @@ public abstract class Evaluator {
 
         @Override
         public boolean matches(Element root, Element element) {
-            return element.hasAttr(key) && element.attr(key).toLowerCase().contains(value); // value is lower case
+            return element.hasAttr(key) && lowerCase(element.attr(key)).contains(value); // value is lower case
         }
 
         @Override
@@ -275,7 +278,7 @@ public abstract class Evaluator {
         Pattern pattern;
 
         public AttributeWithValueMatching(String key, Pattern pattern) {
-            this.key = key.trim().toLowerCase();
+            this.key = normalize(key);
             this.pattern = pattern;
         }
 
@@ -302,12 +305,12 @@ public abstract class Evaluator {
             Validate.notEmpty(key);
             Validate.notEmpty(value);
 
-            this.key = key.trim().toLowerCase();
+            this.key = normalize(key);
             if (value.startsWith("\"") && value.endsWith("\"")
                     || value.startsWith("'") && value.endsWith("'")) {
                 value = value.substring(1, value.length()-1);
             }
-            this.value = value.trim().toLowerCase();
+            this.value = normalize(value);
         }
     }
 
@@ -648,12 +651,12 @@ public abstract class Evaluator {
         private String searchText;
 
         public ContainsText(String searchText) {
-            this.searchText = searchText.toLowerCase();
+            this.searchText = lowerCase(searchText);
         }
 
         @Override
         public boolean matches(Element root, Element element) {
-            return (element.text().toLowerCase().contains(searchText));
+            return lowerCase(element.text()).contains(searchText);
         }
 
         @Override
@@ -669,12 +672,12 @@ public abstract class Evaluator {
         private String searchText;
 
         public ContainsData(String searchText) {
-            this.searchText = searchText.toLowerCase();
+            this.searchText = lowerCase(searchText);
         }
 
         @Override
         public boolean matches(Element root, Element element) {
-            return (element.data().toLowerCase().contains(searchText));
+            return lowerCase(element.data()).contains(searchText);
         }
 
         @Override
@@ -690,12 +693,12 @@ public abstract class Evaluator {
         private String searchText;
 
         public ContainsOwnText(String searchText) {
-            this.searchText = searchText.toLowerCase();
+            this.searchText = lowerCase(searchText);
         }
 
         @Override
         public boolean matches(Element root, Element element) {
-            return (element.ownText().toLowerCase().contains(searchText));
+            return lowerCase(element.ownText()).contains(searchText);
         }
 
         @Override

--- a/src/main/java/org/jsoup/select/QueryParser.java
+++ b/src/main/java/org/jsoup/select/QueryParser.java
@@ -9,6 +9,8 @@ import org.jsoup.helper.StringUtil;
 import org.jsoup.helper.Validate;
 import org.jsoup.parser.TokenQueue;
 
+import static org.jsoup.internal.Normalizer.normalize;
+
 /**
  * Parses a CSS selector into an Evaluator tree.
  */
@@ -222,7 +224,7 @@ public class QueryParser {
 
         // namespaces: wildcard match equals(tagName) or ending in ":"+tagName
         if (tagName.startsWith("*|")) {
-            evals.add(new CombiningEvaluator.Or(new Evaluator.Tag(tagName.trim().toLowerCase()), new Evaluator.TagEndsWith(tagName.replace("*|", ":").trim().toLowerCase())));
+            evals.add(new CombiningEvaluator.Or(new Evaluator.Tag(normalize(tagName)), new Evaluator.TagEndsWith(normalize(tagName.replace("*|", ":")))));
         } else {
             // namespaces: if element name is "abc:def", selector must be "abc|def", so flip:
             if (tagName.contains("|"))
@@ -288,7 +290,7 @@ public class QueryParser {
     private static final Pattern NTH_B  = Pattern.compile("(\\+|-)?(\\d+)");
 
 	private void cssNthChild(boolean backwards, boolean ofType) {
-		String argS = tq.chompTo(")").trim().toLowerCase();
+		String argS = normalize(tq.chompTo(")"));
 		Matcher mAB = NTH_AB.matcher(argS);
 		Matcher mB = NTH_B.matcher(argS);
 		final int a, b;

--- a/src/test/java/org/jsoup/MultiLocaleRule.java
+++ b/src/test/java/org/jsoup/MultiLocaleRule.java
@@ -1,0 +1,41 @@
+package org.jsoup;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Locale;
+
+public class MultiLocaleRule implements TestRule {
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface MultiLocaleTest {
+    }
+
+    public Statement apply(final Statement statement, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                MultiLocaleTest annotation = description.getAnnotation(MultiLocaleTest.class);
+                if (annotation == null) {
+                    statement.evaluate();
+                    return;
+                }
+
+                evaluateWithLocale(Locale.ENGLISH);
+                evaluateWithLocale(new Locale("tr"));
+            }
+
+            private void evaluateWithLocale(Locale locale) throws Throwable {
+                Locale oldLocale = Locale.getDefault();
+                Locale.setDefault(locale);
+                try {
+                    statement.evaluate();
+                } finally {
+                    Locale.setDefault(oldLocale);
+                }
+            }
+        };
+    }
+}

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -2,7 +2,10 @@ package org.jsoup.helper;
 
 import static org.junit.Assert.*;
 
+import org.jsoup.MultiLocaleRule;
+import org.jsoup.MultiLocaleRule.MultiLocaleTest;
 import org.jsoup.integration.ParseTest;
+import org.junit.Rule;
 import org.junit.Test;
 import org.jsoup.Connection;
 
@@ -13,6 +16,8 @@ import java.net.MalformedURLException;
 
 public class HttpConnectionTest {
     /* most actual network http connection tests are in integration */
+
+    @Rule public MultiLocaleRule rule = new MultiLocaleRule();
 
     @Test(expected=IllegalArgumentException.class) public void throwsExceptionOnParseWithoutExecute() throws IOException {
         Connection con = HttpConnection.connect("http://example.com");
@@ -29,7 +34,7 @@ public class HttpConnectionTest {
         con.response().bodyAsBytes();
     }
 
-    @Test public void caseInsensitiveHeaders() {
+    @Test @MultiLocaleTest public void caseInsensitiveHeaders() {
         Connection.Response res = new HttpConnection.Response();
         Map<String, String> headers = res.headers();
         headers.put("Accept-Encoding", "gzip");
@@ -39,15 +44,20 @@ public class HttpConnectionTest {
         assertTrue(res.hasHeader("Accept-Encoding"));
         assertTrue(res.hasHeader("accept-encoding"));
         assertTrue(res.hasHeader("accept-Encoding"));
+        assertTrue(res.hasHeader("ACCEPT-ENCODING"));
 
         assertEquals("gzip", res.header("accept-Encoding"));
+        assertEquals("gzip", res.header("ACCEPT-ENCODING"));
         assertEquals("text/html", res.header("Content-Type"));
         assertEquals("http://example.com", res.header("Referrer"));
 
         res.removeHeader("Content-Type");
         assertFalse(res.hasHeader("content-type"));
 
-        res.header("accept-encoding", "deflate");
+        res.removeHeader("ACCEPT-ENCODING");
+        assertFalse(res.hasHeader("Accept-Encoding"));
+
+        res.header("ACCEPT-ENCODING", "deflate");
         assertEquals("deflate", res.header("Accept-Encoding"));
         assertEquals("deflate", res.header("accept-Encoding"));
     }

--- a/src/test/java/org/jsoup/parser/ParserSettingsTest.java
+++ b/src/test/java/org/jsoup/parser/ParserSettingsTest.java
@@ -1,27 +1,50 @@
 package org.jsoup.parser;
 
+import org.jsoup.MultiLocaleRule;
+import org.jsoup.MultiLocaleRule.MultiLocaleTest;
+import org.jsoup.nodes.Attributes;
+import org.junit.Rule;
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 
 public class ParserSettingsTest {
-    @Test
-    public void caseSupport() {
+    @Rule public MultiLocaleRule rule = new MultiLocaleRule();
+
+    @Test @MultiLocaleTest public void caseSupport() {
         ParseSettings bothOn = new ParseSettings(true, true);
         ParseSettings bothOff = new ParseSettings(false, false);
         ParseSettings tagOn = new ParseSettings(true, false);
         ParseSettings attrOn = new ParseSettings(false, true);
 
-        assertEquals("FOO", bothOn.normalizeTag("FOO"));
-        assertEquals("FOO", bothOn.normalizeAttribute("FOO"));
+        assertEquals("IMG", bothOn.normalizeTag("IMG"));
+        assertEquals("ID", bothOn.normalizeAttribute("ID"));
 
-        assertEquals("foo", bothOff.normalizeTag("FOO"));
-        assertEquals("foo", bothOff.normalizeAttribute("FOO"));
+        assertEquals("img", bothOff.normalizeTag("IMG"));
+        assertEquals("id", bothOff.normalizeAttribute("ID"));
 
-        assertEquals("FOO", tagOn.normalizeTag("FOO"));
-        assertEquals("foo", tagOn.normalizeAttribute("FOO"));
+        assertEquals("IMG", tagOn.normalizeTag("IMG"));
+        assertEquals("id", tagOn.normalizeAttribute("ID"));
 
-        assertEquals("foo", attrOn.normalizeTag("FOO"));
-        assertEquals("FOO", attrOn.normalizeAttribute("FOO"));
+        assertEquals("img", attrOn.normalizeTag("IMG"));
+        assertEquals("ID", attrOn.normalizeAttribute("ID"));
+    }
 
+    @Test @MultiLocaleTest public void attributeCaseNormalization() throws Exception {
+        ParseSettings parseSettings = new ParseSettings(false, false);
+
+        String normalizedAttribute = parseSettings.normalizeAttribute("HIDDEN");
+
+        assertEquals("hidden", normalizedAttribute);
+    }
+
+    @Test @MultiLocaleTest public void attributesCaseNormalization() throws Exception {
+        ParseSettings parseSettings = new ParseSettings(false, false);
+        Attributes attributes = new Attributes();
+        attributes.put("ITEM", "1");
+
+        Attributes normalizedAttributes = parseSettings.normalizeAttributes(attributes);
+
+        assertEquals("item", normalizedAttributes.asList().get(0).getKey());
     }
 }

--- a/src/test/java/org/jsoup/parser/TagTest.java
+++ b/src/test/java/org/jsoup/parser/TagTest.java
@@ -1,12 +1,17 @@
 package org.jsoup.parser;
 
+import org.jsoup.MultiLocaleRule;
+import org.jsoup.MultiLocaleRule.MultiLocaleTest;
+import org.junit.Rule;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
  Tag tests.
  @author Jonathan Hedley, jonathan@hedley.net */
 public class TagTest {
+    @Rule public MultiLocaleRule rule = new MultiLocaleRule();
 
     @Test public void isCaseSensitive() {
         Tag p1 = Tag.valueOf("P");
@@ -14,10 +19,10 @@ public class TagTest {
         assertFalse(p1.equals(p2));
     }
 
-    @Test public void canBeInsensitive() {
-        Tag p1 = Tag.valueOf("P", ParseSettings.htmlDefault);
-        Tag p2 = Tag.valueOf("p", ParseSettings.htmlDefault);
-        assertEquals(p1, p2);
+    @Test @MultiLocaleTest public void canBeInsensitive() {
+        Tag script1 = Tag.valueOf("script", ParseSettings.htmlDefault);
+        Tag script2 = Tag.valueOf("SCRIPT", ParseSettings.htmlDefault);
+        assertSame(script1, script2);
     }
 
     @Test public void trims() {

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -1,10 +1,12 @@
 package org.jsoup.safety;
 
+import org.jsoup.MultiLocaleRule;
+import org.jsoup.MultiLocaleRule.MultiLocaleTest;
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Entities;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -14,6 +16,8 @@ import static org.junit.Assert.*;
 
  @author Jonathan Hedley, jonathan@hedley.net */
 public class CleanerTest {
+    @Rule public MultiLocaleRule rule = new MultiLocaleRule();
+
     @Test public void simpleBehaviourTest() {
         String h = "<div><p class=foo><a href='http://evil.com'>Hello <b id=bar>there</b>!</a></div>";
         String cleanHtml = Jsoup.clean(h, Whitelist.simpleText());
@@ -77,7 +81,18 @@ public class CleanerTest {
         assertEquals("<p>Contact me <a rel=\"nofollow\">here</a></p>",
                 TextUtil.stripNewlines(cleanHtml));
     }
-    
+
+    @Test @MultiLocaleTest public void whitelistedProtocolShouldBeRetained() {
+        Whitelist whitelist = Whitelist.none()
+                .addTags("a")
+                .addAttributes("a", "href")
+                .addProtocols("a", "href", "something");
+
+        String cleanHtml = Jsoup.clean("<a href=\"SOMETHING://x\"></a>", whitelist);
+
+        assertEquals("<a href=\"SOMETHING://x\"></a>", TextUtil.stripNewlines(cleanHtml));
+    }
+
     @Test public void testDropComments() {
         String h = "<p>Hello<!-- no --></p>";
         String cleanHtml = Jsoup.clean(h, Whitelist.relaxed());

--- a/src/test/java/org/jsoup/select/SelectorTest.java
+++ b/src/test/java/org/jsoup/select/SelectorTest.java
@@ -1,8 +1,11 @@
 package org.jsoup.select;
 
+import org.jsoup.MultiLocaleRule;
+import org.jsoup.MultiLocaleRule.MultiLocaleTest;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -13,6 +16,8 @@ import static org.junit.Assert.*;
  * @author Jonathan Hedley, jonathan@hedley.net
  */
 public class SelectorTest {
+    @Rule public MultiLocaleRule rule = new MultiLocaleRule();
+
     @Test public void testByTag() {
         // should be case insensitive
         Elements els = Jsoup.parse("<div id=1><div id=2><p>Hello</p></div></div><DIV id=3>").select("DIV");
@@ -58,8 +63,8 @@ public class SelectorTest {
         assertEquals("Two", elsFromClass.get(1).text());
     }
 
-    @Test public void testByAttribute() {
-        String h = "<div Title=Foo /><div Title=Bar /><div Style=Qux /><div title=Bam /><div title=SLAM />" +
+    @Test @MultiLocaleTest public void testByAttribute() {
+        String h = "<div Title=Foo /><div Title=Bar /><div Style=Qux /><div title=Balim /><div title=SLIM />" +
                 "<div data-name='with spaces'/>";
         Document doc = Jsoup.parse(h);
 
@@ -86,17 +91,17 @@ public class SelectorTest {
         Elements starts = doc.select("[title^=ba]");
         assertEquals(2, starts.size());
         assertEquals("Bar", starts.first().attr("title"));
-        assertEquals("Bam", starts.last().attr("title"));
+        assertEquals("Balim", starts.last().attr("title"));
 
-        Elements ends = doc.select("[title$=am]");
+        Elements ends = doc.select("[title$=im]");
         assertEquals(2, ends.size());
-        assertEquals("Bam", ends.first().attr("title"));
-        assertEquals("SLAM", ends.last().attr("title"));
+        assertEquals("Balim", ends.first().attr("title"));
+        assertEquals("SLIM", ends.last().attr("title"));
 
-        Elements contains = doc.select("[title*=a]");
-        assertEquals(3, contains.size());
-        assertEquals("Bar", contains.first().attr("title"));
-        assertEquals("SLAM", contains.last().attr("title"));
+        Elements contains = doc.select("[title*=i]");
+        assertEquals(2, contains.size());
+        assertEquals("Balim", contains.first().attr("title"));
+        assertEquals("SLIM", contains.last().attr("title"));
     }
 
     @Test public void testNamespacedTag() {
@@ -141,8 +146,8 @@ public class SelectorTest {
         assertEquals("2", byContains.last().id());
     }
 
-    @Test public void testByAttributeStarting() {
-        Document doc = Jsoup.parse("<div id=1 data-name=jsoup>Hello</div><p data-val=5 id=2>There</p><p id=3>No</p>");
+    @Test @MultiLocaleTest public void testByAttributeStarting() {
+        Document doc = Jsoup.parse("<div id=1 ATTRIBUTE data-name=jsoup>Hello</div><p data-val=5 id=2>There</p><p id=3>No</p>");
         Elements withData = doc.select("[^data-]");
         assertEquals(2, withData.size());
         assertEquals("1", withData.first().id());
@@ -151,6 +156,8 @@ public class SelectorTest {
         withData = doc.select("p[^data-]");
         assertEquals(1, withData.size());
         assertEquals("2", withData.first().id());
+
+        assertEquals(1, doc.select("[^attrib]").size());
     }
 
     @Test public void testByAttributeRegex() {
@@ -518,8 +525,8 @@ public class SelectorTest {
         assertEquals("Two", divs.first().text());
     }
 
-    @Test public void testPseudoContains() {
-        Document doc = Jsoup.parse("<div><p>The Rain.</p> <p class=light>The <i>rain</i>.</p> <p>Rain, the.</p></div>");
+    @Test @MultiLocaleTest public void testPseudoContains() {
+        Document doc = Jsoup.parse("<div><p>The Rain.</p> <p class=light>The <i>RAIN</i>.</p> <p>Rain, the.</p></div>");
 
         Elements ps1 = doc.select("p:contains(Rain)");
         assertEquals(3, ps1.size());
@@ -527,7 +534,7 @@ public class SelectorTest {
         Elements ps2 = doc.select("p:contains(the rain)");
         assertEquals(2, ps2.size());
         assertEquals("The Rain.", ps2.first().html());
-        assertEquals("The <i>rain</i>.", ps2.last().html());
+        assertEquals("The <i>RAIN</i>.", ps2.last().html());
 
         Elements ps3 = doc.select("p:contains(the Rain):has(i)");
         assertEquals(1, ps3.size());
@@ -539,6 +546,9 @@ public class SelectorTest {
 
         Elements ps5 = doc.select(":contains(rain)");
         assertEquals(8, ps5.size()); // html, body, div,...
+
+        Elements ps6 = doc.select(":contains(RAIN)");
+        assertEquals(8, ps6.size());
     }
 
     @Test public void testPsuedoContainsWithParentheses() {
@@ -553,13 +563,17 @@ public class SelectorTest {
         assertEquals("2", ps2.first().id());
     }
 
-    @Test public void containsOwn() {
-        Document doc = Jsoup.parse("<p id=1>Hello <b>there</b> now</p>");
-        Elements ps = doc.select("p:containsOwn(Hello now)");
+    @Test @MultiLocaleTest public void containsOwn() {
+        Document doc = Jsoup.parse("<p id=1>Hello <b>there</b> igor</p>");
+        Elements ps = doc.select("p:containsOwn(Hello IGOR)");
         assertEquals(1, ps.size());
         assertEquals("1", ps.first().id());
 
         assertEquals(0, doc.select("p:containsOwn(there)").size());
+
+        Document doc2 = Jsoup.parse("<p>Hello <b>there</b> IGOR</p>");
+        assertEquals(1, doc2.select("p:containsOwn(igor)").size());
+
     }
 
     @Test public void testMatches() {
@@ -703,26 +717,28 @@ public class SelectorTest {
         assertEquals("Two", doc.select("div[data=\"[Another)]]\"]").first().text());
     }
 
-    @Test public void containsData() {
-        String html = "<p>jsoup</p><script>jsoup</script><span><!-- comments --></span>";
+    @Test @MultiLocaleTest public void containsData() {
+        String html = "<p>function</p><script>FUNCTION</script><style>item</style><span><!-- comments --></span>";
         Document doc = Jsoup.parse(html);
         Element body = doc.body();
 
-        Elements dataEls1 = body.select(":containsData(jsoup)");
-        Elements dataEls2 = body.select("script:containsData(jsoup)");
+        Elements dataEls1 = body.select(":containsData(function)");
+        Elements dataEls2 = body.select("script:containsData(function)");
         Elements dataEls3 = body.select("span:containsData(comments)");
-        Elements dataEls4 = body.select(":containsData(s)");
+        Elements dataEls4 = body.select(":containsData(o)");
+        Elements dataEls5 = body.select("style:containsData(ITEM)");
 
         assertEquals(2, dataEls1.size()); // body and script
         assertEquals(1, dataEls2.size());
         assertEquals(dataEls1.last(), dataEls2.first());
-        assertEquals("<script>jsoup</script>", dataEls2.outerHtml());
+        assertEquals("<script>FUNCTION</script>", dataEls2.outerHtml());
         assertEquals(1, dataEls3.size());
         assertEquals("span", dataEls3.first().tagName());
         assertEquals(3, dataEls4.size());
         assertEquals("body", dataEls4.first().tagName());
         assertEquals("script", dataEls4.get(1).tagName());
         assertEquals("span", dataEls4.get(2).tagName());
+        assertEquals(1, dataEls5.size());
     }
 
     @Test public void containsWithQuote() {


### PR DESCRIPTION
`String.toLowerCase()` uses the default locale for the case conversion. This can lead to undesired results when using the Turkish locale (see the blog post linked in issue #256).

This pull request adds some tests to make sure jsoup's behavior is independent of the default locale. `MultiLocaleRule` runs every test annotated with `@MultiLocaleTest` twice. Once with `Locale.ENGLISH` as the default locale and once with Turkish as the default value.

This does not fix content matching issues with non-ASCII data, e.g. the one described in issue #474. However, it now consistently fails independent of the default locale.

Fixes #256