### PR TITLE
Add new classes/functions to select and modify text as text (not structure)

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -12,6 +12,8 @@ import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
 import org.jsoup.select.QueryParser;
 import org.jsoup.select.Selector;
+import org.jsoup.text.Region;
+import org.jsoup.text.Regions;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1254,6 +1256,21 @@ public class Element extends Node {
     private void html(StringBuilder accum) {
         for (Node node : childNodes)
             node.outerHtml(accum);
+    }
+
+    /**
+     *  Return the {@link Regions} whose text match needle. Matching
+     *  is as for {@link org.jsoup.Region#findNext()}.
+     */
+    public Regions find(final String needle) {
+        Regions result = new Regions();
+        Region r = Region.find(needle, this, this);
+        while(r != null) {
+            result.add(r);
+            r.splitTextNodes();
+            r = r.findNext(needle, this);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -650,7 +650,8 @@ public abstract class Node implements Cloneable {
         clone.reindexChildren(0);
 
         clone.parentNode = null;
-        parentNode.addChildren(siblingIndex + 1, clone);
+        if(parentNode != null)
+            parentNode.addChildren(siblingIndex + 1, clone);
     }
 
 

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -33,7 +33,7 @@ public abstract class Node implements Cloneable {
     protected Node(String baseUri, Attributes attributes) {
         Validate.notNull(baseUri);
         Validate.notNull(attributes);
-        
+
         childNodes = EMPTY_NODES;
         this.baseUri = baseUri.trim();
         this.attributes = attributes;
@@ -65,7 +65,7 @@ public abstract class Node implements Cloneable {
      * </p>
      * E.g.:
      * <blockquote><code>String url = a.attr("abs:href");</code></blockquote>
-     * 
+     *
      * @param attributeKey The attribute key.
      * @return The attribute, or empty string if not present (to avoid nulls).
      * @see #attributes()
@@ -170,7 +170,7 @@ public abstract class Node implements Cloneable {
      * As an alternate, you can use the {@link #attr} method with the <code>abs:</code> prefix, e.g.:
      * <code>String absUrl = linkEl.attr("abs:href");</code>
      * </p>
-     * 
+     *
      * @param attributeKey The attribute key
      * @return An absolute URL if one could be made, or an empty string (not null) if the attribute was missing or
      * could not be made successfully into a URL.
@@ -225,7 +225,7 @@ public abstract class Node implements Cloneable {
     public final int childNodeSize() {
         return childNodes.size();
     }
-    
+
     protected Node[] childNodesAsArray() {
         return childNodes.toArray(new Node[childNodeSize()]);
     }
@@ -256,16 +256,16 @@ public abstract class Node implements Cloneable {
             node = node.parentNode;
         return node;
     }
-    
+
     /**
-     * Gets the Document associated with this Node. 
+     * Gets the Document associated with this Node.
      * @return the Document associated with this Node, or null if there is no such Document.
      */
     public Document ownerDocument() {
         Node root = root();
         return (root instanceof Document) ? (Document) root : null;
     }
-    
+
     /**
      * Remove (delete) this node from the DOM tree. If this node has children, they are also removed.
      */
@@ -328,7 +328,7 @@ public abstract class Node implements Cloneable {
         Validate.notNull(html);
         Validate.notNull(parentNode);
 
-        Element context = parent() instanceof Element ? (Element) parent() : null;        
+        Element context = parent() instanceof Element ? (Element) parent() : null;
         List<Node> nodes = Parser.parseFragment(html, context, baseUri());
         parentNode.addChildren(index, nodes.toArray(new Node[nodes.size()]));
     }
@@ -373,7 +373,7 @@ public abstract class Node implements Cloneable {
      * Calling {@code element.unwrap()} on the {@code span} element will result in the html:
      * <p>{@code <div>One Two <b>Three</b></div>}</p>
      * and the {@code "Two "} {@link TextNode} being returned.
-     * 
+     *
      * @return the first child of this node, after the node has been unwrapped. Null if the node had no children.
      * @see #remove()
      * @see #wrap(String)
@@ -395,7 +395,7 @@ public abstract class Node implements Cloneable {
         else
             return el;
     }
-    
+
     /**
      * Replace this node in the DOM with the supplied node.
      * @param in the node that will will replace the existing node.
@@ -417,7 +417,7 @@ public abstract class Node implements Cloneable {
         Validate.notNull(in);
         if (in.parentNode != null)
             in.parentNode.removeChild(in);
-        
+
         final int index = out.siblingIndex;
         childNodes.set(index, in);
         in.parentNode = this;
@@ -465,13 +465,13 @@ public abstract class Node implements Cloneable {
             child.parentNode.removeChild(child);
         child.setParentNode(this);
     }
-    
+
     private void reindexChildren(int start) {
         for (int i = start; i < childNodes.size(); i++) {
             childNodes.get(i).setSiblingIndex(i);
         }
     }
-    
+
     /**
      Retrieves this node's sibling nodes. Similar to {@link #childNodes()  node.parent.childNodes()}, but does not
      include this node (a node is not a sibling of itself).
@@ -496,7 +496,7 @@ public abstract class Node implements Cloneable {
     public Node nextSibling() {
         if (parentNode == null)
             return null; // root
-        
+
         final List<Node> siblings = parentNode.childNodes;
         final int index = siblingIndex+1;
         if (siblings.size() > index)
@@ -528,7 +528,7 @@ public abstract class Node implements Cloneable {
     public int siblingIndex() {
         return siblingIndex;
     }
-    
+
     protected void setSiblingIndex(int siblingIndex) {
         this.siblingIndex = siblingIndex;
     }
@@ -584,8 +584,8 @@ public abstract class Node implements Cloneable {
         outerHtml(appendable);
         return appendable;
     }
-    
-	public String toString() {
+
+        public String toString() {
         return outerHtml();
     }
 
@@ -618,6 +618,41 @@ public abstract class Node implements Cloneable {
 
         return this.outerHtml().equals(((Node) o).outerHtml());
     }
+
+    /**
+     *  Split this node in two, leaving both as children of the same
+     *  parent and all children of this node in one of the two.
+     *  Children from 0-child inclusive are left in this Node,
+     *  children after child are moved to the new Node, which is this
+     *  Node's {@link Node#nextSibling()}.
+     *
+     *  Do nothing if child is the last child.
+     */
+
+    public void splitAfter(Node child) {
+        int i = childNodes.indexOf(child);
+        if(i < 0 || i == childNodes.size() - 1)
+            return;
+
+        Node clone;
+
+        try {
+            clone = (Node) super.clone();
+            clone.attributes = attributes != null ? attributes.clone() : null;
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+
+        clone.childNodes = new ArrayList<Node>();
+        clone.childNodes.addAll(childNodes.subList(i+1, childNodes.size()));
+        for(Node moving : clone.childNodes)
+            clone.reparentChild(moving);
+        clone.reindexChildren(0);
+
+        clone.parentNode = null;
+        parentNode.addChildren(siblingIndex + 1, clone);
+    }
+
 
     /**
      * Create a stand-alone, deep copy of this node, and all of its children. The cloned node will have no siblings or
@@ -684,19 +719,19 @@ public abstract class Node implements Cloneable {
 
         public void head(Node node, int depth) {
             try {
-				node.outerHtmlHead(accum, depth, out);
-			} catch (IOException exception) {
-				throw new SerializationException(exception);
-			}
+                                node.outerHtmlHead(accum, depth, out);
+                        } catch (IOException exception) {
+                                throw new SerializationException(exception);
+                        }
         }
 
         public void tail(Node node, int depth) {
             if (!node.nodeName().equals("#text")) { // saves a void hit.
-				try {
-					node.outerHtmlTail(accum, depth, out);
-				} catch (IOException exception) {
-					throw new SerializationException(exception);
-				}
+                                try {
+                                        node.outerHtmlTail(accum, depth, out);
+                                } catch (IOException exception) {
+                                        throw new SerializationException(exception);
+                                }
             }
         }
     }

--- a/src/main/java/org/jsoup/text/Point.java
+++ b/src/main/java/org/jsoup/text/Point.java
@@ -1,0 +1,371 @@
+package org.jsoup.text;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+
+/**
+ * A single point in a document. This is either before the first
+ * character in a document, between two, or after the last
+ * character. Point is usually used only as start/end of a
+ * {@link Region}.
+ *
+ * <p>A Point is always in a TextNode, which means that in a sequence
+ * such as abc&lt;u&gt;def, there are two possible Points between c
+ * and d, namely, tied to the c and to the d. The former
+ * ({@link #leftBound()}) is usually better if you want to operate on a
+ * {@link Region} that ends with the c, the latter ({@link #rightBound()})
+ * is usually better if you want to operate on a {@link Region} that
+ * starts with the d.
+ *
+ * <p>This class contains both a normal constructor and a number of
+ * functions that create new points: If you have a point, you can get
+ * a new point at the start or end of the surrounding block/inline
+ * element, and if you have an {@link org.jsoup.node.Element}, you can
+ * get a point at the start or end of that Element.
+ */
+public class Point {
+    private TextNode in;
+    private int offset;
+
+    /**
+     *  Creates a Point before that character in that node.
+     *
+     *  <p>If character is larger than the number of characters in the
+     *  node, then the new point is after the last character in the
+     *  node (which is subtly different from being before the first
+     *  character of the following TextNode).
+     *
+     *  This is immutable, except that the TextNode may be changed.
+     */
+    public Point(final TextNode node, final int character) {
+        in = node;
+        offset = Math.min(character, node.getWholeText().length());
+    }
+
+    /**
+     * Returns the TextNode containing this Point.
+     */
+    public TextNode getTextNode() {
+        revalidate();
+        return in;
+    }
+
+    /**
+     * Returns the offset of this Point in getTextNode().
+     */
+    public int getOffset() {
+        revalidate();
+        return offset;
+    }
+
+    /**
+     * Return a Point at the same location as this, and in the same
+     * {@link org.jsoup.nodes.TextNode} as to the character on its
+     * left.
+     *
+     * <p>There is one exception: If this Point is before the first
+     * character within the specified Node, then the Point returned is
+     * (necessarily) tied to the character on its right.
+     */
+    public Point leftBound(final Node within) {
+        revalidate();
+        if(offset > 0)
+            return this;
+        Region.NeighbouringTextNode previous =
+            Region.NeighbouringTextNode.previous(in, within);
+        if(previous.textNode == null)
+            return this;
+        return new Point(previous.textNode,
+                         previous.textNode.getWholeText().length());
+    }
+
+    /**
+     * Return a Point at the same location as this, and in the same
+     * {@link org.jsoup.nodes.TextNode} as to the character on its
+     * left.
+     *
+     * <p>There is one exception: If this Point is before the first
+     * character in the {@link org.jsoup.nodes.Document}, then the
+     * Point returned is (necessarily) tied to the character on its
+     * right.
+     */
+    public Point leftBound() {
+        return leftBound(null);
+    }
+
+    /**
+     * Return a Point at the same location as this, and in the same
+     * {@link org.jsoup.nodes.TextNode} as to the character on its
+     * right. This is usually self.
+     *
+     * <p>There is one exception: If this Point is after the last
+     * character within the Node supplied, then the Point returned is
+     * (necessarily) tied to the character on its left.
+     */
+    public Point rightBound(final Node within) {
+        revalidate();
+        if(offset < in.getWholeText().length())
+            return this;
+        Region.NeighbouringTextNode next =
+            Region.NeighbouringTextNode.next(in, within);
+        if(next.textNode == null)
+            return this;
+        return new Point(next.textNode, 0);
+    }
+
+    /**
+     * Return a Point at the same location as this, and in the same
+     * {@link org.jsoup.nodes.TextNode} as to the character on its
+     * right.
+     *
+     * <p>There is one exception: If this Point is after the last
+     * character in the {@link org.jsoup.nodes.Document}, then
+     * the Point is (necessarily) tied to the character on its left.
+     */
+    public Point rightBound() {
+        return rightBound(null);
+    }
+
+    /**
+     *  Make sure this Point points after the last character of a
+     *  TextNode, which is the last child of its parent, which is the
+     *  last child, etc, until the supplied grandParent. That node is
+     *  not affected (but may receive one extra child).
+     */
+    void splitAfterUpTo(final Node grandParent) {
+        revalidate();
+        if(offset > 0 && offset < in.getWholeText().length())
+            in.splitText(offset);
+        Node n = in;
+        while(n.parent() != null && n.parent() != grandParent) {
+            n.parent().splitAfter(n);
+            n = n.parent();
+        }
+    }
+
+    /**
+     *  Return the next region after this Point and within the
+     *  specified Node that contains text, or null if no such region
+     *  exists. (Whitespace matches whitespace, any other characters
+     *  must match exactly.)
+     */
+    public Region findNext(final String text, final Node within) {
+        revalidate();
+        return Region.findNext(text, getTextNode(), getOffset(),
+                               within);
+    }
+
+    /**
+     *  Return a Region containing up to about the specified number of
+     *  characters starting at this point. The limit is counted along
+     *  the lines of {@link org.jsoup.nodes.TextNode#getWholeText()}. Note
+     *  that {@link org.jsoup.text.Region#getText()} may add spaces at
+     *  block element boundaries and collapse adjacent spaces, so the
+     *  two counts may be slightly different.
+     *
+     *  <p>The returned node can be much shorter, if this point is
+     *  close to the end of the document.
+     */
+    public Region followingRegion(final int characters) {
+        return followingRegion(characters, null);
+    }
+
+    /**
+     *  Return a Region containing up to about the specified number of
+     *  characters starting at this point. The limit is counted along
+     *  the lines of {@link org.jsoup.nodes.TextNode#getWholeText()}. Note
+     *  that {@link org.jsoup.text.Region#getText()} may add spaces at
+     *  block element boundaries and collapse adjacent spaces, so the
+     *  two counts may be slightly different.
+     *
+     *  <p>The returned node can be much shorter, since it's
+     *  constrained to be within the specified Node (if non-null).
+     */
+    public Region followingRegion(final int characters, final Node within) {
+        revalidate();
+        int have = in.getWholeText().length() - offset;
+        TextNode n = in;
+        while(have < characters) {
+            TextNode next =
+                Region.NeighbouringTextNode.next(n, within).textNode;
+            if(next == null)
+                return new Region(this,
+                                  new Point(n, n.getWholeText().length()));
+            n = next;
+            have += n.getWholeText().length();
+        }
+        int unneeded = have - characters;
+        Point end = new Point(n, n.getWholeText().length() - unneeded);
+        return new Region(this, end);
+    }
+
+    /**
+     *  Return a Region containing up to about the specified number of
+     *  characters end at this point. The limit is counted along
+     *  the lines of {@link org.jsoup.nodes.TextNode#getWholeText()}. Note
+     *  that {@link org.jsoup.text.Region#getText()} may add spaces at
+     *  block element boundaries and collapse adjacent spaces, so the
+     *  two counts may be slightly different.
+     *
+     *  <p>The returned node can be much shorter, if this point is
+     *  close to the start of the document.
+     */
+    public Region precedingRegion(final int characters) {
+        return precedingRegion(characters, null);
+    }
+
+    /**
+     *  Return a Region containing up to about the specified number of
+     *  characters end at this point. The limit is counted along
+     *  the lines of {@link org.jsoup.nodes.TextNode#getWholeText()}. Note
+     *  that {@link org.jsoup.text.Region#getText()} may add spaces at
+     *  block element boundaries and collapse adjacent spaces, so the
+     *  two counts may be slightly different.
+     *
+     *  <p>The returned node can be much shorter, since it's
+     *  constrained to be within the specified Node (if non-null).
+     */
+    public Region precedingRegion(final int characters, final Node within) {
+        revalidate();
+        int have = offset;
+        TextNode n = in;
+        while(have < characters) {
+            TextNode previous =
+                Region.NeighbouringTextNode.previous(n, within).textNode;
+            if(previous == null)
+                return new Region(new Point(n, 0), this);
+            n = previous;
+            have += n.getWholeText().length();
+        }
+        int unneeded = have - characters;
+        Point start = new Point(n, unneeded);
+        return new Region(start, this);
+    }
+
+    private Point boundaryHelper(boolean block, boolean end) {
+        Node n = in;
+        TextNode result = null;
+        while(n != null &&
+              (!(n instanceof Element) ||
+               (block && !((Element)n).isBlock())))
+            n = n.parent();
+        if(end)
+            result = Region.NeighbouringTextNode.previous(n, n).textNode;
+        else
+            result = Region.NeighbouringTextNode.next(n, n).textNode;
+        if(result == null)
+            result = in;
+        if(end)
+            return new Point(result, result.getWholeText().length());
+        else
+            return new Point(result, 0);
+    }
+
+    /**
+     *  Return a Point just before the first character in the same
+     *  Element as this Point.
+     */
+
+    public Point atStartOfElement() {
+        return boundaryHelper(false, false);
+    }
+
+    /**
+     *  Return a Point just before the first character in the same
+     *  block Element as this Point; typically this is the start of a
+     *  paragraph.
+     */
+
+    public Point atStartOfBlock() {
+        return boundaryHelper(true, false);
+    }
+
+    /**
+     *  Return a Point just after the last character in the same
+     *  Element as this Point.
+     */
+
+    public Point atEndOfElement() {
+        return boundaryHelper(false, true);
+    }
+
+    /**
+     *  Return a Point just after the last character in the same block
+     *  Element as this Point; typically this is the end of a
+     *  paragraph.
+     */
+
+    public Point atEndOfBlock() {
+        return boundaryHelper(true, true);
+    }
+
+    /**
+     *  Return a Point just before the first character within e, if
+     *  necessary creating an empty TextNode.
+     */
+
+    static public Point atStartOfElement(final Element e) {
+        TextNode result = Region.NeighbouringTextNode.next(e, e).textNode;
+        if(result == null) {
+            e.prependText("");
+            result = Region.NeighbouringTextNode.next(e, e).textNode;
+        }
+        return new Point(result, 0);
+    }
+
+    /**
+     *  Return a Point just after the last character within e, if
+     *  necessary creating an empty TextNode.
+     */
+
+    static public Point atEndOfElement(final Element e) {
+        TextNode result = Region.NeighbouringTextNode.previous(e, e).textNode;
+        if(result == null) {
+            e.appendText("");
+            result = Region.NeighbouringTextNode.previous(e, e).textNode;
+        }
+        return new Point(result, result.getWholeText().length());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Point)) return false;
+
+        revalidate();
+        Point other = (Point)o;
+        return in == other.in && offset == other.offset;
+    }
+
+    @Override
+    public int hashCode() {
+        revalidate();
+        return in.hashCode() * 31 + offset;
+    }
+
+    @Override
+    public String toString() {
+        revalidate();
+        return in + ": " + offset;
+    }
+
+    /**
+     *  If a Point has been rendered invalid by
+     *  Region.splitTextNodes() or Point.splitAfterUpTo(), then this
+     *  private helper function undoes the damage. However, it does no
+     *  magic, and of course cannot recover from substantive changes to
+     *  the document.
+     */
+
+    private void revalidate() {
+        while(offset > in.getWholeText().length()) {
+            Node n = in.nextSibling();
+            if(!(n instanceof TextNode))
+                throw new IllegalArgumentException("Invalid point used");
+            offset -= in.getWholeText().length();
+            in = (TextNode)n;
+        }
+    }
+}

--- a/src/main/java/org/jsoup/text/Region.java
+++ b/src/main/java/org/jsoup/text/Region.java
@@ -1,0 +1,623 @@
+package org.jsoup.text;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.jsoup.helper.StringUtil;
+
+import static org.jsoup.helper.StringUtil.appendNormalisedWhitespace;
+import static org.jsoup.helper.StringUtil.isWhitespace;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+import org.jsoup.parser.Parser;
+
+
+/**
+ *  A part of a document, consisting of a start and an end Point.
+ *
+ *  <p>The Region class permits you to find text by text (rather than by
+ *  structure, as {@Link Element#select()} does) and remove, wrap or
+ *  replace it.
+ *
+ *  <p>Since a Region may span elements, even block elements, changing
+ *  it can necessarily involve fairly deep changes in the DOM
+ *  structure. For example, wrapping the last word of one paragraph
+ *  and the first of the following in &lt;a href&gt; moves the words
+ *  to two new one-word paragraphs wrapped in an &lt;a href&gt;.  You
+ *  can detect and/or avoid such deep changes using
+ *  spansBlockElements(), splitByBlockElements(), spansElements() and
+ *  splitByElements(), so that you can disturb nothing, only inline
+ *  elements or all ones, as appropriate for each modification.
+ */
+public class Region {
+    private Point start;
+    private Point end;
+
+    /**
+     *  Create a Region from p1 to p2, which must be at or after p1.
+     */
+    public Region(final Point p1, final Point p2) {
+        start = p1.rightBound();
+        end = p2.leftBound();
+        if(p1.equals(end) || p2.equals(start))
+            end = start;
+    }
+
+    /**
+     *  Create a Region spanning all of n.
+     */
+    public Region(final Element e) {
+        start = Point.atStartOfElement(e);
+        end = Point.atEndOfElement(e);
+    }
+
+    /**
+     * Return the start of this region.
+     */
+    public Point getStart() {
+        return start;
+    }
+
+    /**
+     * Return the end of this Region.
+     */
+    public Point getEnd() {
+        return end;
+    }
+
+    /**
+     * Return the textual content of this Region, normalised.
+     * Crossing a block element boundary results in a single space,
+     * crossing an inline element boundary results in nothing.
+     */
+    public String getText() {
+        if(start.getTextNode() == end.getTextNode()) {
+            String whole = start.getTextNode().getWholeText()
+                .substring(start.getOffset(), end.getOffset());
+            return StringUtil.normaliseWhitespace(whole).trim();
+        }
+
+        StringBuilder result = new StringBuilder();
+        appendNormalisedWhitespace(result,
+                                   start.getTextNode().getWholeText()
+                                   .substring(start.getOffset()),
+                                   false);
+        NeighbouringTextNode next =
+            NeighbouringTextNode.next(start.getTextNode(), null);
+        while(next.textNode != null && next.textNode != end.getTextNode()) {
+            if(next.hasSeenBlockElement &&
+               (result.length() > 0 &&
+                !isWhitespace(result.charAt(result.length()-1))))
+               result.append(" ");
+            appendNormalisedWhitespace(result,
+                                       next.textNode.getWholeText(),
+                                       next.hasSeenBlockElement);
+            next = NeighbouringTextNode.next(next.textNode, null);
+        }
+        if(next.hasSeenBlockElement &&
+           (result.length() > 0 &&
+            !isWhitespace(result.charAt(result.length()-1))))
+            result.append(" ");
+        appendNormalisedWhitespace(result,
+                                   end.getTextNode().getWholeText()
+                                   .substring(0, end.getOffset()),
+                                   next.hasSeenBlockElement);
+        return result.toString().trim();
+    }
+
+
+
+    /**
+     *  Split the Region into Regions such that each Region is entirely
+     *  within a single Element.
+     *
+     *  <p>This is useful if you want to, say, elide the region: You
+     *  can replace the first Region with an ellipsis and drop the
+     *  remainder outright.
+     */
+    public Regions splitByElements() {
+        return regionSplitHelper(false);
+    }
+
+    /**
+     *  Split the Region into Regions such that each Region is entirely
+     *  within a single Element.
+     *
+     *  <p>This is useful if you want to, say, wrap the region in
+     *  &lt;a href...&gt; or &lt;b&gt;.
+     */
+    public Regions splitByBlockElements() {
+        return regionSplitHelper(true);
+    }
+
+    Regions regionSplitHelper(boolean block) {
+        Regions result = new Regions();
+        Point s = start;
+        TextNode t = start.getTextNode();
+        while(t != null && t != end.getTextNode()) {
+            NeighbouringTextNode n = NeighbouringTextNode.next(t, null);
+            if(n.textNode != null &&
+               (n.hasSeenBlockElement ||
+                (n.hasSeenElement && !block))) {
+                result.add(new Region(s,
+                                      new Point(t, t.getWholeText().length())));
+                s = new Point(n.textNode, 0);
+            }
+            t = n.textNode;
+        }
+        if(!s.equals(end))
+            result.add(new Region(s, end));
+        return result;
+    }
+
+    /**
+     *  Return true if this Region contains characters in different
+     *  elements, as e.g. "...baq&lt;qux..." does, and false if all
+     *  characters are in the same element.
+     */
+
+    public boolean spansMultipleElements() {
+        return spanHelper(false);
+    }
+
+    /**
+     *  Return true if this Region contains characters in different
+     *  block elements, as e.g. "... Great
+     *  Again&lt;/h1&gt;&lt;p&gt;Just ..." does, and false if all
+     *  characters are in the same block element.
+     */
+
+    public boolean spansMultipleBlockElements() {
+        return spanHelper(true);
+    }
+
+    boolean spanHelper(boolean block) {
+        TextNode t = start.getTextNode();
+        while(t != end.getTextNode()) {
+            NeighbouringTextNode n = NeighbouringTextNode.next(t, null);
+            if(n.hasSeenBlockElement ||
+               (n.hasSeenElement && !block))
+                return true;
+            t = n.textNode;
+        }
+        return false;
+    }
+
+    /**
+     *  Split the start and end nodes such that each TextNode is
+     *  either inside or outside this Region.
+     *
+     *  <p>Note that if two Region start/end in the same
+     *  {@link org.jsoup.nodes.TextNode}, then splitting one may
+     *  invalidate the other, which can make working with
+     *  {@link Regions} tricky. The simplest way to avoid this problem
+     *  is to call splitTextNodes() on each Region immediately after
+     *  construction, as {@link org.jsoup.nodes.Element#find()} does.
+     */
+    public void splitTextNodes() {
+        if(start.getOffset() == 0 &&
+           end.getOffset() == end.getTextNode().getWholeText().length())
+            return;
+
+        end.splitAfterUpTo(end.getTextNode().parent());
+        if(start.getOffset() == 0)
+            return;
+
+        start.splitAfterUpTo(start.getTextNode().parent());
+        if(end.getTextNode() == start.getTextNode()) {
+            int length = end.getOffset() - start.getOffset();
+            start = start.rightBound();
+            end = new Point(start.getTextNode(), length);
+        } else {
+            start = start.rightBound();
+        }
+    }
+
+
+    /**
+     *  Remove this Region from the Document.
+     *
+     *  <p>This removes the TextNodes, and those parents which would
+     *  be empty afterwards. It does not remove a strict subtree, but
+     *  rather a number of siblings and their children. (If a div
+     *  contains four paragraphs, and you remove the middle two, the
+     *  div is not affected, it merely loses two of its four children.)
+     */
+    public void remove() {
+        for(Node n : parents())
+            n.remove();
+    }
+
+
+    /**
+     *  Wrap this Region in the new HTML and returns the wrapper.
+     *
+     *  <p>This splits {@link TextNode}s and {@link Element}s just
+     *  sufficiently to that the new HTML can wrap the region. (If a
+     *  div contains four paragraphs, and you wrap the middle two, the
+     *  div has three children afterwards, and the middle child has
+     *  two.)
+     *
+     *  <p>This returns null if the region is completely empty or if html
+     *  cannot be parsed.
+     */
+    public Element wrap(final String html) {
+        List<Node> region = parents();
+        if(region.isEmpty())
+            return null;
+        Node parent = region.get(0).parent();
+        Element context = parent instanceof Element ? (Element) parent : null;
+        List<Node> wrappers =
+            Parser.parseFragment(html, context, parent.root().baseUri());
+        Element wrapper = (Element)wrappers.get(0);
+        if (wrapper == null || !(wrapper instanceof Element))
+            return null;
+        region.get(0).before(wrapper);
+        wrapper.insertChildren(0, region);
+        return wrapper;
+    }
+
+
+    /**
+     *  Return a list of siblings such that all of this region is
+     *  within the return value, and nothing outside the Region is.
+     *
+     *  <p>Note that this changes the document (just) enough that
+     *  there is such a flock of siblings.
+     */
+    public List<Node> parents() {
+        ensureRemovability();
+        List<Node> result = new LinkedList<Node>();
+        Node common = parentElement();
+        if(common == null)
+            return result;
+        Node first = parentChain(start.getTextNode(), common).get(0);
+        Node last = parentChain(end.getTextNode(), common).get(0);
+        if(last == first) {
+            result.add(first);
+            return result;
+        }
+        Node n = first;
+        while(n != null && n != last) {
+            result.add(n);
+            n = n.nextSibling();
+        };
+        result.add(last);
+        return result;
+    }
+
+
+    /**
+     *  Split the parent nodes of the start and end point such that if
+     *  a node is a parent if anything outside the region, then it
+     *  either is also the parent of the complete region, or is not
+     *  the parent of anything in the region.
+     */
+    public void ensureRemovability() {
+        splitTextNodes();
+        Node common = parentElement();
+        if(common == null)
+            return;
+        end.splitAfterUpTo(common);
+        Point before = start.leftBound(common);
+        if(before != start && before.getTextNode() != null)
+            before.splitAfterUpTo(common);
+    }
+
+
+    /**
+     *  Return the closest Element that spans all of this Region and also
+     *  spans at least one character outside it.
+     *
+     *  <p>If the Region spans all of the document, then the result is
+     *  the closest parent Element that spans the entire Region. If
+     *  the Region is empty, then the result is null.
+     */
+    public Element parentElement() {
+        if(start == end)
+            return null;
+        List<Node> before = parentChain(start.leftBound().getTextNode(), null);
+        List<Node> first = parentChain(start.rightBound().getTextNode(), null);
+        List<Node> last = parentChain(end.leftBound().getTextNode(), null);
+        List<Node> after = parentChain(end.rightBound().getTextNode(), null);
+        Element common = null;
+        while(!first.isEmpty() && !last.isEmpty() &&
+              first.get(0) == last.get(0) &&
+              ((!before.isEmpty() && first.get(0) == before.get(0)) ||
+               (!after.isEmpty() && first.get(0) == after.get(0)) ||
+               (before.isEmpty() && after.isEmpty()))) {
+            if(first.get(0) instanceof Element)
+                common = (Element)first.get(0);
+            first.remove(0);
+            if(!before.isEmpty())
+                before.remove(0);
+            last.remove(0);
+            if(!after.isEmpty())
+                after.remove(0);
+
+        }
+        return common;
+    }
+
+    /**
+     *  Return a list of nodes starting with the root and ending with
+     *  the argument. If within is non-null, then the list starts with
+     *  a child of within instead of with the root.
+     */
+    static List<Node> parentChain(final Node child, final Node within) {
+        List<Node> result = new LinkedList<Node>();
+        Node n = child;
+        while(n != null && n != within) {
+            result.add(0, n);
+            n = n.parent();
+        }
+        return result;
+    }
+
+    /**
+     *  This helper returns a Region starting at start/offset if text
+     *  matches the text in that region. (Whitespace matches
+     *  whitespace, any other characters must match exactly.)
+     *
+     *  <p>Return null if text does not match.
+     */
+    static Region regionOrNull(final String text,
+                               final TextNode start,
+                               final int offset) {
+        int tp = 0;
+        int np = offset;
+        TextNode end = start;
+        boolean ts = false;
+        boolean ns = false;
+        while(tp < text.length()) {
+            int wp = tp;
+            while(np >= end.getWholeText().length()) {
+                NeighbouringTextNode next =
+                    NeighbouringTextNode.next(end, null);
+                end = next.textNode;
+                if(next.hasSeenBlockElement)
+                    ns = true;
+                np = 0;
+                if(end == null)
+                    return null;
+            }
+            if(ts) {
+                int c = end.getWholeText().charAt(np);
+                if(Character.isSpaceChar(c) || Character.isWhitespace(c)) {
+                    ns = true;
+                    np++;
+                } else if(ns) {
+                    tp++;
+                } else {
+                    return null;
+                }
+            } else if(text.charAt(tp) == end.getWholeText().charAt(np)) {
+                np++;
+                tp++;
+            } else if(end.getWholeText().charAt(np) == '\u00AD') {
+                np++;
+            } else {
+                return null;
+            }
+            if(tp > wp && tp < text.length()) {
+                int st = text.charAt(tp);
+                boolean ws = ts;
+                ts = Character.isSpaceChar(st) || Character.isWhitespace(st);
+                if(ws && !ts && !ns)
+                    return null;
+            }
+        }
+        return new Region(new Point(start, offset), new Point(end, np));
+    }
+
+    static class NeighbouringTextNode {
+        public final boolean hasSeenBlockElement;
+        public final boolean hasSeenElement;
+        public final TextNode textNode;
+
+        private NeighbouringTextNode(final Node n, boolean s, boolean b) {
+            hasSeenElement = s;
+            hasSeenBlockElement = b;
+            textNode = (TextNode)n;
+        }
+
+        private static boolean isElement(final boolean was, final Node n) {
+            return was || (n != null && n instanceof Element);
+        }
+
+        private static boolean isBlockElement(final boolean was, final Node n) {
+            return was ||
+                ((n != null) &&
+                 (n instanceof Element) &&
+                 (((Element)n).isBlock() ||
+                  ((Element)n).tag().getName().equals("br")));
+        }
+
+        public static NeighbouringTextNode next(final Node startingPoint,
+                                                final Node within) {
+            Node next = startingPoint;
+            boolean element = false;
+            boolean block = false;
+            do {
+                element = isElement(element, next);
+                block = isBlockElement(block, next);
+                if(next.childNodeSize() > 0) {
+                    next = next.childNode(0);
+                } else if(next.nextSibling() != null) {
+                    next = next.nextSibling();
+                } else {
+                    next = next.parent();
+                    element = isElement(element, next);
+                    block = isBlockElement(block, next);
+                    while(next != null && next != within &&
+                          next.nextSibling() == null) {
+                        next = next.parent();
+                        element = isElement(element, next);
+                        block = isBlockElement(block, next);
+                    }
+                    if(next == within)
+                        next = null;
+                    if(next != null)
+                        next = next.nextSibling();
+                }
+            } while(next != null && !(next instanceof TextNode));
+            return new NeighbouringTextNode(next, element, block);
+        }
+
+        public static NeighbouringTextNode previous(final Node startingPoint,
+                                                    final Node within) {
+            Node previous = startingPoint;
+            boolean element = false;
+            boolean block = false;
+            do {
+                element = isElement(element, previous);
+                block = isBlockElement(block, previous);
+                if(previous.childNodeSize() > 0) {
+                    previous = previous.childNode(previous.childNodeSize() - 1);
+                } else if(previous.previousSibling() != null) {
+                    previous = previous.previousSibling();
+                } else {
+                    previous = previous.parent();
+                    element = isElement(element, previous);
+                    block = isBlockElement(block, previous);
+                    while(previous != null &&
+                          previous != within &&
+                          previous.previousSibling() == null) {
+                        previous = previous.parent();
+                        element = isElement(element, previous);
+                        block = isBlockElement(block, previous);
+                    }
+                    if(previous == within)
+                        previous = null;
+                    if(previous != null)
+                        previous = previous.previousSibling();
+                }
+            } while(previous != null && !(previous instanceof TextNode));
+            return new NeighbouringTextNode(previous, element, block);
+        }
+    }
+
+
+    /**
+     *  Return the first region within the supplied Node at/after
+     *  start/offset containing text, or null if no such region
+     *  exists. (Whitespace matches whitespace, any other characters
+     *  must match exactly.)
+     *
+     *  <p>Return null if text does not match.
+     */
+    static Region findNext(final String text,
+                           TextNode start, int offset, Node within) {
+        TextNode at = start;
+        int pos = offset;
+        while(at != null) {
+            Region result = regionOrNull(text, at, pos);
+            if(result != null)
+                return result;
+
+            pos = at.getWholeText().indexOf(text.charAt(0), pos+1);
+            if(pos < 0) {
+                pos = 0;
+                at = NeighbouringTextNode.next(at, within).textNode;
+            }
+        }
+        return null;
+    }
+
+
+    /**
+     *  Return the first region within the specified Node that
+     *  contains text, or null if no such region exists. (Whitespace
+     *  matches whitespace, any other characters must match exactly.)
+     *
+     *  <p>Return null if text does not match.
+     */
+    static public Region find(final String text,
+                              final Node start, final Node within) {
+        if(start instanceof TextNode)
+            return findNext(text, (TextNode)start, 0, within);
+        return findNext(text,
+                        NeighbouringTextNode.next(start, within).textNode, 0,
+                        within);
+    }
+
+    /**
+     *  Return the next region after this Region and within the
+     *  specified Node that contains text, or null if no such region
+     *  exists. (Whitespace matches whitespace, any other characters
+     *  must match exactly.)
+     */
+    public Region findNext(final String text, final Node within) {
+        return getEnd().findNext(text, within);
+    }
+
+    /**
+     Test if this region is blank -- that is, empty or only whitespace (including newlines).
+     @return true if this region is empty or only whitespace, false if it contains any text content.
+     */
+
+    public boolean isBlank() {
+        return StringUtil.isBlank(getText());
+    }
+
+    /**
+     *  Removes whitespace from the edges of the Region, leaving the
+     *  document unchanged and the Region possibly shorter.
+     */
+
+    public Region trim() {
+        boolean progress = true;
+        String whole = start.getTextNode().getWholeText();
+        while(progress && !start.equals(end)) {
+            progress = false;
+            if(start.getOffset() >= whole.length()) {
+                start = start.rightBound();
+                whole = start.getTextNode().getWholeText();
+            }
+            if(!start.equals(end) &&
+               start.getOffset() < whole.length() &&
+               isWhitespace(whole.codePointAt(start.getOffset()))) {
+                progress = true;
+                start = new Point(start.getTextNode(), start.getOffset()+1);
+            }
+        }
+        progress = true;
+        whole = end.getTextNode().getWholeText();
+        while(progress && !start.equals(end)) {
+            progress = false;
+            if(end.getOffset() == 0) {
+                end = end.leftBound();
+                whole = end.getTextNode().getWholeText();
+            }
+            if(!start.equals(end) &&
+               end.getOffset() > 0 &&
+               isWhitespace(whole.codePointAt(end.getOffset()-1))) {
+                progress = true;
+                end = new Point(end.getTextNode(), end.getOffset()-1);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Region)) return false;
+
+        Region other = (Region)o;
+        return start == other.start && end == other.end;
+    }
+
+    @Override
+    public int hashCode() {
+        return start.hashCode() * 31 + end.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return getText();
+    }
+}

--- a/src/main/java/org/jsoup/text/Regions.java
+++ b/src/main/java/org/jsoup/text/Regions.java
@@ -1,0 +1,124 @@
+package org.jsoup.text;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+
+
+/**
+ *  A list of {@link Region}s, with function such as remove() and
+ *  wrap() that do the same as their {@link Region} equivalents.
+ *
+ *  This is essentially a convenience class in order to operate on
+ *  regions that straddle block elements.
+ */
+public class Regions extends ArrayList<Region> {
+
+    public Regions() {
+        super();
+    }
+
+
+    /**
+     *  Remove all these {@link Region}s from this Document.
+     */
+    public void remove() {
+        for(Node n : parents()) {
+            Node p = n.parentNode();
+            n.remove();
+        }
+    }
+
+
+    /**
+     *  Return a set of Nodes spanning all of these {@link Region}s,
+     *  and containing nothing else. This is not merely a list of
+     *  {@link Region#parents()}, it substitutes shared parents for
+     *  those siblings where possible. Because of that, the result may
+     *  not be a set of siblings.
+     */
+    public Set<Node> parents() {
+        Set<Node> result = new HashSet<Node>();
+        for(Region r : this)
+            result.addAll(r.parents());
+        boolean progress = true;
+        while(progress) {
+            progress = false;
+            Set<Node> parents = new HashSet<Node>();
+            for(Node n : result)
+                parents.add(n.parentNode());
+            parents.remove(null);
+            for(Node n : parents) {
+                if(!progress && result.containsAll(n.childNodes())) {
+                    result.removeAll(n.childNodes());
+                    result.add(n);
+                    progress = true;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     *  Wrap each of these {@link Region}s in the supplied html. If
+     *  two regions are adjacent, then two instances of the supplied
+     *  HTML will be, too.
+     */
+    public void wrap(final String html) {
+        for(Region r : this)
+            r.wrap(html);
+    }
+
+    /**
+     *  Split the Region into Regions such that each Region is entirely
+     *  within a single Element.
+     *
+     *  <p>This is useful if you want to, say, elide the region: You
+     *  can replace the first Region with an ellipsis and drop thee
+     *  remainder outright.
+     */
+
+    public Regions splitByElements() {
+        Regions result = new Regions();
+        for(Region r : this)
+            result.addAll(r.splitByElements());
+        return result;
+    }
+
+    /**
+     *  Split the Regions into Regions such that each Region is entirely
+     *  within a single Element.
+     *
+     *  <p>This is useful if you want to, say, wrap the region in
+     *  &lt;a href...&gt; or &lt;b&gt;.
+     */
+    public Regions splitByBlockElements() {
+        Regions result = new Regions();
+        for(Region r : this)
+            result.addAll(r.splitByBlockElements());
+        return result;
+    }
+
+    /**
+     *  Get the first Region.
+     *  @return The first Region, or <code>null</code> if contents is empty.
+     */
+    public Region first() {
+        return isEmpty() ? null : get(0);
+    }
+
+    /**
+     *  Get the last Region.
+     *  @return The last Region, or <code>null</code> if contents is empty.
+     */
+    public Region last() {
+        if(isEmpty())
+            return null;
+        return get(size()-1);
+    }
+}

--- a/src/main/java/org/jsoup/text/package-info.java
+++ b/src/main/java/org/jsoup/text/package-info.java
@@ -1,0 +1,6 @@
+/**
+ Classes to support text-oriented document operations: Point to point
+ to a particular place in the text, Region to mark a region between
+ two points, and Regions to bundle together zero or more Region objects.
+ */
+package org.jsoup.text;

--- a/src/test/java/org/jsoup/nodes/NodeTest.java
+++ b/src/test/java/org/jsoup/nodes/NodeTest.java
@@ -31,14 +31,14 @@ public class NodeTest {
 
         Element dodgyBase = new Element(tag, "wtf://no-such-protocol/", attribs);
         assertEquals("http://bar/qux", dodgyBase.absUrl("absHref")); // base fails, but href good, so get that
-        assertEquals("", dodgyBase.absUrl("relHref")); // base fails, only rel href, so return nothing 
+        assertEquals("", dodgyBase.absUrl("relHref")); // base fails, only rel href, so return nothing
     }
 
     @Test public void setBaseUriIsRecursive() {
         Document doc = Jsoup.parse("<div><p></p></div>");
         String baseUri = "https://jsoup.org";
         doc.setBaseUri(baseUri);
-        
+
         assertEquals(baseUri, doc.baseUri());
         assertEquals(baseUri, doc.select("div").first().baseUri());
         assertEquals(baseUri, doc.select("p").first().baseUri());
@@ -130,25 +130,25 @@ public class NodeTest {
         Element a1 = doc.select("a").first();
         assertEquals("http://example.com/one/two.html", a1.absUrl("href"));
     }
-    
+
     @Test public void testRemove() {
         Document doc = Jsoup.parse("<p>One <span>two</span> three</p>");
         Element p = doc.select("p").first();
         p.childNode(0).remove();
-        
+
         assertEquals("two three", p.text());
         assertEquals("<span>two</span> three", TextUtil.stripNewlines(p.html()));
     }
-    
+
     @Test public void testReplace() {
         Document doc = Jsoup.parse("<p>One <span>two</span> three</p>");
         Element p = doc.select("p").first();
         Element insert = doc.createElement("em").text("foo");
         p.childNode(1).replaceWith(insert);
-        
+
         assertEquals("One <em>foo</em> three", p.html());
     }
-    
+
     @Test public void ownerDocument() {
         Document doc = Jsoup.parse("<p>Hello");
         Element p = doc.select("p").first();
@@ -194,6 +194,9 @@ public class NodeTest {
 
         doc.select("b").first().after("<i>five</i>");
         assertEquals("<p>One <b>two</b><i>five</i><em>four</em> three</p>", doc.body().html());
+
+        doc.select("p").first().after("<p>six</p>");
+        assertEquals("<p>One <b>two</b><i>five</i><em>four</em> three</p>\n<p>six</p>", doc.body().html());
     }
 
     @Test public void unwrap() {
@@ -288,5 +291,51 @@ public class NodeTest {
         assertTrue(elClone.hasClass("foo"));
         assertTrue(el.text().equals("None"));
         assertTrue(elClone.text().equals("Text"));
+    }
+
+    @Test public void splits() {
+        Document doc =
+            org.jsoup.Jsoup.parse("<div><b>f</b><i>o</i><u>o</u></div>");
+        Element div = doc.select("div").first();
+        assertEquals(3, div.childNodeSize());
+        assertNull(div.nextSibling());
+        Element body = div.parent();
+        assertEquals(1, body.childNodeSize());
+
+        Element b = doc.select("b").first();
+        Element i = doc.select("i").first();
+        Element u = doc.select("u").first();
+
+        div.splitAfter(u);
+        assertEquals(1, body.childNodeSize());
+        assertEquals(body, div.parent());
+
+        div.splitAfter(body);
+        assertEquals(1, body.childNodeSize());
+        assertEquals(body, div.parent());
+
+        assertEquals(1, i.siblingIndex());
+
+        div.splitAfter(i);
+        assertEquals(2, div.childNodeSize());
+        assertEquals(div, b.parent());
+        assertEquals(div, i.parent());
+
+        Element udiv = div.nextElementSibling();
+        assertNotNull(udiv);
+        assertEquals(body, div.parent());
+        assertEquals(body, udiv.parent());
+        assertEquals(div, udiv.previousElementSibling());
+        assertEquals(2, body.childNodeSize());
+        assertEquals(1, udiv.childNodeSize());
+        assertEquals(u, udiv.child(0));
+        assertEquals(udiv, u.parent());
+
+        div.splitAfter(b);
+        assertEquals(1, div.childNodeSize());
+        assertEquals(3, body.childNodeSize());
+        assertEquals(div.nextElementSibling(), i.parent());
+        assertEquals(udiv.previousElementSibling(), i.parent());
+        assertEquals(body.child(1), i.parent());
     }
 }

--- a/src/test/java/org/jsoup/text/PointTest.java
+++ b/src/test/java/org/jsoup/text/PointTest.java
@@ -1,0 +1,119 @@
+package org.jsoup.text;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+import org.jsoup.parser.Parser;
+
+/**
+ *  Point tests.
+ */
+public class PointTest {
+    static public TextNode firstTextNode(Node node) {
+        for(Node child : node.childNodes()) {
+            if(child instanceof TextNode)
+                return (TextNode)child;
+            if(child.childNodeSize() > 0) {
+                TextNode result = firstTextNode(child);
+                if(result != null)
+                    return result;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    public void isBasicallySane() {
+        Document html = Parser.parseBodyFragment("<p>Three words here", "");
+        TextNode text = (TextNode)html.select("p").first().childNode(0);
+        Point p0 = new Point(text, 0);
+        Point p2 = new Point(text, 2);
+        Point p42 = new Point(text, 42);
+        Point p69 = new Point(text, 42);
+
+        assertTrue(p0.equals(p0));
+        assertFalse(p0.equals(p2));
+        assertFalse(p42.equals(p2));
+        assertTrue(p42.equals(p69));
+
+        assertEquals(text, p0.getTextNode());
+        assertEquals(2, p2.getOffset());
+    }
+
+    @Test
+    public void testLeftAndRightBoundness() {
+        Document html = Parser.parseBodyFragment("<p>One<b>two</b></p>", "");
+        Element p = html.select("p").first();
+        Element b = html.select("b").first();
+
+        Point left = new Point((TextNode)p.childNode(0), 3);
+        Point right = new Point((TextNode)b.childNode(0), 0);
+        assertTrue(right == right.rightBound());
+        assertTrue(left == left.leftBound());
+        assertEquals("two", right.getTextNode().text());
+        assertEquals(3, right.leftBound().getOffset());
+        assertEquals(left, right.leftBound());
+        assertEquals(right, left.rightBound());
+        assertEquals(right, right.leftBound().rightBound());
+
+        Point start = new Point((TextNode)p.childNode(0), 0);
+        Point end = new Point((TextNode)b.childNode(0), 3);
+        assertTrue(start == start.leftBound());
+        assertTrue(start == start.rightBound());
+        assertTrue(end == end.leftBound());
+        assertTrue(end == end.rightBound());
+    }
+
+    @Test
+    public void splits() {
+        Document html = Parser.parseBodyFragment("<p>a<b>c</b>", "");
+        Element p = html.select("p").first();
+        (new Point(firstTextNode(p), 1)).splitAfterUpTo(p.parentNode());
+        assertEquals("<p>a</p>", p.outerHtml());
+    }
+
+    // This needs a several-paragraph test; the first four paragraphs of
+    // http://www.nybooks.com/articles/2014/10/23/find-your-beach/ will do.
+
+    static private String LONG_DOCUMENT =
+        "<p>Across the way from our apartment—on Houston, I guess—there’s a new wall ad. The site is forty feet high, twenty feet wide. It changes once or twice a year. Whatever’s on that wall is my view: I look at it more than the sky or the new World Trade Center, more than the water towers, the passing cabs. It has a subliminal effect. Last semester it was a spot for high-end vodka, and while I wrangled children into their snowsuits, chock-full of domestic resentment, I’d find myself dreaming of cold martinis.\n" +
+        "<p>Before that came an ad so high-end I couldn’t tell what it was for. There was no text—or none that I could see—and the visual was of a yellow firebird set upon a background of hellish red. It seemed a gnomic message, deliberately placed to drive a sleepless woman mad. Once, staring at it with a newborn in my arms, I saw another mother, in the tower opposite, holding her baby. It was 4 AM. We stood there at our respective windows, separated by a hundred feet of expensive New York air.\n"+
+        "<p>The tower I live in is university accommodation; so is the tower opposite. The idea occurred that it was quite likely that the woman at the window also wrote books for a living, and, like me, was not writing anything right now. Maybe she was considering antidepressants. Maybe she was already on them. It was hard to tell. Certainly she had no way of viewing the ad in question, not without opening her window, jumping, and turning as she fell. I was her view. I was the ad for what she already had.\n"+
+        "<p>But that was all some time ago. Now the ad says: <i>Find your beach.</i> The bottle of beer—it’s an ad for beer—is very yellow and the background luxury-holiday-blue. It seems to me uniquely well placed, like a piece of commissioned public art in perfect sympathy with its urban site. The tone is pure Manhattan. Echoes can be found in the personal growth section of the bookstore (“Find your happy”), and in exercise classes (“Find your soul”), and in the therapist’s office (“Find your self”). I find it significant that there exists a more expansive, national version of this ad that runs in magazines, and on television.\n";
+
+    @Test
+    public void findsNeighbouringText() {
+        Document html = Parser.parseBodyFragment(LONG_DOCUMENT, "");
+        Region beach = html.find("Find your beach").first();
+        Region justbefore = beach.getStart().precedingRegion(32);
+        assertEquals("some time ago. Now the ad says:", justbefore.getText());
+        Region furtherbefore = justbefore.getStart().precedingRegion(30);
+        assertEquals("already had. But that was all",
+                     furtherbefore.getText());
+        Region beginning =
+            furtherbefore.getStart().precedingRegion(LONG_DOCUMENT.length());
+        assertTrue(beginning.getText().startsWith("Across the way from"));
+        assertTrue(beginning.getText().endsWith("what she"));
+
+        assertEquals(justbefore.getText(),
+                     furtherbefore.getEnd().followingRegion(32).getText());
+    }
+
+    @Test
+    public void findsParagraphLimits() {
+        Document html = Parser.parseBodyFragment(LONG_DOCUMENT, "");
+        Region beach = html.find("beach").first();
+        assertEquals("Find your beach.",
+                     new Region(beach.getStart().atStartOfElement(),
+                                beach.getEnd().atEndOfElement()).getText());
+        Region paragraph = new Region(beach.getStart().atStartOfBlock(),
+                                      beach.getEnd().atEndOfBlock());
+        assertTrue(paragraph.getText().startsWith("But that was all") &&
+                   paragraph.getText().endsWith("and on television."));
+    }
+}

--- a/src/test/java/org/jsoup/text/RegionTest.java
+++ b/src/test/java/org/jsoup/text/RegionTest.java
@@ -1,0 +1,247 @@
+package org.jsoup.text;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.jsoup.Jsoup;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+import org.jsoup.parser.Parser;
+
+/**
+ *  Region tests.
+ */
+public class RegionTest {
+    @Test
+    public void findsSimpleRegion() {
+        Document html = Jsoup.parse("<p>Three words here");
+        Region words = html.find("words").first();
+        assertNotNull(words);
+        assertEquals("words", words.getStart().getTextNode().getWholeText());
+    }
+
+    @Test
+    public void findsParagraphSpanningRegion() {
+        Document html = Jsoup.parse("<p>Four words<p>about love.");
+        Region words = html.find("words about").first();
+        assertNotNull(words);
+        assertEquals("words", words.getStart().getTextNode().text());
+        assertEquals("about", words.getEnd().getTextNode().text());
+        assertEquals("words about", words.getText());
+    }
+
+    @Test
+    public void findsBrSpanningRegion() {
+        Document html = Jsoup.parse("<p>Four words<br>about love.");
+        Region words = html.find("words about").first();
+        assertNotNull(words);
+        assertEquals("words", words.getStart().getTextNode().text());
+        assertEquals("about", words.getEnd().getTextNode().text());
+        assertEquals("words about", words.getText());
+        // and for bonus harshness, try it on a Document with fewer
+        // spaces than what Jsoup.parse() produces.
+        for(Element p : html.select("p"))
+            for(TextNode t : p.textNodes())
+                t.text(t.text());
+        for(Element p : html.select("br"))
+            for(TextNode t : p.textNodes())
+                t.text(t.text());
+        assertEquals(1, html.find("words about").size());
+    }
+
+    @Test
+    public void findsPartlyBoldText() {
+        Document html = Jsoup.parse("<p>Four partly em<b>bold</b>ened words.");
+        Region words = html.find("emboldened").first();
+        assertNotNull(words);
+        assertEquals("em", words.getStart().getTextNode().text());
+        assertEquals("ened", words.getEnd().getTextNode().text());
+        assertEquals("emboldened", words.getText());
+
+        assertEquals(0, html.find("em bold").size());
+    }
+
+    @Test
+    public void findsProSHyCessShyedWords() {
+        Document html = Jsoup.parse("<p>Cleverly pro&shy;cess&shy;ed text here");
+        Region processed = html.find("processed").first();
+        assertEquals("pro\u00ADcess\u00ADed", processed.getText());
+    }
+
+
+    @Test
+    public void splitsAtElementBoundary() {
+        Document html = Jsoup.parse("<p>Four partly em<b>bold</b>ened words.");
+        Region words = html.find("emboldened").first();
+        assertNotNull(words);
+        Regions parts = words.splitByElements();
+        assertEquals(3, parts.size());
+        assertEquals("em", parts.first().getText());
+        assertEquals("bold", parts.get(1).getText());
+        assertEquals("ened", parts.get(2).getText());
+    }
+
+    @Test
+    public void handlesEmptyRegion() {
+        Document html = Jsoup.parse("<p>Four partly em<b>bold</b>ened words.");
+        Region emboldened = html.find("emboldened").first();
+        assertNotNull(emboldened);
+        Region empty = new Region(emboldened.getStart(), emboldened.getStart());
+        assertEquals(0, empty.splitByElements().size());
+        assertEquals(0, empty.splitByBlockElements().size());
+        empty.trim();
+        assertEquals(emboldened.getStart(), empty.getStart());
+        assertEquals(emboldened.getStart(), empty.getEnd());
+        assertEquals("", empty.getText());
+
+        Region dot = html.find(".").first();
+        // next assertion breaks if the region doesn't end at the end
+        // of the document
+        assertEquals(dot.getEnd(), dot.getEnd().rightBound());
+        empty = new Region(dot.getEnd(), dot.getEnd());
+        assertEquals(0, empty.splitByElements().size());
+        assertEquals(0, empty.splitByBlockElements().size());
+        empty.trim();
+        assertEquals(empty.getEnd(), empty.getStart());
+        assertEquals("", empty.getText());
+    }
+
+    @Test
+    public void entireElementRegions() {
+        Document html = Jsoup.parse("<p><i>Partly em<b>bold</b></i>ened blah.");
+        Element i = html.select("i").first();
+        assertEquals("Partly embold", new Region(i).getText());
+        assertEquals("bold", new Region(html.select("b").first()).getText());
+        i.after("<div><img></div>");
+        Region div = new Region(html.select("div").first());
+        assertEquals("", div.getText());
+        assertNotEquals(0, html.select("div").first().textNodes().size());
+    }
+
+    @Test
+    public void splitsTextNodes() {
+        Document html = Jsoup.parse("<p>Four partly em<b>bold</b>ened words.");
+        Element p = html.select("p").first();
+
+        Region emboldened = html.find("emboldened").first();
+        emboldened.splitTextNodes();
+        assertEquals("emboldened", emboldened.getText());
+        assertEquals("<p>Four partly em<b>bold</b>ened words.</p>",
+                     p.outerHtml());
+
+        Region four = html.find("Four").first();
+        four.splitTextNodes();
+        assertEquals("Four", four.getText());
+        assertEquals("<p>Four partly em<b>bold</b>ened words.</p>",
+                     p.outerHtml());
+
+        Region partly = html.find("partly").first();
+        assertEquals("partly", partly.getText());
+        assertEquals("<p>Four partly em<b>bold</b>ened words.</p>",
+                     p.outerHtml());
+
+        Region old = html.find("old").first();
+        old.splitTextNodes();
+        assertEquals("old", old.getText());
+        assertEquals("<p>Four partly em<b>bold</b>ened words.</p>",
+                     p.outerHtml());
+    }
+
+
+    @Test
+    public void findsExternalParent() {
+        Document html = Jsoup.parse("<p>Three <i>for<b>matte</b>d</i> words.");
+        Element p = html.select("p").first();
+        Element i = html.select("i").first();
+        assertEquals(p, p.find("Three").first().parentElement());
+        assertEquals(i, p.find("matte").first().parentElement());
+        assertEquals(i, p.find("ormatted").first().parentElement());
+        assertEquals(p, p.find("formatted").first().parentElement());
+    }
+
+
+    @Test
+    public void splitsSpans() {
+        Document html = Jsoup.parse("<p>Four partly em<b>bold</b>ened words.");
+        Element p = html.select("p").first();
+        p.find("olden").first().ensureRemovability();
+        assertEquals("<p>Four partly em<b>b</b><b>old</b>ened words.</p>",
+                     html.select("p").first().outerHtml());
+
+        p.find("old").first().ensureRemovability();
+        assertEquals("<p>Four partly em<b>b</b><b>old</b>ened words.</p>",
+                     p.outerHtml());
+
+        Region partly = p.find("partly").first();
+        partly.ensureRemovability();
+        assertEquals("partly", partly.getStart().getTextNode().text());
+        assertEquals("<p>Four partly em<b>b</b><b>old</b>ened words.</p>",
+                     p.outerHtml());
+    }
+
+    @Test
+    public void removesMinimally() {
+        Document html = Jsoup.parse("<p>Four partly em<b>bold</b>ened words.");
+        Element p = html.select("p").first();
+        Region partly = p.find("partly").first();
+        assertEquals(p, partly.parentElement());
+        assertEquals(1, partly.parents().size());
+        assertEquals("partly", partly.parents().get(0).toString());
+        partly.remove();
+        assertEquals("<p>Four  em<b>bold</b>ened words.</p>",
+                     p.outerHtml());
+
+        p.find("bold").remove();
+        assertEquals("<p>Four  emened words.</p>",
+                     p.outerHtml());
+    }
+
+    @Test
+    public void wraps() {
+        Document html = Jsoup.parse("<p>Partly em<b>bold</b>ened words.");
+        Element p = html.select("p").first();
+        p.find("Partly").first().wrap("<i>");
+        assertEquals("<p><i>Partly</i> em<b>bold</b>ened words.</p>",
+                     p.outerHtml());
+        p.find("olden").first().wrap("<i>");
+        assertEquals("<p><i>Partly</i> em<b>b</b><i><b>old</b>en</i>ed words.</p>",
+                     p.outerHtml());
+    }
+
+    @Test
+    public void trims() {
+        Document html = Jsoup.parse("<p>Some partly <b>bold</b> words about life.");
+        Element p = html.select("p").first();
+        Region all = p.find("partly bold words").first();
+        Region bold = p.find("bold").first();
+        Region prelude = new Region(all.getStart(), bold.getStart());
+        Region postlude = new Region(bold.getEnd(), all.getEnd());
+        assertEquals("partly bold words", all.getText());
+        assertEquals("partly", prelude.getText());
+        assertEquals("words", postlude.getText());
+        prelude.trim();
+        assertEquals("partly", prelude.getText());
+        postlude.trim();
+        assertEquals("words", postlude.getText());
+        assertEquals("partly bold words", all.getText());
+
+        html = Jsoup.parse("<p>one <p>two");
+        all = html.find("one two").first();
+        assertNotNull(all);
+        Region one = html.find("one").first();
+        assertNotNull(one);
+        Region rest = new Region(one.getEnd(), all.getEnd());
+        assertEquals("two", rest.getText());
+        rest.getStart().getTextNode().text("\n\n");
+        assertEquals("two", rest.getText());
+        rest.trim();
+        assertEquals("two", rest.getText());
+        rest.getEnd().getTextNode().text("2\n\n");
+        rest.trim();
+        assertEquals("2", rest.getText());
+    }
+}

--- a/src/test/java/org/jsoup/text/RegionsTest.java
+++ b/src/test/java/org/jsoup/text/RegionsTest.java
@@ -1,0 +1,52 @@
+package org.jsoup.text;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.jsoup.Jsoup;
+import org.jsoup.TextUtil;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+
+import org.jsoup.parser.Parser;
+
+
+/**
+ *  Regions tests.
+ */
+public class RegionsTest {
+    @Test
+    public void removesMinimally() {
+        Document html = Jsoup.parse("<p>word blah <b>word</b> blah word");
+        Element p = html.select("p").first();
+        p.find("word").remove();
+        assertEquals("<p> blah  blah </p>", p.outerHtml());
+
+        html = Jsoup.parse("<div><p>word <b>word</b><p><b>blah word");
+        Element div = html.select("div").first();
+        div.find("word blah").remove();
+        assertEquals("<div><p>word </p><p><b> word</b></p></div>",
+                     TextUtil.stripNewlines(div.outerHtml()));
+
+        html = Jsoup.parse("<p>wo<span>rdwordwo</span>rd</p>");
+        p = html.select("p").first();
+        Regions words = p.find("rdwo");
+        assertEquals(2, words.size());
+        assertEquals(0, words.get(0).getStart().getTextNode().siblingIndex());
+        assertEquals(1, words.get(1).getStart().getTextNode().siblingIndex());
+        words.remove();
+        assertEquals("word", p.html());
+    }
+
+    @Test
+    public void wraps() {
+        Document html = Jsoup.parse("<p>Partly em<b>bold</b>ened words.");
+        Element p = html.select("p").first();
+        p.find("olden").first().splitByElements().wrap("<i>");
+        assertEquals("<p>Partly em<b>b<i>old</i></b><i>en</i>ed words.</p>",
+                     p.outerHtml());
+    }
+}


### PR DESCRIPTION
The new cookbook entries would be along the lines of.

To make all instances of the word jsoup into a link:
```
    html.find("jsoup").splitByBlockElements().wrap("<a href=http://www.jsoup.org>");
```

To make sure a particular string is a block element and has a particular class:
```
    html.find(foo.bar()).wrap("<div class=particular>);
```

I was a little uncertain how to name the getters. Much of jsoup uses foo(), but e.g. TextNode.getWholeText() uses getFoo(), like the more modern parts of the java standard library. I picked e.g. Point.getOffset() now, but I'll be happy to change to offset() if you prefer that.