### PR TITLE
Try harder to get charset from meta elements

### DIFF
--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -4,6 +4,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.XmlDeclaration;
 import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -101,16 +102,20 @@ public final class DataUtil {
             // look for <meta http-equiv="Content-Type" content="text/html;charset=gb2312"> or HTML5 <meta charset="gb2312">
             docData = Charset.forName(defaultCharset).decode(byteData).toString();
             doc = parser.parseInput(docData, baseUri);
-            Element meta = doc.select("meta[http-equiv=content-type], meta[charset]").first();
+            Elements metaElements = doc.select("meta[http-equiv=content-type], meta[charset]");
             String foundCharset = null; // if not found, will keep utf-8 as best attempt
-            if (meta != null) {
+            for (Element meta : metaElements) {
                 if (meta.hasAttr("http-equiv")) {
                     foundCharset = getCharsetFromContentType(meta.attr("content"));
                 }
                 if (foundCharset == null && meta.hasAttr("charset")) {
                     foundCharset = meta.attr("charset");
                 }
+                if (foundCharset != null) {
+                    break;
+                }
             }
+
             // look for <?xml encoding='ISO-8859-1'?>
             if (foundCharset == null && doc.childNodeSize() > 0 && doc.childNode(0) instanceof XmlDeclaration) {
                 XmlDeclaration prolog = (XmlDeclaration) doc.childNode(0);

--- a/src/test/java/org/jsoup/helper/DataUtilTest.java
+++ b/src/test/java/org/jsoup/helper/DataUtilTest.java
@@ -114,6 +114,18 @@ public class DataUtilTest {
     }
 
     @Test
+    public void firstMetaElementWithCharsetShouldBeUsedForDecoding() throws Exception {
+        ByteBuffer inBuffer = ByteBuffer.wrap(("<html><head>" +
+                "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=iso-8859-1\">" +
+                "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=koi8-u\">" +
+                "</head><body>Übergrößenträger</body></html>").getBytes("iso-8859-1"));
+
+        Document doc = DataUtil.parseByteData(inBuffer, null, "http://example.com", Parser.htmlParser());
+
+        assertEquals("Übergrößenträger", doc.body().text());
+    }
+
+    @Test
     public void supportsBOMinFiles() throws IOException {
         // test files from http://www.i18nl10n.com/korean/utftest/
         File in = getFile("/bomtests/bom_utf16be.html");

--- a/src/test/java/org/jsoup/helper/DataUtilTest.java
+++ b/src/test/java/org/jsoup/helper/DataUtilTest.java
@@ -102,6 +102,18 @@ public class DataUtilTest {
     }
 
     @Test
+    public void secondMetaElementWithContentTypeContainsCharsetParameter() throws Exception {
+        ByteBuffer inBuffer = ByteBuffer.wrap(("<html><head>" +
+                "<meta http-equiv=\"Content-Type\" content=\"text/html\">" +
+                "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=euc-kr\">" +
+                "</head><body>한국어</body></html>").getBytes("euc-kr"));
+
+        Document doc = DataUtil.parseByteData(inBuffer, null, "http://example.com", Parser.htmlParser());
+
+        assertEquals("한국어", doc.body().text());
+    }
+
+    @Test
     public void supportsBOMinFiles() throws IOException {
         // test files from http://www.i18nl10n.com/korean/utftest/
         File in = getFile("/bomtests/bom_utf16be.html");


### PR DESCRIPTION
Current state:
When attempting to retrieve the charset only the first meta element with content type information will be looked at. No further meta elements are considered even when the first one doesn't contain a charset parameter. See `DataUtilTest.secondMetaElementWithContentTypeContainsCharsetParameter()`.

With this fix:
All meta elements are looked at until a charset is found, i.e. the first viable one is used.

Fixes #834 