### PR TITLE
add test case for hashcode in attribute

### DIFF
--- a/src/test/java/org/jsoup/nodes/AttributeTest.java
+++ b/src/test/java/org/jsoup/nodes/AttributeTest.java
@@ -17,4 +17,11 @@ public class AttributeTest {
         assertEquals(s + "=\"A" + s + "B\"", attr.html());
         assertEquals(attr.html(), attr.toString());
     }
+
+    @Test
+    public void testHashCode() {
+        String s = new String(Character.toChars(135361));
+        Attribute attr = new Attribute(s, (("A" + s) + "B"));
+        assertEquals(111849895, attr.hashCode());
+    }
 }


### PR DESCRIPTION
Hello,

I propose this changes to specify the [hashCode](https://github.com/jhy/jsoup/blob/master/src/main/java/org/jsoup/nodes/Attribute.java#L152) of the object `org.jsoup.nodes.Attribute`.