### PR TITLE
Improved node traversal (including skipping of subtrees, filtering)

### DIFF
--- a/src/main/java/org/jsoup/examples/HtmlToPlainText.java
+++ b/src/main/java/org/jsoup/examples/HtmlToPlainText.java
@@ -60,8 +60,7 @@ public class HtmlToPlainText {
      */
     public String getPlainText(Element element) {
         FormattingVisitor formatter = new FormattingVisitor();
-        NodeTraversor traversor = new NodeTraversor(formatter);
-        traversor.traverse(element); // walk the DOM, and call .head() and .tail() for each node
+        NodeTraversor.traverse(formatter, element); // walk the DOM, and call .head() and .tail() for each node
 
         return formatter.toString();
     }

--- a/src/main/java/org/jsoup/helper/W3CDom.java
+++ b/src/main/java/org/jsoup/helper/W3CDom.java
@@ -59,8 +59,7 @@ public class W3CDom {
             out.setDocumentURI(in.location());
 
         org.jsoup.nodes.Element rootEl = in.child(0); // skip the #root node
-        NodeTraversor traversor = new NodeTraversor(new W3CBuilder(out));
-        traversor.traverse(rootEl);
+        NodeTraversor.traverse(new W3CBuilder(out), rootEl);
     }
 
     /**

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -917,7 +917,7 @@ public class Element extends Node {
      */
     public String text() {
         final StringBuilder accum = new StringBuilder();
-        new NodeTraversor(new NodeVisitor() {
+        NodeTraversor.traverse(new NodeVisitor() {
             public void head(Node node, int depth) {
                 if (node instanceof TextNode) {
                     TextNode textNode = (TextNode) node;
@@ -933,7 +933,7 @@ public class Element extends Node {
 
             public void tail(Node node, int depth) {
             }
-        }).traverse(this);
+        }, this);
         return accum.toString().trim();
     }
 

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -540,8 +540,7 @@ public abstract class Node implements Cloneable {
      */
     public Node traverse(NodeVisitor nodeVisitor) {
         Validate.notNull(nodeVisitor);
-        NodeTraversor traversor = new NodeTraversor(nodeVisitor);
-        traversor.traverse(this);
+        NodeTraversor.traverse(nodeVisitor, this);
         return this;
     }
 
@@ -556,7 +555,7 @@ public abstract class Node implements Cloneable {
     }
 
     protected void outerHtml(Appendable accum) {
-        new NodeTraversor(new OuterHtmlVisitor(accum, getOutputSettings())).traverse(this);
+        NodeTraversor.traverse(new OuterHtmlVisitor(accum, getOutputSettings()), this);
     }
 
     // if this node has no document (or parent), retrieve the default output settings

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -4,6 +4,7 @@ import org.jsoup.SerializationException;
 import org.jsoup.helper.StringUtil;
 import org.jsoup.helper.Validate;
 import org.jsoup.parser.Parser;
+import org.jsoup.select.NodeFilter;
 import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
 
@@ -541,6 +542,17 @@ public abstract class Node implements Cloneable {
     public Node traverse(NodeVisitor nodeVisitor) {
         Validate.notNull(nodeVisitor);
         NodeTraversor.traverse(nodeVisitor, this);
+        return this;
+    }
+
+    /**
+     * Perform a depth-first filtering through this node and its descendants.
+     * @param nodeFilter the filter callbacks to perform on each node
+     * @return this node, for chaining
+     */
+    public Node filter(NodeFilter nodeFilter) {
+        Validate.notNull(nodeFilter);
+        NodeTraversor.filter(nodeFilter, this);
         return this;
     }
 

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -139,8 +139,7 @@ public class Cleaner {
 
     private int copySafeNodes(Element source, Element dest) {
         CleaningVisitor cleaningVisitor = new CleaningVisitor(source, dest);
-        NodeTraversor traversor = new NodeTraversor(cleaningVisitor);
-        traversor.traverse(source);
+        NodeTraversor.traverse(cleaningVisitor, source);
         return cleaningVisitor.numDiscarded;
     }
 

--- a/src/main/java/org/jsoup/select/Collector.java
+++ b/src/main/java/org/jsoup/select/Collector.java
@@ -21,7 +21,7 @@ public class Collector {
      */
     public static Elements collect (Evaluator eval, Element root) {
         Elements elements = new Elements();
-        new NodeTraversor(new Accumulator(root, elements, eval)).traverse(root);
+        NodeTraversor.traverse(new Accumulator(root, elements, eval), root);
         return elements;
     }
 

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -607,11 +607,7 @@ public class Elements extends ArrayList<Element> {
      * @return this, for chaining
      */
     public Elements traverse(NodeVisitor nodeVisitor) {
-        Validate.notNull(nodeVisitor);
-        NodeTraversor traversor = new NodeTraversor(nodeVisitor);
-        for (Element el: this) {
-            traversor.traverse(el);
-        }
+        NodeTraversor.traverse(nodeVisitor, this);
         return this;
     }
 

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -612,6 +612,16 @@ public class Elements extends ArrayList<Element> {
     }
 
     /**
+     * Perform a depth-first filtering on each of the selected elements.
+     * @param nodeFilter the filter callbacks to perform on each node
+     * @return this, for chaining
+     */
+    public Elements filter(NodeFilter nodeFilter) {
+        NodeTraversor.filter(nodeFilter, this);
+        return this;
+    }
+
+    /**
      * Get the {@link FormElement} forms from the selected elements, if any.
      * @return a list of {@link FormElement}s pulled from the matched elements. The list will be empty if the elements contain
      * no forms.

--- a/src/main/java/org/jsoup/select/NodeFilter.java
+++ b/src/main/java/org/jsoup/select/NodeFilter.java
@@ -1,0 +1,58 @@
+package org.jsoup.select;
+
+import org.jsoup.nodes.Node;
+
+/**
+ * Node filter interface. Provide an implementing class to {@link NodeTraversor} to iterate through nodes.
+ * <p>
+ * This interface provides two methods, {@code head} and {@code tail}. The head method is called when the node is first
+ * seen, and the tail method when all of the node's children have been visited. As an example, head can be used to
+ * create a start tag for a node, and tail to create the end tag.
+ * </p>
+ * <p>
+ * For every node, the filter has to decide whether to
+ * <ul>
+ * <li>continue ({@link FilterResult#CONTINUE}),</li>
+ * <li>skip all children ({@link FilterResult#SKIP_CHILDREN}),</li>
+ * <li>skip node entirely ({@link FilterResult#SKIP_ENTIRELY}),</li>
+ * <li>remove the subtree ({@link FilterResult#REMOVE}),</li>
+ * <li>interrupt the iteration and return ({@link FilterResult#STOP}).</li>
+ * </ul>
+ * The difference between {@link FilterResult#SKIP_CHILDREN} and {@link FilterResult#SKIP_ENTIRELY} is that the first
+ * will invoke {@link NodeFilter#tail(Node, int)} on the node, while the latter will not.
+ * Within {@link NodeFilter#tail(Node, int)}, both are equivalent to {@link FilterResult#CONTINUE}.
+ * </p>
+ */
+public interface NodeFilter {
+    /**
+     * Filter decision.
+     */
+    public enum FilterResult {
+        /** Continue processing the tree */
+        CONTINUE,
+        /** Skip the child nodes, but do call {@link NodeFilter#tail(Node, int)} next. */
+        SKIP_CHILDREN,
+        /** Skip the subtree, and do not call {@link NodeFilter#tail(Node, int)}. */
+        SKIP_ENTIRELY,
+        /** Remove the node and its children */
+        REMOVE,
+        /** Stop processing */
+        STOP
+    }
+
+    /**
+     * Callback for when a node is first visited.
+     * @param node the node being visited.
+     * @param depth the depth of the node, relative to the root node. E.g., the root node has depth 0, and a child node of that will have depth 1.
+     * @return Filter decision
+     */
+    FilterResult head(Node node, int depth);
+
+    /**
+     * Callback for when a node is last visited, after all of its descendants have been visited.
+     * @param node the node being visited.
+     * @param depth the depth of the node, relative to the root node. E.g., the root node has depth 0, and a child node of that will have depth 1.
+     * @return Filter decision
+     */
+    FilterResult tail(Node node, int depth);
+}

--- a/src/main/java/org/jsoup/select/NodeTraversor.java
+++ b/src/main/java/org/jsoup/select/NodeTraversor.java
@@ -1,6 +1,9 @@
 package org.jsoup.select;
 
+import org.jsoup.helper.Validate;
+import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
+import org.jsoup.select.NodeFilter.FilterResult;
 
 /**
  * Depth-first node traversor. Use to iterate through all nodes under and including the specified root node.
@@ -65,5 +68,70 @@ public class NodeTraversor {
         Validate.notNull(elements);
         for (Element el : elements)
             traverse(visitor, el);
+    }
+
+    /**
+     * Start a depth-first filtering of the root and all of its descendants.
+     * @param filter Node visitor.
+     * @param root the root node point to traverse.
+     * @return The filter result of the root node, or {@link FilterResult#STOP}.
+     */
+    public static FilterResult filter(NodeFilter filter, Node root) {
+        Node node = root;
+        int depth = 0;
+
+        while (node != null) {
+            FilterResult result = filter.head(node, depth);
+            if (result == FilterResult.STOP)
+                return result;
+            // Descend into child nodes:
+            if (result == FilterResult.CONTINUE && node.childNodeSize() > 0) {
+                node = node.childNode(0);
+                ++depth;
+                continue;
+            }
+            // No siblings, move upwards:
+            while (node.nextSibling() == null && depth > 0) {
+                // 'tail' current node:
+                if (result == FilterResult.CONTINUE || result == FilterResult.SKIP_CHILDREN) {
+                    result = filter.tail(node, depth);
+                    if (result == FilterResult.STOP)
+                        return result;
+                }
+                Node prev = node; // In case we need to remove it below.
+                node = node.parentNode();
+                depth--;
+                if (result == FilterResult.REMOVE)
+                    prev.remove(); // Remove AFTER finding parent.
+                result = FilterResult.CONTINUE; // Parent was not pruned.
+            }
+            // 'tail' current node, then proceed with siblings:
+            if (result == FilterResult.CONTINUE || result == FilterResult.SKIP_CHILDREN) {
+                result = filter.tail(node, depth);
+                if (result == FilterResult.STOP)
+                    return result;
+            }
+            if (node == root)
+                return result;
+            Node prev = node; // In case we need to remove it below.
+            node = node.nextSibling();
+            if (result == FilterResult.REMOVE)
+                prev.remove(); // Remove AFTER finding sibling.
+        }
+        // root == null?
+        return FilterResult.CONTINUE;
+    }
+
+    /**
+     * Start a depth-first filtering of all elements.
+     * @param filter Node filter.
+     * @param elements Elements to filter.
+     */
+    public static void filter(NodeFilter filter, Elements elements) {
+        Validate.notNull(filter);
+        Validate.notNull(elements);
+        for (Element el : elements)
+            if (filter(filter, el) == FilterResult.STOP)
+                break;
     }
 }

--- a/src/main/java/org/jsoup/select/NodeTraversor.java
+++ b/src/main/java/org/jsoup/select/NodeTraversor.java
@@ -24,6 +24,15 @@ public class NodeTraversor {
      * @param root the root node point to traverse.
      */
     public void traverse(Node root) {
+        traverse(visitor, root);
+    }
+
+    /**
+     * Start a depth-first traverse of the root and all of its descendants.
+     * @param visitor Node visitor.
+     * @param root the root node point to traverse.
+     */
+    public static void traverse(NodeVisitor visitor, Node root) {
         Node node = root;
         int depth = 0;
         

--- a/src/main/java/org/jsoup/select/NodeTraversor.java
+++ b/src/main/java/org/jsoup/select/NodeTraversor.java
@@ -54,4 +54,16 @@ public class NodeTraversor {
             }
         }
     }
+
+    /**
+     * Start a depth-first traverse of all elements.
+     * @param visitor Node visitor.
+     * @param elements Elements to filter.
+     */
+    public static void traverse(NodeVisitor visitor, Elements elements) {
+        Validate.notNull(visitor);
+        Validate.notNull(elements);
+        for (Element el : elements)
+            traverse(visitor, el);
+    }
 }

--- a/src/test/java/org/jsoup/select/TraversorTest.java
+++ b/src/test/java/org/jsoup/select/TraversorTest.java
@@ -1,0 +1,107 @@
+package org.jsoup.select;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Node;
+import org.junit.Test;
+
+public class TraversorTest {
+    // Note: NodeTraversor.traverse(new NodeVisitor) is tested in
+    // ElementsTest#traverse()
+
+    @Test
+    public void filterVisit() {
+        Document doc = Jsoup.parse("<div><p>Hello</p></div><div>There</div>");
+        final StringBuilder accum = new StringBuilder();
+        NodeTraversor.filter(new NodeFilter() {
+            public FilterResult head(Node node, int depth) {
+                accum.append("<" + node.nodeName() + ">");
+                return FilterResult.CONTINUE;
+            }
+
+            public FilterResult tail(Node node, int depth) {
+                accum.append("</" + node.nodeName() + ">");
+                return FilterResult.CONTINUE;
+            }
+        }, doc.select("div"));
+        assertEquals("<div><p><#text></#text></p></div><div><#text></#text></div>", accum.toString());
+    }
+
+    @Test
+    public void filterSkipChildren() {
+        Document doc = Jsoup.parse("<div><p>Hello</p></div><div>There</div>");
+        final StringBuilder accum = new StringBuilder();
+        NodeTraversor.filter(new NodeFilter() {
+            public FilterResult head(Node node, int depth) {
+                accum.append("<" + node.nodeName() + ">");
+                // OMIT contents of p:
+                return ("p".equals(node.nodeName())) ? FilterResult.SKIP_CHILDREN : FilterResult.CONTINUE;
+            }
+
+            public FilterResult tail(Node node, int depth) {
+                accum.append("</" + node.nodeName() + ">");
+                return FilterResult.CONTINUE;
+            }
+        }, doc.select("div"));
+        assertEquals("<div><p></p></div><div><#text></#text></div>", accum.toString());
+    }
+
+    @Test
+    public void filterSkipEntirely() {
+        Document doc = Jsoup.parse("<div><p>Hello</p></div><div>There</div>");
+        final StringBuilder accum = new StringBuilder();
+        NodeTraversor.filter(new NodeFilter() {
+            public FilterResult head(Node node, int depth) {
+                // OMIT p:
+                if ("p".equals(node.nodeName()))
+                    return FilterResult.SKIP_ENTIRELY;
+                accum.append("<" + node.nodeName() + ">");
+                return FilterResult.CONTINUE;
+            }
+
+            public FilterResult tail(Node node, int depth) {
+                accum.append("</" + node.nodeName() + ">");
+                return FilterResult.CONTINUE;
+            }
+        }, doc.select("div"));
+        assertEquals("<div></div><div><#text></#text></div>", accum.toString());
+    }
+
+    @Test
+    public void filterRemove() {
+        Document doc = Jsoup.parse("<div><p>Hello</p></div><div>There be <b>bold</b></div>");
+        NodeTraversor.filter(new NodeFilter() {
+            public FilterResult head(Node node, int depth) {
+                // Delete "p" in head:
+                return ("p".equals(node.nodeName())) ? FilterResult.REMOVE : FilterResult.CONTINUE;
+            }
+
+            public FilterResult tail(Node node, int depth) {
+                // Delete "b" in tail:
+                return ("b".equals(node.nodeName())) ? FilterResult.REMOVE : FilterResult.CONTINUE;
+            }
+        }, doc.select("div"));
+        assertEquals("<div></div>\n<div>\n There be \n</div>", doc.select("body").html());
+    }
+
+    @Test
+    public void filterStop() {
+        Document doc = Jsoup.parse("<div><p>Hello</p></div><div>There</div>");
+        final StringBuilder accum = new StringBuilder();
+        NodeTraversor.filter(new NodeFilter() {
+            public FilterResult head(Node node, int depth) {
+                accum.append("<" + node.nodeName() + ">");
+                return FilterResult.CONTINUE;
+            }
+
+            public FilterResult tail(Node node, int depth) {
+                accum.append("</" + node.nodeName() + ">");
+                // Stop after p.
+                return ("p".equals(node.nodeName())) ? FilterResult.STOP : FilterResult.CONTINUE;
+            }
+        }, doc.select("div"));
+        assertEquals("<div><p><#text></#text></p>", accum.toString());
+    }
+}


### PR DESCRIPTION
This branch contains:

1. A static `NodeTraversor.traverse(visitor, start)` method, no need to instantiate `NodeTraversor`.
   In fact, that class was essentially useless as instance.
   Old: `new NodeTraversor(visitor).traverse(node);`
   New: `NodeTraversor.traverse(visitor, node);`
   (old method is still possible for compatibility!)

   Feel free to cherry-pick only the first two commits, to get only this smaller change.

2. `NodePartialVisitor` to partially traverse the tree (`head` can return `false` to skip a subtree)

3. `NodeFilteringVisitor` to filter a tree. Both `head` and `tail` can return `false` to delete a subtree prior/after processing it. Perfect for filtering a tree.

In my own codebase, I use Java 8, where these methods can be made `default` methods in the interface, rather than putting them into the helper class. But you appear to want to keep compatibility for Java 5 users (although even Java 7 is officially end-of-lifed by now), so I added static methods to `NodeTraversor` instead. The Java 8 default method approach would move the `traverse` method to the visitor, i.e. you would simply call `visitor.traverse(node);` without referencing `NodeTraversor` at all.

Note: `Elements.traverse` currently only accepts the original `NodeFilter` yet. It would be just copy & paste to allow the two other interfaces, too. But maybe it would be more consistent to put this into `NodeTraversor`, too; or to put everything into `Node` and `Elements` only?
We would then have `node.traverse(visitor)` and `elements.traverse(visitor)`.