### PR TITLE
Speed up matching CSS selectors and other tasks which use elementSiblingIndex() see #863

### DIFF
--- a/src/main/java/org/jsoup/helper/ChangeNotifyingList.java
+++ b/src/main/java/org/jsoup/helper/ChangeNotifyingList.java
@@ -1,0 +1,148 @@
+package org.jsoup.helper;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * A list wrapper which can notify a runnable when the list is modified.
+ *
+ * @param <E>
+ */
+public class ChangeNotifyingList<E> implements List<E> {
+
+    /** Delegate list where changes will be made to.*/
+    private List<E> delegateList;
+    
+    /** Runnable to be called when the delegate list is modified */
+    private final Runnable onChange;
+    
+    /**
+     * 
+     * @param list List to wrap. This list should only be modified via this wrapper class.
+     * @param onChange The runnable to call when the wrapped list is modified by this.
+     */
+    public ChangeNotifyingList(List<E> list, Runnable onChange) {
+        this.delegateList = list;
+        this.onChange = onChange;
+    }
+
+    /**
+     * Called when a changing operation is made to the delegate list. 
+     */
+    private void changeHappend() {
+        this.onChange.run();
+    }
+
+    public int size() {
+        return delegateList.size();
+    }
+
+    public boolean isEmpty() {
+        return delegateList.isEmpty();
+    }
+
+    public boolean contains(Object o) {
+        return delegateList.contains(o);
+    }
+
+    public Iterator<E> iterator() {
+        return delegateList.iterator();
+    }
+
+    public Object[] toArray() {
+        return delegateList.toArray();
+    }
+
+    public <T> T[] toArray(T[] a) {
+        return delegateList.toArray(a);
+    }
+
+    public boolean add(E e) {
+        changeHappend();
+        return delegateList.add(e);
+    }
+
+    public boolean remove(Object o) {
+        changeHappend();
+        return delegateList.remove(o);
+    }
+
+    public boolean containsAll(Collection<?> c) {
+        return delegateList.containsAll(c);
+    }
+
+    public boolean addAll(Collection<? extends E> c) {
+        changeHappend();
+        return delegateList.addAll(c);
+    }
+
+    public boolean addAll(int index, Collection<? extends E> c) {
+        changeHappend();
+        return delegateList.addAll(index, c);
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        changeHappend();
+        return delegateList.removeAll(c);
+    }
+
+    public boolean retainAll(Collection<?> c) {
+        changeHappend();
+        return delegateList.retainAll(c);
+    }
+
+    public void clear() {
+        changeHappend();
+        delegateList.clear();
+    }
+
+    public boolean equals(Object o) {
+        return delegateList.equals(o);
+    }
+
+    public int hashCode() {
+        return delegateList.hashCode();
+    }
+
+    public E get(int index) {
+        return delegateList.get(index);
+    }
+
+    public E set(int index, E element) {
+        changeHappend();
+        return delegateList.set(index, element);
+    }
+
+    public void add(int index, E element) {
+        changeHappend();
+        delegateList.add(index, element);
+    }
+
+    public E remove(int index) {
+        changeHappend();
+        return delegateList.remove(index);
+    }
+
+    public int indexOf(Object o) {
+        return delegateList.indexOf(o);
+    }
+
+    public int lastIndexOf(Object o) {
+        return delegateList.lastIndexOf(o);
+    }
+
+    public ListIterator<E> listIterator() {
+        return delegateList.listIterator();
+    }
+
+    public ListIterator<E> listIterator(int index) {
+        return delegateList.listIterator(index);
+    }
+
+    public List<E> subList(int fromIndex, int toIndex) {
+        return delegateList.subList(fromIndex, toIndex);
+    }
+    
+}

--- a/src/test/java/org/jsoup/helper/ChangeNotifyingListTest.java
+++ b/src/test/java/org/jsoup/helper/ChangeNotifyingListTest.java
@@ -1,0 +1,233 @@
+package org.jsoup.helper;
+
+import static org.junit.Assert.fail;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ChangeNotifyingListTest {
+    
+    public static class TestRunnable implements Runnable {
+        
+        public boolean called = false;
+        
+        public void run() {
+            called = true;
+        }
+    }
+
+    @Test
+    public void testHashCode() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.hashCode();
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testSize() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.size();
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testIsEmpty() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.isEmpty();
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testContains() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.contains("");
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testIterator() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.iterator();
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testToArray() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.toArray();
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testToArrayTArray() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.toArray(new String[0]);
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testAddT() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.add("");
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testRemoveObject() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.remove("");
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testContainsAll() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.containsAll(new LinkedList<String>());
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testAddAllCollectionOfQextendsT() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.addAll(new LinkedList<String>());
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testAddAllIntCollectionOfQextendsT() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.addAll(0, new LinkedList<String>());
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testRemoveAll() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.removeAll(new LinkedList<String>());
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testRetainAll() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.retainAll(new LinkedList<String>());
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testClear() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.clear();
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testEqualsObject() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.equals("");
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testGet() {
+        TestRunnable testRunnable = new TestRunnable();
+        List<String> list = new LinkedList<String>();
+        list.add("foo");
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(list, testRunnable);
+        changeNotifyingList.get(0);
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testSet() {
+        TestRunnable testRunnable = new TestRunnable();
+        List<String> list = new LinkedList<String>();
+        list.add("foo");
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(list, testRunnable);
+        changeNotifyingList.set(0, "");
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testAddIntT() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.add(0, "");
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testRemoveInt() {
+        TestRunnable testRunnable = new TestRunnable();
+        List<String> list = new LinkedList<String>();
+        list.add("foo");
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(list, testRunnable);
+        changeNotifyingList.remove(0);
+        assertTrue(testRunnable.called);
+    }
+
+    @Test
+    public void testIndexOf() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.indexOf("");
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testLastIndexOf() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.lastIndexOf("");
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testListIterator() {
+        TestRunnable testRunnable = new TestRunnable();
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(new LinkedList<String>(), testRunnable);
+        changeNotifyingList.listIterator();
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testListIteratorInt() {
+        TestRunnable testRunnable = new TestRunnable();
+        List<String> list = new LinkedList<String>();
+        list.add("foo");
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(list, testRunnable);
+        changeNotifyingList.listIterator(0);
+        assertFalse(testRunnable.called);
+    }
+
+    @Test
+    public void testSubList() {
+        TestRunnable testRunnable = new TestRunnable();
+        List<String> list = new LinkedList<String>();
+        list.add("foo");
+        ChangeNotifyingList<String> changeNotifyingList = new ChangeNotifyingList<String>(list, testRunnable);
+        changeNotifyingList.subList(0, 0);
+        assertFalse(testRunnable.called);
+    }
+}

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -8,6 +8,8 @@ import org.jsoup.nodes.FormElement;
 import org.jsoup.nodes.Node;
 import org.junit.Test;
 
+import junit.framework.Assert;
+
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -346,6 +348,32 @@ public class ElementsTest {
         Elements prevAF = els.prevAll("p:contains(1)");
         assertEquals(1, prevAF.size());
         assertEquals("1", prevAF.first().text());
+    }
+    
+    
+    @Test public void elementSiblingIndexRemoveTest() {
+        Document doc = Jsoup.parse("<div><h1>1<h2>2</div>");
+
+        Element h1Element = doc.select("h1").first();
+        assertEquals(0, h1Element.elementSiblingIndex() + 0);
+        
+        Element h2Element = doc.select("h2").first();
+        assertEquals(1, h2Element.elementSiblingIndex() + 0);
+
+        h1Element.remove();
+        
+        assertEquals(0, h2Element.elementSiblingIndex() + 0);
+    }
+    
+    @Test public void elementSiblingIndexPrependTest() {
+        Document doc = Jsoup.parse("<div><h2>2</div>");
+
+        Element h2Element = doc.select("h2").first();
+        assertEquals(0, h2Element.elementSiblingIndex() + 0);
+        
+        h2Element.parent().prependElement("h1");
+        
+        assertEquals(1, h2Element.elementSiblingIndex() + 0);
     }
 
     @Test public void eachText() {


### PR DESCRIPTION
Matching css selectors can be rather slow because finding the elementSiblingIndex() is relatively slow. In this I modify Element to cache a Map of its child elements to their elementSiblingIndex(). This results in a massive speed up. Checking a parsed CSS selector against 10.8M elements the time goes from 38.5s to 0.8s. The CSS selector I am using is `html > body > blockquote:nth-child(1209) > a:nth-child(11)`

The change involves:
1. Creating a ChangeNotifyingList, which wraps a given List and will call the given Runnable each time the List is modified.
2. Change childNodes in Node to use a ChangeNotifyingList.
   * We are able to follow the previous behavior of using a static final EMPTY_LIST to avoid creating unnecessary objects when a Element is created.
3. When childNodes in Node is modified the ChangeNotifyingList calls Node#onChildNodeChange()
4. Element is updated to have a field childElementToSiblingElementIndex, which maps its child Elements to their sibling element index.
   * The field is initially null and is set the first time a element tries to find its sibling element index.
   * The field is set back to null any time the childNodes list is modified.

This should result in Jsoup being no slower to parse Documents or edit documents, while dramatically speeding up CSS selector matching. Further with the ChangeNotifyingList future developers are free to modify the childNodes list without needing to add special code to null the Element.childElementToSiblingElementIndex field.