### PR TITLE
Java 7 SSLProtocol fix

### DIFF
--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -1,14 +1,14 @@
 package org.jsoup;
 
-import org.jsoup.nodes.Document;
-import org.jsoup.parser.Parser;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Proxy;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Map;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
 
 /**
  * A Connection provides a convenient interface to fetch content from the web, and parse them into Documents.
@@ -330,6 +330,14 @@ public interface Connection {
      * @return this Connection, for chaining
      */
     Connection response(Response response);
+    
+    /**
+     * 
+     * @param secureProtocol
+     * @return this Connection, for chaining
+     */
+    Connection secureProtocol(String secureProtocol);
+    
 
     /**
      * Common methods for Requests and Responses
@@ -611,6 +619,22 @@ public interface Connection {
          * @return character set to encode post data
          */
         String postDataCharset();
+        
+        /**
+         * 
+         * @return the desired secure protocol
+         * @author Tommaso Formica
+         */
+        String secureProtocol();
+
+        /**
+         * 
+         * @param secureProtocol the desired secure protocol to set
+         * @return  this Request, for chaining
+         * @author Tommaso Formica
+         */
+        Request secureProtocol(String secureProtocol);
+
 
     }
 

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -1,24 +1,48 @@
 package org.jsoup.helper;
 
-import org.jsoup.*;
-import org.jsoup.nodes.Document;
-import org.jsoup.parser.Parser;
-import org.jsoup.parser.TokenQueue;
+import static org.jsoup.Connection.Method.HEAD;
 
-import javax.net.ssl.*;
-import java.io.*;
-import java.net.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
-import static org.jsoup.Connection.Method.HEAD;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.jsoup.Connection;
+import org.jsoup.HttpStatusException;
+import org.jsoup.UnsupportedMimeTypeException;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.jsoup.parser.TokenQueue;
 
 /**
  * Implementation of {@link Connection}.
@@ -471,6 +495,7 @@ public class HttpConnection implements Connection {
         private boolean parserDefined = false; // called parser(...) vs initialized in ctor
         private boolean validateTSLCertificates = true;
         private String postDataCharset = DataUtil.defaultCharset;
+        private String secureProtocol = "SSL";
 
         private Request() {
             timeoutMilliseconds = 30000; // 30 seconds
@@ -590,6 +615,17 @@ public class HttpConnection implements Connection {
 
         public String postDataCharset() {
             return postDataCharset;
+        }
+
+        public String secureProtocol()
+        {
+           return secureProtocol;
+        }
+
+        public Connection.Request secureProtocol(String secureProtocol)
+        {
+            this.secureProtocol = secureProtocol;
+            return this;
         }
     }
 
@@ -782,7 +818,7 @@ public class HttpConnection implements Connection {
 
             if (conn instanceof HttpsURLConnection) {
                 if (!req.validateTLSCertificates()) {
-                    initUnSecureTSL();
+                    initUnSecureTSL(req.secureProtocol());
                     ((HttpsURLConnection)conn).setSSLSocketFactory(sslSocketFactory);
                     ((HttpsURLConnection)conn).setHostnameVerifier(getInsecureVerifier());
                 }
@@ -819,10 +855,11 @@ public class HttpConnection implements Connection {
          * <p/>
          * please not that this method will only perform action if sslSocketFactory is not yet
          * instantiated.
+         * @param string 
          *
          * @throws IOException
          */
-        private static synchronized void initUnSecureTSL() throws IOException {
+        private static synchronized void initUnSecureTSL(String secureProtocol) throws IOException {
             if (sslSocketFactory == null) {
                 // Create a trust manager that does not validate certificate chains
                 final TrustManager[] trustAllCerts = new TrustManager[]{new X509TrustManager() {
@@ -841,7 +878,7 @@ public class HttpConnection implements Connection {
                 // Install the all-trusting trust manager
                 final SSLContext sslContext;
                 try {
-                    sslContext = SSLContext.getInstance("SSL");
+                    sslContext = SSLContext.getInstance(secureProtocol);
                     sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
                     // Create an ssl socket factory with our all-trusting manager
                     sslSocketFactory = sslContext.getSocketFactory();
@@ -1110,5 +1147,10 @@ public class HttpConnection implements Connection {
         public String toString() {
             return key + "=" + value;
         }
+    }
+    public Connection secureProtocol(String secureProtocol)
+    {
+        req.secureProtocol(secureProtocol);
+        return this;
     }
 }

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -1,15 +1,24 @@
 package org.jsoup.helper;
 
-import static org.junit.Assert.*;
-
-import org.jsoup.integration.ParseTest;
-import org.junit.Test;
-import org.jsoup.Connection;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.*;
-import java.net.URL;
 import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.integration.ParseTest;
+import org.junit.Test;
 
 public class HttpConnectionTest {
     /* most actual network http connection tests are in integration */
@@ -181,5 +190,18 @@ public class HttpConnectionTest {
         Connection con = HttpConnection.connect("http://example.com/");
         con.requestBody("foo");
         assertEquals("foo", con.request().requestBody());
+    }
+    
+    @Test
+    public void setSecureProtocol() throws IOException
+    {
+
+        org.jsoup.helper.HttpConnection.Response resConnect = null;
+
+        resConnect =    (org.jsoup.helper.HttpConnection.Response) Jsoup.connect("https://telematici.agenziaentrate.gov.it/Main/index.jsp").validateTLSCertificates(false).secureProtocol("TLSv1.2")
+                          .method(org.jsoup.Connection.Method.GET).execute();
+
+        assertNotNull(resConnect);
+
     }
 }


### PR DESCRIPTION
Hello,
CST Technobank (https://www.csttech.it) is one of the market leaders in Italy in the field of Tax Compliance software for Financial Institution. Our software stack actively uses popular FOSS such as JSoup. We recently had troubles connecting to Italian Revenue Agency (https://telematici.agenziaentrate.gov.it) by means of JSoup at some of our customers running Java 7. We investigated, found a problem with JSoup code and now want to share our findings with the development team.

Inside the HttpConnection class there's `secureProtocol ="SSL"` hardcoded , this means that the TLS version changes according to the jdk. As a result of this with Java 7 projects it's not possible to succesfully connect  to `https` websites that implement a more recent version of it (in our test "https://telematici.agenziaentrate.gov.it/Main/index.jsp" implements TLSv1.2).  There is, however, no problem if the project is ran using Java 8 , which is unsupported by most of our customers.

We have added a method called `secureProtocol` in JSoup API that can be used to set the desired secure protocol, and a Test inside the `HttpConnectionTest` test class  named  setSecureProtocol() that shows it in action. Please check it and share your comments with us.

We would appreciate if JSoup merges this change for the next version. In order to make our software usable before regulatory deadlines, we had to reimplement the above API into a package of ours, thus actually making a fork of JSoup into our code. A really bad workaround.

Credits to
 - Tommaso Formica (tommaso.formica ---at--- csttech.it)
 - Sahaj Quinci (sahaj.quinci ---at--- csttech.it)