### PR TITLE
Continuation to PR #892

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,7 @@
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jetty</artifactId>
       <version>6.1.26</version>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mortbay.jetty</groupId>
+      <artifactId>jetty</artifactId>
+      <version>6.1.26</version>
+    </dependency>
+
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -661,6 +661,7 @@ public class HttpConnection implements Connection {
                 if (res.hasHeader(LOCATION) && req.followRedirects()) {
                     if (status != HTTP_TEMP_REDIR) {
                         req.method(Method.GET); // always redirect with a get. any data param from original req are dropped.
+                        req.removeHeader(CONTENT_TYPE); // also remove Content-Type header from get request
                         req.data().clear();
                     }
 

--- a/src/test/java/org/jsoup/integration/TestWithJetty.java
+++ b/src/test/java/org/jsoup/integration/TestWithJetty.java
@@ -1,0 +1,60 @@
+package org.jsoup.integration;
+
+import org.jsoup.HttpStatusException;
+import org.jsoup.Jsoup;
+import org.jsoup.integration.servlets.FailOnGetWContentTypeServlet;
+import org.jsoup.integration.servlets.RedirOnPostToFailOnGetWContentTypeServlet;
+import org.jsoup.nodes.Document;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mortbay.jetty.HttpHeaders;
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.servlet.ServletHandler;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestWithJetty {
+    private static Server jetty;
+    private static int port;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        jetty = new Server(0);
+        ServletHandler servletHandler = new ServletHandler();
+        jetty.addHandler(servletHandler);
+
+        servletHandler.addServletWithMapping(FailOnGetWContentTypeServlet.class, "/FailOnGetWContentTypeServlet");
+        servletHandler.addServletWithMapping(RedirOnPostToFailOnGetWContentTypeServlet.class, "/RedirOnPostToFailOnGetWContentTypeServlet");
+
+        jetty.start();
+        port = jetty.getConnectors()[0].getLocalPort();
+    }
+
+    @Test
+    public void failOnGetWContentType() throws IOException {
+        try {
+            Jsoup.connect("http://localhost:" + port + "/FailOnGetWContentTypeServlet")
+                    .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded; charset=UTF-8")
+                    .get();
+        } catch (HttpStatusException e) {
+            assertEquals(400, e.getStatusCode());
+        }
+    }
+
+    @Test
+    public void redirectOnPostToFailOnGetWContentTypeServlet() throws IOException {
+        Document doc = Jsoup.connect("http://localhost:" + port + "/RedirOnPostToFailOnGetWContentTypeServlet")
+                .data("somekey", "somevalue")
+                .post();
+        assertTrue(doc.select("h1").text().equals("Hello from FailOnGetWContentTypeServlet"));
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        jetty.stop();
+    }
+}

--- a/src/test/java/org/jsoup/integration/servlets/FailOnGetWContentTypeServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/FailOnGetWContentTypeServlet.java
@@ -1,0 +1,23 @@
+package org.jsoup.integration.servlets;
+
+import org.jsoup.helper.HttpConnection;
+import org.mortbay.jetty.HttpHeaders;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class FailOnGetWContentTypeServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (req.getHeader(HttpHeaders.CONTENT_TYPE) != null) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        } else {
+            resp.setContentType("text/html");
+            resp.setStatus(HttpServletResponse.SC_OK);
+            resp.getWriter().println("<h1>Hello from FailOnGetWContentTypeServlet</h1>");
+        }
+    }
+}

--- a/src/test/java/org/jsoup/integration/servlets/RedirOnPostToFailOnGetWContentTypeServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/RedirOnPostToFailOnGetWContentTypeServlet.java
@@ -1,0 +1,17 @@
+package org.jsoup.integration.servlets;
+
+import org.mortbay.jetty.HttpHeaders;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class RedirOnPostToFailOnGetWContentTypeServlet extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.sendRedirect("FailOnGetWContentTypeServlet");
+    }
+
+}


### PR DESCRIPTION
Hi! Content-Type header is set by _HttpConnection.Response#setOutputContentType_ called from _HttpConnection.Response#execute_ when the request method has a body and data was added to the connection (by _Connection#data_).
In my case it was a POST request (it can have a body) and I added data, that's why after _setOutputContentType_ executed I got Content-Type = "application/x-www-form-urlencoded; charset=UTF-8" in the request.
To reproduce - Jsoup.connect("http://some-server-which-returns-400-when-content-type-header-is-present-in-get-request").data("somekey", "somevalue").post();
I created a test case with Jetty as a local server to reproduce the behaviour of the corporate server I encountered the issue with.