### PR TITLE
Support `file:/...` URLs for local testing #363

### DIFF
--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -263,7 +263,8 @@ public class Jsoup {
 	}
 
 	public static Document load(String fileURL) throws Exception {
-		return new FileConnection().load(fileURL);
+		ProtocolConnection connection = Protocols.getProtocolConnection(fileURL);
+		return connection.load(fileURL);
 	}
     
 }

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -5,7 +5,9 @@ import org.jsoup.parser.Parser;
 import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Whitelist;
 import org.jsoup.helper.DataUtil;
+import org.jsoup.helper.FileConnection;
 import org.jsoup.helper.HttpConnection;
+import org.jsoup.helper.Protocols;
 
 import java.io.File;
 import java.io.IOException;
@@ -249,5 +251,19 @@ public class Jsoup {
     public static boolean isValid(String bodyHtml, Whitelist whitelist) {
         return new Cleaner(whitelist).isValidBodyHtml(bodyHtml);
     }
+
+    /**
+     Enable Jsoup to handle file:// protocols to load file from local directory. 
+     @param  protocolName : E.g. Protocol.FILE
+     @param  enable		  : Enable/Disable Access. Default false
+     * */
+	public static FileConnection allowProtocol(String protocolName, boolean enable) {
+		Protocols.setValue(protocolName, enable);
+		return new FileConnection();
+	}
+
+	public static Document load(String fileURL) throws Exception {
+		return new FileConnection().load(fileURL);
+	}
     
 }

--- a/src/main/java/org/jsoup/ProtocolConnection.java
+++ b/src/main/java/org/jsoup/ProtocolConnection.java
@@ -1,0 +1,16 @@
+/**
+ * 
+ */
+package org.jsoup;
+
+import org.jsoup.nodes.Document;
+
+/**
+ * @author Jay Patel
+ *
+ */
+public interface ProtocolConnection {
+	
+	public Document load(String fileURL) throws Exception;
+
+}

--- a/src/main/java/org/jsoup/examples/FileProtocolLoad.java
+++ b/src/main/java/org/jsoup/examples/FileProtocolLoad.java
@@ -1,0 +1,26 @@
+package org.jsoup.examples;
+
+import org.jsoup.Jsoup;
+import org.jsoup.helper.Protocols;
+import org.jsoup.nodes.Document;
+
+public class FileProtocolLoad {
+
+	public static void main(String[] args) throws Exception {
+		
+		String fileURL = "file:///C:/Users/Jay Patel/Desktop/sample.html";
+		
+		// Document doc = Jsoup.allowProtocol(Protocols.FILE, true).load(fileURL);
+		// System.out.println(doc.toString());
+		
+		// type 2
+		//Jsoup.allowProtocol(Protocols.FILE, true);
+		Document doc = Jsoup.load(fileURL);
+		Jsoup.allowProtocol(Protocols.FILE, true);
+		System.out.println(doc.toString());
+		
+		
+		
+	}
+
+}

--- a/src/main/java/org/jsoup/examples/FileProtocolLoad.java
+++ b/src/main/java/org/jsoup/examples/FileProtocolLoad.java
@@ -10,13 +10,14 @@ public class FileProtocolLoad {
 		
 		String fileURL = "file:///C:/Users/Jay Patel/Desktop/sample.html";
 		
-		// Document doc = Jsoup.allowProtocol(Protocols.FILE, true).load(fileURL);
-		// System.out.println(doc.toString());
+		 Document doc = Jsoup.allowProtocol(Protocols.FILE, true).load(fileURL);
+		 System.out.println(doc.toString());
 		
 		// type 2
 		//Jsoup.allowProtocol(Protocols.FILE, true);
-		Document doc = Jsoup.load(fileURL);
-		Jsoup.allowProtocol(Protocols.FILE, true);
+		//Jsoup.allowProtocol(Protocols.FILE, true);
+		//Document doc = Jsoup.load(fileURL);
+		
 		System.out.println(doc.toString());
 		
 		

--- a/src/main/java/org/jsoup/helper/FileConnection.java
+++ b/src/main/java/org/jsoup/helper/FileConnection.java
@@ -1,0 +1,48 @@
+/**
+ * 
+ */
+package org.jsoup.helper;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+
+
+/**
+ * @author Jay Patel
+ *
+ */
+public class FileConnection {
+
+	public Document load(String fileURL) throws Exception {
+		try {
+			fileURL = fileURL.replaceAll(" ", "%20");
+			
+			URI filepath = new URL(fileURL).toURI();
+			
+			String protocol = filepath.getScheme();
+			
+			if(Protocols.isEnabled(protocol)){
+				File f = new File(filepath);
+				Document doc = Jsoup.parse(f, null);
+				return doc;
+			}else {
+				throw new IllegalAccessError("Enable jsoup to handle "+ protocol +" protocol. ");
+			}
+			
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Invalid URL ", e);
+		} catch (MalformedURLException e) {
+			throw new IllegalArgumentException("Invalid URL ", e);
+		} catch (Exception e) {
+			throw new Exception("Unknown reason ", e);
+		}
+	}
+
+}

--- a/src/main/java/org/jsoup/helper/FileConnection.java
+++ b/src/main/java/org/jsoup/helper/FileConnection.java
@@ -10,6 +10,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.jsoup.Jsoup;
+import org.jsoup.ProtocolConnection;
 import org.jsoup.nodes.Document;
 
 
@@ -18,8 +19,9 @@ import org.jsoup.nodes.Document;
  * @author Jay Patel
  *
  */
-public class FileConnection {
+public class FileConnection implements ProtocolConnection {
 
+	@Override
 	public Document load(String fileURL) throws Exception {
 		try {
 			fileURL = fileURL.replaceAll(" ", "%20");
@@ -44,5 +46,7 @@ public class FileConnection {
 			throw new Exception("Unknown reason ", e);
 		}
 	}
+
+	
 
 }

--- a/src/main/java/org/jsoup/helper/Protocols.java
+++ b/src/main/java/org/jsoup/helper/Protocols.java
@@ -3,6 +3,11 @@
  */
 package org.jsoup.helper;
 
+import java.net.URI;
+import java.net.URL;
+
+import org.jsoup.ProtocolConnection;
+
 /**
  * @author Jay Patel
  *
@@ -11,6 +16,7 @@ public class Protocols {
 	
 	public static final String FILE = "file";
 	private static boolean isFileProtocolEnable = false; // default 
+	
 
 	public static boolean setValue(String protocolName, boolean enable) {
 		if(FILE.equalsIgnoreCase(protocolName)){
@@ -28,5 +34,21 @@ public class Protocols {
 			
 	}
 	
+	public static ProtocolConnection getProtocolConnection(String url) {
+		String fileURL = url.replaceAll(" ", "%20");
+		URI filepath;
+		try {
+			filepath = new URL(fileURL).toURI();
+			String scheme = filepath.getScheme();
+			if(FILE.equalsIgnoreCase(scheme)){
+				return new FileConnection();
+			}
+			return null; 
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+		 
+	}
 
 }

--- a/src/main/java/org/jsoup/helper/Protocols.java
+++ b/src/main/java/org/jsoup/helper/Protocols.java
@@ -1,0 +1,32 @@
+/**
+ * 
+ */
+package org.jsoup.helper;
+
+/**
+ * @author Jay Patel
+ *
+ */
+public class Protocols {
+	
+	public static final String FILE = "file";
+	private static boolean isFileProtocolEnable = false; // default 
+
+	public static boolean setValue(String protocolName, boolean enable) {
+		if(FILE.equalsIgnoreCase(protocolName)){
+			isFileProtocolEnable = enable;
+			return true;
+		}
+		return false;
+	}
+
+	public static boolean isEnabled(String protocol) {
+		if(FILE.equalsIgnoreCase(protocol)){
+			return isFileProtocolEnable;
+		}
+		return false; // if nothing matches return false.
+			
+	}
+	
+
+}


### PR DESCRIPTION
**Usage 1:**
```
String fileURL = "file:///<location_to>.html";
Document doc = Jsoup.allowProtocol(Protocols.FILE, true).load(fileURL);
```
**Usage 2:**
```
Jsoup.allowProtocol(Protocols.FILE, true);
Document doc = Jsoup.load(fileURL);
```
Error:
If accessed without allowProtocol
```java.lang.IllegalAccessError: Enable jsoup to handle file protocol.```

Further protocols can be supported by implementing the ProtocolConnection class
e.g. `FTPConnection` implements `ProtocolConnection`

P.S. This is a crude implementation I'll clean up this PR
Let me know your thoughts on this. 