### PR TITLE
Missing Test Case for whitespace class name

### DIFF
--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -1165,4 +1165,20 @@ public class ElementTest {
         assertEquals("p", matched.nodeName());
         assertTrue(matched.is(":containsOwn(get what you want)"));
     }
+	
+	
+	
+    @Test 
+    public void whiteSpaceClassElement(){
+	    Tag tag = Tag.valueOf("a");
+	    Attributes attribs = new Attributes();
+	    Element el = new Element(tag, "", attribs);
+	    
+	    attribs.put("class", "abc ");
+	    boolean hasClass = el.hasClass("ab");
+	    assertFalse(hasClass);
+	        
+	}
+	
+	
 }


### PR DESCRIPTION
The method that checks if an element has a class is never tested for a class name that ends with a whitespace. The implemented functionality is correct however if the "if (i - start == wantLen && classAttr.regionMatches(true, start, className, 0, wantLen)) {" check is removed, no tests catch this. The missing test case was discovered through mutation testing analysis.