### PR TITLE
Missing Test Case to preserve consumeToIgnoreCase() behavior

### DIFF
--- a/src/test/java/org/jsoup/parser/TokenQueueTest.java
+++ b/src/test/java/org/jsoup/parser/TokenQueueTest.java
@@ -58,4 +58,17 @@ public class TokenQueueTest {
         tq.addFirst("Three");
         assertEquals("Three Two", tq.remainder());
     }
+    
+    
+    @Test 
+    public void consumeToIgnoreSecondCallTest(){
+		String t = "<textarea>one < two </TEXTarea> third </TEXTarea>";
+		TokenQueue tq = new TokenQueue(t);
+		String data = tq.chompToIgnoreCase("</textarea>");
+		assertEquals("<textarea>one < two ", data);
+		
+		data = tq.chompToIgnoreCase("</textarea>");
+		assertEquals(" third ", data);
+    }
+    
 }


### PR DESCRIPTION
Since pos is a class attribute, calling consumeToIgnoreCase() on the same queue will return different Strings. If this is the intended behavior than this test preserves that. If not the second assert should be changed to assertEquals("<textarea>one < two ", data); . Nevertheless that would cause the test to fail based on current implementation. This missing behavior preservation was detected by running mutation testing analysis.