### PR TITLE
patch about issue #836 addChildren is quadratic

### DIFF
--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -8,11 +8,7 @@ import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 /**
  The base, abstract Node model. Elements, Documents, Comments etc are all Node instances.

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -460,12 +460,11 @@ public abstract class Node implements Cloneable {
         Validate.noNullElements(children);
         final List<Node> nodes = ensureChildNodes();
 
-        for (int i = children.length - 1; i >= 0; i--) {
-            Node in = children[i];
-            reparentChild(in);
-            nodes.add(index, in);
-            reindexChildren(index);
+        for (Node child : children) {
+            reparentChild(child);
         }
+        nodes.addAll(index, Arrays.asList(children));
+        reindexChildren(index);
     }
     
     protected void reparentChild(Node child) {


### PR DESCRIPTION
patch about  issue #836 addChildren is quadratic
when add many children, the origin implementation will move childNodes array per loop.(method add(index, obj)),
a performance improvement was made using addAll(index, objs).there are three steps:
1. reparent all the children
2. use addAll(index, objs) to insert children
3. reset sibling index
it is very similar with method addChildren(Node... children).