### PR TITLE
[fix] parsing of mixed-case tags after b934c5d

### DIFF
--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -760,7 +760,7 @@ enum HtmlTreeBuilderState {
         }
 
         boolean anyOtherEndTag(Token t, HtmlTreeBuilder tb) {
-            String name = t.asEndTag().name(); // matches with case sensitivity if enabled
+            String name = tb.settings.normalizeTag(t.asEndTag().name()); // matches with case sensitivity if enabled
             ArrayList<Element> stack = tb.getStack();
             for (int pos = stack.size() -1; pos >= 0; pos--) {
                 Element node = stack.get(pos);

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1005,6 +1005,13 @@ public class HtmlParserTest {
         assertEquals("<r> <X> A </X> <y> B </y> </r>", StringUtil.normaliseWhitespace(doc.body().html()));
     }
 
+    @Test public void caseInsensitiveParseTree() {
+        String html = "<r><X>A</X><y>B</y></r>";
+        Parser parser = Parser.htmlParser();
+        Document doc = parser.parseInput(html, "");
+        assertEquals("<r> <x> A </x> <y> B </y> </r>", StringUtil.normaliseWhitespace(doc.body().html()));
+    }
+
     @Test public void selfClosingVoidIsNotAnError() {
         String html = "<p>test<br/>test<br/></p>";
         Parser parser = Parser.htmlParser().setTrackErrors(5);


### PR DESCRIPTION
This PR will fix the parser issue introduced by b934c5d and commented by @Tunous.

```
input: "<r><X>A</X><y>B</y></r>"
expected: "<r> <x> A </x> <y> B </y> </r>"
actual: "<r> <x> A <y> B </y> </x> </r>"
```

We got the same with a mixed-case `<noScript>` element in some of our html input.

```html
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<STYLE type="text/css">
  body { padding:10px; }
</STYLE>
</head>
<body>
<noScript>no Javascript enabled</noScript>
<h1>Headline1</h1>
<h2>Headline 2</h2>
</body>
</html>
```