### PR TITLE
Bugfix #951 Method nextElementSibling() returns null after adding an element to a document that was cloned 

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1330,6 +1330,6 @@ public class Element extends Node {
 
     @Override
     public Element clone() {
-        return (Element) super.clone();
+        return (Element) super.doClone(this);
     }
 }

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -1117,4 +1117,21 @@ public class ElementTest {
         assertEquals(p1, p9);
         assertEquals(p1, p10);
     }
+
+    @Test public void testDoAfterOnCloneElementNotNullParent(){
+        String html = "<!DOCTYPE html><html lang=\"en\"><head></head><body><div>Initial element</div></body></html>";
+        Document original = Jsoup.parse(html);
+        Document clone = original.clone();
+
+        Element originalElement = original.body().child(0);
+        originalElement.after("<div>New element</div>");
+        Element originalNextElementSibling = originalElement.nextElementSibling();
+        Element originalNextSibling = (Element) originalElement.nextSibling();
+
+        assertNotNull(clone);
+        assertNotEquals(clone,original);
+        assertNotNull(clone.parentNode);
+        assertNotNull(originalNextElementSibling);
+        assertNotNull(originalNextSibling);
+    }
 }


### PR DESCRIPTION
This commit fix the ISSUE https://github.com/jhy/jsoup/issues/951

Problem: Once a document is cloned and try to append an after element the document cloned
doesn't recognize the parent and that result in a nextElementSibling equals to null.

Solution: The Element.clone() method calls Element.doClone() with self as parameter to create a new instance.

Changes:
- Element.clone calls to doClone method with self as arg
- New test case added to verify the generated objects are different and with no null values.

"Omar Bautista" <joxebus@gmail.com>