### PR TITLE
Handle invalid namespace prefixes when converting to W3C Dom

### DIFF
--- a/src/main/java/org/jsoup/helper/W3CDom.java
+++ b/src/main/java/org/jsoup/helper/W3CDom.java
@@ -69,7 +69,6 @@ public class W3CDom {
     protected static class W3CBuilder implements NodeVisitor {
         private static final String xmlnsKey = "xmlns";
         private static final String xmlnsPrefix = "xmlns:";
-        private static final String DEFAULT_NAMESPACE = "http://www.w3.org/1999/xhtml";
 
         private final Document doc;
         private final Stack<HashMap<String, String>> namespacesStack = new Stack<>(); // stack of namespaces, prefix => urn
@@ -87,8 +86,11 @@ public class W3CDom {
 
                 String prefix = updateNamespaces(sourceEl);
                 String namespace = namespacesStack.peek().get(prefix);
+
+                // If this element has a prefix which is not declared, then simply ignore it
+                // and treat it as though it had no prefix at all.
                 if(namespace == null) {
-                    namespace  = DEFAULT_NAMESPACE;
+                    namespace  = namespacesStack.peek().get("");
                 }
 
                 Element el = doc.createElementNS(namespace, sourceEl.tagName());

--- a/src/main/java/org/jsoup/helper/W3CDom.java
+++ b/src/main/java/org/jsoup/helper/W3CDom.java
@@ -69,6 +69,7 @@ public class W3CDom {
     protected static class W3CBuilder implements NodeVisitor {
         private static final String xmlnsKey = "xmlns";
         private static final String xmlnsPrefix = "xmlns:";
+        private static final String DEFAULT_NAMESPACE = "http://www.w3.org/1999/xhtml";
 
         private final Document doc;
         private final Stack<HashMap<String, String>> namespacesStack = new Stack<>(); // stack of namespaces, prefix => urn
@@ -86,6 +87,9 @@ public class W3CDom {
 
                 String prefix = updateNamespaces(sourceEl);
                 String namespace = namespacesStack.peek().get(prefix);
+                if(namespace == null) {
+                    namespace  = DEFAULT_NAMESPACE;
+                }
 
                 Element el = doc.createElementNS(namespace, sourceEl.tagName());
                 copyAttributes(sourceEl, el);

--- a/src/test/java/org/jsoup/helper/W3CDomTest.java
+++ b/src/test/java/org/jsoup/helper/W3CDomTest.java
@@ -7,11 +7,19 @@ import org.jsoup.nodes.Element;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.xpath.XPathEvaluator;
 
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.io.File;
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class W3CDomTest {
@@ -59,7 +67,24 @@ public class W3CDomTest {
         String out = w3c.asString(wDoc);
         assertEquals(doc.location(), wDoc.getDocumentURI() );
     }
-    
+
+    @Test
+    public void undeclaredNamespaces() throws IOException, XPathExpressionException {
+        File in = ParseTest.getFile("/htmltests/ietags.html");
+        org.jsoup.nodes.Document doc = Jsoup.parse(in, "UTF8");
+
+        W3CDom w3c = new W3CDom();
+        Document wDoc = w3c.fromJsoup(doc);
+
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        NodeList nodes = (NodeList)xPath.evaluate("//*[local-name() = 'menuitem']",
+            wDoc.getDocumentElement(), XPathConstants.NODESET);
+
+        assertThat(nodes.getLength(), equalTo(1));
+
+        org.w3c.dom.Element menuItem = (org.w3c.dom.Element) nodes.item(0);
+        assertThat(menuItem.getAttribute("id"), equalTo("MSOMenu_Help"));
+    }
     
 
     @Test

--- a/src/test/java/org/jsoup/helper/W3CDomTest.java
+++ b/src/test/java/org/jsoup/helper/W3CDomTest.java
@@ -8,19 +8,13 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.w3c.dom.xpath.XPathEvaluator;
 
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 import java.io.File;
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class W3CDomTest {
     @Test

--- a/src/test/java/org/jsoup/helper/W3CDomTest.java
+++ b/src/test/java/org/jsoup/helper/W3CDomTest.java
@@ -69,20 +69,17 @@ public class W3CDomTest {
     }
 
     @Test
-    public void undeclaredNamespaces() throws IOException, XPathExpressionException {
+    public void undeclaredPrefixes() throws IOException, XPathExpressionException {
         File in = ParseTest.getFile("/htmltests/ietags.html");
         org.jsoup.nodes.Document doc = Jsoup.parse(in, "UTF8");
 
         W3CDom w3c = new W3CDom();
         Document wDoc = w3c.fromJsoup(doc);
 
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        NodeList nodes = (NodeList)xPath.evaluate("//*[local-name() = 'menuitem']",
-            wDoc.getDocumentElement(), XPathConstants.NODESET);
+        NodeList ns = wDoc.getElementsByTagNameNS("http://www.w3.org/1999/xhtml", "menuitem");
+        assertThat(ns.getLength(), equalTo(1));
 
-        assertThat(nodes.getLength(), equalTo(1));
-
-        org.w3c.dom.Element menuItem = (org.w3c.dom.Element) nodes.item(0);
+        org.w3c.dom.Element menuItem = (org.w3c.dom.Element) ns.item(0);
         assertThat(menuItem.getAttribute("id"), equalTo("MSOMenu_Help"));
     }
     

--- a/src/test/resources/htmltests/ietags.html
+++ b/src/test/resources/htmltests/ietags.html
@@ -1,0 +1,520 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" __expr-val-dir="ltr" lang="nl-nl" dir="ltr">
+<style>/* verbergt de ribbon */
+.zhg-ribbon {
+    display:none;
+}</style>
+
+<head><meta http-equiv="X-UA-Compatible" content="IE=8" /><meta name="GENERATOR" content="Microsoft SharePoint" /><meta name="progid" content="SharePoint.WebPartPage.Document" /><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><meta http-equiv="Expires" content="0" /><title>
+
+    Annie M.G. Schmidtschool
+
+</title><link rel="stylesheet" type="text/css" href="/_catalogs/theme/Themed/9262B884/control2s-B7BF791D.css?ctag=10"/>
+    <link rel="stylesheet" type="text/css" href="/_catalogs/theme/Themed/9262B884/corev4-86EA5BCC.css?ctag=10"/>
+    <link rel="stylesheet" type="text/css" href="/_catalogs/theme/Themed/9262B884/DHSInternet2-756A8699.css?ctag=10"/>
+
+    <script type="text/javascript">var _fV4UI = true;</script>
+    <script type="text/javascript">
+        // <![CDATA[
+        document.write('<script src="/_layouts/1043/init.js?rev=wewYbpgbTs6uuAygt4TbAg%3D%3D"></' + 'script>');
+        document.write('<script type="text/javascript" src="/ScriptResource.axd?d=kP22toYkZveIWRgsYMYhdcXHKkx9BGjsLxaMwmcz0Pgtw2CxjIxc5p-PODrGeaKYWBXqoV1Mjbdc0GlZfoD3Bj7K2M-oALdDfl0JWgxs5M3UPIQyN4EqDxg7D32tVdy6RG0CsvdvO8VR6m1cRcEFyDT5I9s1&amp;t=2e2045e2"></' + 'script>');
+        document.write('<script type="text/javascript" src="/_layouts/blank.js?rev=QGOYAJlouiWgFRlhHVlMKA%3D%3D"></' + 'script>');
+        document.write('<script type="text/javascript" src="/ScriptResource.axd?d=ggvv3I2iB8VGchERo6zpRfO1ATmEC2rzU-WApMNFogcy34KdxP-Hshwn6fdoAh9q6K_XJ2fGwSdgracm74GybV0qZrRtfjp8n5hB-5peBXOnaq_TJr6D1A31jrcrcg-YlGUNp50OCfaQdzwnLWuTR_pBiE7n7OIR6zshFbqyD4tcksw_0&amp;t=2e2045e2"></' + 'script>');
+        // ]]>
+    </script>
+    <link type="text/xml" rel="alternate" href="/_vti_bin/spsdisco.aspx" /><link rel="shortcut icon" href="/_layouts/images/favicon.ico" type="image/vnd.microsoft.icon" /><style type="text/css">
+        .s4-skipribbonshortcut { display:none; }
+        .ctl00_PlaceHolderMain_LeftTopZone_0 { border-color:Black;border-width:1px;border-style:Solid; }
+        .ctl00_PlaceHolderMain_RightTopZone_0 { border-color:Black;border-width:1px;border-style:Solid; }
+        .ctl00_wpz_0 { border-color:Black;border-width:1px;border-style:Solid; }
+
+    </style></head>
+<body scroll="yes" onload="if (typeof(_spBodyOnLoadWrapper) != 'undefined') _spBodyOnLoadWrapper();">
+<form name="aspnetForm" method="post" action="default.aspx" onsubmit="javascript:return WebForm_OnSubmit();" id="aspnetForm">
+    <div>
+        <input type="hidden" name="MSOWebPartPage_PostbackSource" id="MSOWebPartPage_PostbackSource" value="" />
+        <input type="hidden" name="MSOTlPn_SelectedWpId" id="MSOTlPn_SelectedWpId" value="" />
+        <input type="hidden" name="MSOTlPn_View" id="MSOTlPn_View" value="0" />
+        <input type="hidden" name="MSOTlPn_ShowSettings" id="MSOTlPn_ShowSettings" value="False" />
+        <input type="hidden" name="MSOGallery_SelectedLibrary" id="MSOGallery_SelectedLibrary" value="" />
+        <input type="hidden" name="MSOGallery_FilterString" id="MSOGallery_FilterString" value="" />
+        <input type="hidden" name="MSOTlPn_Button" id="MSOTlPn_Button" value="none" />
+        <input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
+        <input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
+        <input type="hidden" name="__REQUESTDIGEST" id="__REQUESTDIGEST" value="0xDAFD23C2ABA7438759C0715721CB8941A39A13AE3A02CD08B5E8BB0B7E5A1A9326CA1951EDEFCC5397DD188E88601BAF500230D8EADAA7E0E49BA92638326325,19 Jan 2018 22:21:07 -0000" />
+        <input type="hidden" name="MSOSPWebPartManager_DisplayModeName" id="MSOSPWebPartManager_DisplayModeName" value="Browse" />
+        <input type="hidden" name="MSOSPWebPartManager_ExitingDesignMode" id="MSOSPWebPartManager_ExitingDesignMode" value="false" />
+        <input type="hidden" name="MSOWebPartPage_Shared" id="MSOWebPartPage_Shared" value="" />
+        <input type="hidden" name="MSOLayout_LayoutChanges" id="MSOLayout_LayoutChanges" value="" />
+        <input type="hidden" name="MSOLayout_InDesignMode" id="MSOLayout_InDesignMode" value="" />
+        <input type="hidden" name="_wpSelected" id="_wpSelected" value="" />
+        <input type="hidden" name="_wzSelected" id="_wzSelected" value="" />
+        <input type="hidden" name="MSOSPWebPartManager_OldDisplayModeName" id="MSOSPWebPartManager_OldDisplayModeName" value="Browse" />
+        <input type="hidden" name="MSOSPWebPartManager_StartWebPartEditingName" id="MSOSPWebPartManager_StartWebPartEditingName" value="false" />
+        <input type="hidden" name="MSOSPWebPartManager_EndWebPartEditing" id="MSOSPWebPartManager_EndWebPartEditing" value="false" />
+        <input type="hidden" name="_maintainWorkspaceScrollPosition" id="_maintainWorkspaceScrollPosition" value="0" />
+        <input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUJNzg4MzcyMjgwD2QWAmYPZBYCAgEPZBYEAgMPZBYCAgYPZBYCZg9kFgICAQ8WAh4TUHJldmlvdXNDb250cm9sTW9kZQspiAFNaWNyb3NvZnQuU2hhcmVQb2ludC5XZWJDb250cm9scy5TUENvbnRyb2xNb2RlLCBNaWNyb3NvZnQuU2hhcmVQb2ludCwgVmVyc2lvbj0xNC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj03MWU5YmNlMTExZTk0MjljAWQCBQ9kFggCBA9kFggFJmdfZDViMDVkNzhfN2JlOF80YmQyXzllZTJfMmZjNjk2Zjc0Zjk5D2QWBGYPFgIeB1Zpc2libGVoZAIBDxYCHwFoZAUmZ184ZjhmZGNjMV8xMmJmXzQ1NTJfYTNiZF9lM2EyNzA1N2IxMzYPZBYEZg8WAh8BaGQCAQ8WAh8BaGQFJmdfZGI5YjM0OTdfZjMyZF80ZDY5X2IzNjdfZjZjOWRkNzQ5ZDBlD2QWBGYPFgIfAWhkAgEPFgIfAWhkBSZnXzJhYWYwZTAzX2Q0M2NfNDEwM19iMzM0X2M0OGUyZmIwOWEwYw9kFgRmDxYCHwFoZAIBDxYCHwFoZAIUD2QWAmYPZBYEAgEPFgIfAWgWAmYPZBYEAgIPZBYGAgEPFgIfAWhkAgMPFggeE0NsaWVudE9uQ2xpY2tTY3JpcHQFcmphdmFTY3JpcHQ6Q29yZUludm9rZSgnVGFrZU9mZmxpbmVUb0NsaWVudFJlYWwnLDEsIDM5LCAnaHR0cDpcdTAwMmZcdTAwMmZ3d3cuYW1nc2NobWlkdHNjaG9vbC5ubCcsIC0xLCAtMSwgJycsICcnKR4YQ2xpZW50T25DbGlja05hdmlnYXRlVXJsZB4oQ2xpZW50T25DbGlja1NjcmlwdENvbnRhaW5pbmdQcmVmaXhlZFVybGQeDEhpZGRlblNjcmlwdAUiVGFrZU9mZmxpbmVEaXNhYmxlZCgxLCAzOSwgLTEsIC0xKWQCBQ8WAh8BaGQCAw8PFgoeCUFjY2Vzc0tleQUBLx4PQXJyb3dJbWFnZVdpZHRoAgUeEEFycm93SW1hZ2VIZWlnaHQCAx4RQXJyb3dJbWFnZU9mZnNldFhmHhFBcnJvd0ltYWdlT2Zmc2V0WQLrA2RkAgMPZBYCAgMPZBYCAgEPPCsABQEADxYCHg9TaXRlTWFwUHJvdmlkZXIFEUN1cnJlbnROYXZpZ2F0aW9uZGQCLA9kFgICAQ9kFgJmD2QWAgIBDw9kFgYeBWNsYXNzBSJtcy1zYnRhYmxlIG1zLXNidGFibGUtZXggczQtc2VhcmNoHgtjZWxscGFkZGluZwUBMB4LY2VsbHNwYWNpbmcFATBkAjYPZBYGAgUPZBYCAgEPEBYCHwFoZBQrAQBkAgcPZBYCZg9kFgJmDxQrAANkZGRkAisPDxYCHwFoZBYCAgMPZBYCAgMPZBYCAgEPPCsACQEADxYCHg1OZXZlckV4cGFuZGVkZ2RkGAEFR2N0bDAwJFBsYWNlSG9sZGVyVG9wTmF2QmFyJFBsYWNlSG9sZGVySG9yaXpvbnRhbE5hdiRUb3BOYXZpZ2F0aW9uTWVudVY0Dw9kBQRIb21lZM1Okbdf1oZZ/iiDodaPKi2NeE+3" />
+    </div>
+
+    <script type="text/javascript">
+        //<![CDATA[
+        var theForm = document.forms['aspnetForm'];
+        if (!theForm) {
+            theForm = document.aspnetForm;
+        }
+        function __doPostBack(eventTarget, eventArgument) {
+            if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
+                theForm.__EVENTTARGET.value = eventTarget;
+                theForm.__EVENTARGUMENT.value = eventArgument;
+                theForm.submit();
+            }
+        }
+        //]]>
+    </script>
+
+
+    <script src="/WebResource.axd?d=K7vis4_pet58O703Q8q9D5xFHmu7AJjB7-f1AoSMZV-OKLQw1YWeFgxEwdKwRJBBIoQM9gY_0ANba8OBseRlh6dpcr41&amp;t=636271743501517547" type="text/javascript"></script>
+
+
+    <script type="text/javascript">
+        //<![CDATA[
+        var MSOWebPartPageFormName = 'aspnetForm';
+        var g_presenceEnabled = true;
+        var g_wsaEnabled = false;
+        var g_wsaLCID = 1043;
+        var g_wsaSiteTemplateId = 'CMSPUBLISHING#0';
+        var g_wsaListTemplateId = 850;
+        var _fV4UI=true;var _spPageContextInfo = {webServerRelativeUrl: "\u002f", webLanguage: 1043, currentLanguage: 1043, webUIVersion:4,pageListId:"{7a506229-1b72-4548-8333-7876f74456eb}",pageItemId:1, alertsEnabled:true, siteServerRelativeUrl: "\u002f", allowSilverlightPrompt:'True'};function CallServer_m1677995088(arg, context) {WebForm_DoCallback('ctl00$ctl15',arg,SP.UI.MyLinksRibbon.MyLinksRibbonPageComponent.ribbonActionCallback,context,null,false); }function _myLinksRibbonLoad2()
+        {
+            var fnd = function () {
+                try {
+                    mylinks_init.MyLinksInit('CallServer_m1677995088');
+                }
+                catch (Ex)
+                { }
+            };
+            RegisterSod('mylinks_init', '/_layouts/SP.UI.MyLinksRibbon.js');
+            LoadSodByKey('mylinks_init', fnd);
+        }
+
+        function _myLinksRibbonLoad1()
+        {
+            ExecuteOrDelayUntilScriptLoaded(_myLinksRibbonLoad2, 'SP.Ribbon.js');
+        }
+
+        _spBodyOnLoadFunctionNames.push('_myLinksRibbonLoad1');
+        document.onreadystatechange=fnRemoveAllStatus; function fnRemoveAllStatus(){removeAllStatus(true)};//]]>
+    </script>
+    <script type="text/javascript">
+        <!--
+        var L_Menu_BaseUrl="";
+        var L_Menu_LCID="1043";
+        var L_Menu_SiteTheme="";
+        //-->
+    </script>
+    <script type="text/javascript">
+        //<![CDATA[
+        function _spNavigateHierarchy(nodeDiv, dataSourceId, dataPath, url, listInContext, type) {
+            CoreInvoke('ProcessDefaultNavigateHierarchy', nodeDiv, dataSourceId, dataPath, url, listInContext, type, document.forms.aspnetForm, "", "\u002fPaginas\u002fdefault.aspx");
+
+        }
+        //]]>
+    </script>
+    <script type="text/javascript">
+        //<![CDATA[
+        var _spWebPartComponents = new Object();//]]>
+    </script>
+    <script type="text/javascript" >
+        <!--
+        //-->
+    </script>
+    <script type="text/javascript">
+        //<![CDATA[
+        var __cultureInfo = '{"name":"nl-NL","numberFormat":{"CurrencyDecimalDigits":2,"CurrencyDecimalSeparator":",","IsReadOnly":true,"CurrencyGroupSizes":[3],"NumberGroupSizes":[3],"PercentGroupSizes":[3],"CurrencyGroupSeparator":".","CurrencySymbol":"€","NaNSymbol":"NaN","CurrencyNegativePattern":12,"NumberNegativePattern":1,"PercentPositivePattern":0,"PercentNegativePattern":0,"NegativeInfinitySymbol":"-Infinity","NegativeSign":"-","NumberDecimalDigits":2,"NumberDecimalSeparator":",","NumberGroupSeparator":".","CurrencyPositivePattern":2,"PositiveInfinitySymbol":"Infinity","PositiveSign":"+","PercentDecimalDigits":2,"PercentDecimalSeparator":",","PercentGroupSeparator":".","PercentSymbol":"%","PerMilleSymbol":"‰","NativeDigits":["0","1","2","3","4","5","6","7","8","9"],"DigitSubstitution":1},"dateTimeFormat":{"AMDesignator":"","Calendar":{"MinSupportedDateTime":"\/Date(-62135596800000)\/","MaxSupportedDateTime":"\/Date(253402297199999)\/","AlgorithmType":1,"CalendarType":1,"Eras":[1],"TwoDigitYearMax":2029,"IsReadOnly":true},"DateSeparator":"-","FirstDayOfWeek":1,"CalendarWeekRule":2,"FullDateTimePattern":"dddd d MMMM yyyy H:mm:ss","LongDatePattern":"dddd d MMMM yyyy","LongTimePattern":"H:mm:ss","MonthDayPattern":"dd MMMM","PMDesignator":"","RFC1123Pattern":"ddd, dd MMM yyyy HH\u0027:\u0027mm\u0027:\u0027ss \u0027GMT\u0027","ShortDatePattern":"d-M-yyyy","ShortTimePattern":"H:mm","SortableDateTimePattern":"yyyy\u0027-\u0027MM\u0027-\u0027dd\u0027T\u0027HH\u0027:\u0027mm\u0027:\u0027ss","TimeSeparator":":","UniversalSortableDateTimePattern":"yyyy\u0027-\u0027MM\u0027-\u0027dd HH\u0027:\u0027mm\u0027:\u0027ss\u0027Z\u0027","YearMonthPattern":"MMMM yyyy","AbbreviatedDayNames":["zo","ma","di","wo","do","vr","za"],"ShortestDayNames":["zo","ma","di","wo","do","vr","za"],"DayNames":["zondag","maandag","dinsdag","woensdag","donderdag","vrijdag","zaterdag"],"AbbreviatedMonthNames":["jan","feb","mrt","apr","mei","jun","jul","aug","sep","okt","nov","dec",""],"MonthNames":["januari","februari","maart","april","mei","juni","juli","augustus","september","oktober","november","december",""],"IsReadOnly":true,"NativeCalendarName":"Gregoriaanse kalender","AbbreviatedMonthGenitiveNames":["jan","feb","mrt","apr","mei","jun","jul","aug","sep","okt","nov","dec",""],"MonthGenitiveNames":["januari","februari","maart","april","mei","juni","juli","augustus","september","oktober","november","december",""]}}';//]]>
+    </script>
+
+    <script src="/_layouts/blank.js?rev=QGOYAJlouiWgFRlhHVlMKA%3D%3D" type="text/javascript"></script>
+    <script type="text/javascript">
+        //<![CDATA[
+        if (typeof(DeferWebFormInitCallback) == 'function') DeferWebFormInitCallback();function WebForm_OnSubmit() {
+            UpdateFormDigest('\u002f', 1440000);
+            var workspaceElem = GetCachedElement("s4-workspace");
+            if (workspaceElem != null)
+            {
+                var scrollElem = GetCachedElement("_maintainWorkspaceScrollPosition");
+                if (scrollElem != null)
+                {
+                    scrollElem.value = workspaceElem.scrollTop;
+                }
+            };
+            if (typeof(_spFormOnSubmitWrapper) != 'undefined') {return _spFormOnSubmitWrapper();} else {return true;};
+            return true;
+        }
+        //]]>
+    </script>
+
+    <div>
+
+        <input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="0CDC50BF" />
+    </div>
+    <script type="text/javascript">
+        //<![CDATA[
+        Sys.WebForms.PageRequestManager._initialize('ctl00$ScriptManager', document.getElementById('aspnetForm'));
+        Sys.WebForms.PageRequestManager.getInstance()._updateControls(['fctl00$WebPartAdderUpdatePanel','tctl00$panelZone'], [], ['ctl00$WebPartAdder'], 90);
+        //]]>
+    </script>
+
+
+    <span id="TurnOnAccessibility" style="display:none" class="s4-notdlg">
+		<a id="linkTurnOnAcc" href="#" class="ms-TurnOnAcc" onclick="SetIsAccessibilityFeatureEnabled(true);UpdateAccessibilityUI();document.getElementById('linkTurnOffAcc').focus();return false;">
+			Meer toegankelijke modus inschakelen
+		</a>
+	</span>
+    <span id="TurnOffAccessibility" style="display:none" class="s4-notdlg">
+		<a id="linkTurnOffAcc" href="#" class="ms-TurnOffAcc" onclick="SetIsAccessibilityFeatureEnabled(false);UpdateAccessibilityUI();document.getElementById('linkTurnOnAcc').focus();return false;">
+	Meer toegankelijke modus uitschakelen</a>
+	</span>
+    <span class="s4-notdlg s4-skipribbonshortcut">
+		<a href="javascript:;" onclick="javascript:this.href='#startNavigation';" class="ms-SkiptoNavigation" accesskey="Y">
+	Lintopdrachten overslaan</a>
+	</span>
+    <span class="s4-notdlg">
+		<a href="javascript:;" onclick="javascript:this.href='#mainContent';" class="ms-SkiptoMainContent" accesskey="X">
+	Verdergaan naar hoofdinhoud</a>
+	</span>
+    <a id="HiddenAnchor" href="javascript:;" style="display:none;"></a>
+
+    <!-- START HS -->
+    <table cellpadding="0" cellspacing="0" class="MainTable">
+        <tr>
+            <td colspan="2">
+                <div id="s4-statusbarcontainer">
+                    <div id="pageStatusBar" class="s4-status-s1"></div>
+                </div>
+
+
+
+                <span id="ctl00_SPNavigation_ctl00_publishingConsoleV4_publishingRibbon"></span>
+
+
+
+
+                <div id="ctl00_WebPartAdderUpdatePanel">
+
+                    <span id="ctl00_WebPartAdder"></span>
+
+                </div>
+                <!-- START RIBBON -->
+                <div class="zhg-ribbon">
+                    <div class='ms-cui-ribbonTopBars'><div class='ms-cui-topBar1'></div><div class='ms-cui-topBar2'><div id='RibbonContainer-TabRowLeft' class='ms-cui-TabRowLeft ms-siteactionscontainer s4-notdlg'>
+						<span class="ms-siteactionsmenu" id="siteactiontd">
+						   </span>
+                        <span class="s4-breadcrumb-anchor"><span style="height:16px;width:16px;position:relative;display:inline-block;overflow:hidden;" class="s4-clust"><a id="GlobalBreadCrumbNavPopout-anchor" onclick="CoreInvoke('callOpenBreadcrumbMenu', event, 'GlobalBreadCrumbNavPopout-anchor', 'GlobalBreadCrumbNavPopout-menu', 'GlobalBreadCrumbNavPopout-img', 's4-breadcrumb-anchor-open', 'ltr', '', false); return false;" onmouseover="" onmouseout="" title="Omhoog" href="javascript:;" style="display:inline-block;height:16px;width:16px;"><img src="/_layouts/images/fgimg.png" alt="Omhoog" style="border:0;position:absolute;left:-0px !important;top:-112px !important;" /></a></span></span><div class="ms-popoutMenu s4-breadcrumb-menu" id="GlobalBreadCrumbNavPopout-menu" style="display:none;">
+                        <div class="s4-breadcrumb-top">
+                            <span id="ctl00_GlobalBreadCrumbNavPopout_Label1" class="s4-breadcrumb-header">Deze paginalocatie is:</span>
+                        </div>
+
+                        <ul class="s4-breadcrumb">
+                            <li class="s4-breadcrumbCurrentNode"><span class="s4-breadcrumb-arrowcont"><span style="height:16px;width:16px;position:relative;display:inline-block;overflow:hidden;" class="s4-clust s4-breadcrumb"><img src="/_layouts/images/fgimg.png" alt="" style="border-width:0px;position:absolute;left:-0px !important;top:-353px !important;" /></span></span><span class="s4-breadcrumbCurrentNode">Home</span></li>
+                        </ul>
+
+                    </div>
+
+                    </div><div id='RibbonContainer-TabRowRight' class='ms-cui-TabRowRight s4-trc-container s4-notdlg'>
+                    </div></div></div>
+                    <script type="text/javascript">
+                        //<![CDATA[
+                        var g_commandUIHandlers = {"name":"CommandHandlers","attrs":{},"children":[]};
+                        //]]>
+                    </script>
+                </div>
+                <!-- END RIBBON -->
+            </td>
+        </tr>
+        <tr class="MainHeader">
+            <td colspan="2" valign="top">
+                <table class="MainHeader-bgimage" border="0" cellpadding="0" cellspacing="0" style="height:75px">
+                    <tr>
+                        <td valign="top">
+                            <img id="ctl00_onetidHeadbnnr0" src="/Style%20Library/dhsNL/images/schoolbanner.jpg" alt="Home" style="border-width:0px;" /></td>
+                        <td align="right" valign="bottom" style="height:75px">
+                            <table cellpadding="0" cellspacing="0" class="ms-globallinks">
+                                <tr>
+                                    <td class="ms-globallinks">
+
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+        <tr class="MainNav">
+            <td colspan="2" valign="top">
+                <a name="startNavigation"></a>
+
+
+                <div id="zz1_TopNavigationMenuV4" class="HSTopNav">
+                    <div class="menu horizontal menu-horizontal">
+                        <ul class="root static">
+                            <li class="static selected"><a class="static selected menu-item" href="/Paginas/default.aspx" accesskey="1"><span class="additional-background"><span class="menu-item-text">Home</span><span class="ms-hidden">Momenteel geselecteerd</span></span></a><ul class="static">
+                                <li class="static dynamic-children"><a class="static dynamic-children menu-item" title="Informatie over de school" href="/school/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">School</span></span></a><ul class="dynamic">
+                                    <li class="dynamic"><a class="dynamic menu-item" href="/school/Paginas/Team.aspx"><span class="additional-background"><span class="menu-item-text">Team</span></span></a></li><li class="dynamic dynamic-children"><a class="dynamic dynamic-children menu-item" href="/school/praktischeinformatie/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">Praktische informatie</span></span></a><ul class="dynamic">
+                                    <li class="dynamic"><a class="dynamic menu-item" href="/school/praktischeinformatie/Paginas/Schooltijden.aspx"><span class="additional-background"><span class="menu-item-text">Schooltijden</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/school/praktischeinformatie/Paginas/De-organisatie.aspx"><span class="additional-background"><span class="menu-item-text">De organisatie</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/school/praktischeinformatie/Paginas/Schoolbenodigdheden.aspx"><span class="additional-background"><span class="menu-item-text">Schoolbenodigdheden</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/school/praktischeinformatie/Paginas/Schoolmelk.aspx"><span class="additional-background"><span class="menu-item-text">Schoolmelk</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/school/praktischeinformatie/Paginas/Te-laat-op-school.aspx"><span class="additional-background"><span class="menu-item-text">Te laat op school</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/school/praktischeinformatie/Paginas/Ziekmelding.aspx"><span class="additional-background"><span class="menu-item-text">Ziekmelding</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/school/praktischeinformatie/Paginas/Leerplicht-en-verlofaanvragen.aspx"><span class="additional-background"><span class="menu-item-text">Leerplicht en verlofaanvragen</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/school/praktischeinformatie/Paginas/Adressen.aspx"><span class="additional-background"><span class="menu-item-text">Adressen</span></span></a></li>
+                                </ul></li><li class="dynamic"><a class="dynamic menu-item" href="/school/Paginas/Onderwijsinhoud.aspx"><span class="additional-background"><span class="menu-item-text">Onderwijsinhoud</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/school/Paginas/Vakantie%20en%20vrije%20dagen.aspx"><span class="additional-background"><span class="menu-item-text">Vakanties en vrije dagen</span></span></a></li>
+                                </ul></li><li class="static"><a class="static menu-item" href="/kinderopvang/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">Kinderopvang</span></span></a></li><li class="static dynamic-children"><a class="static dynamic-children menu-item" title="Informatie voor ouders" href="/ouders/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">Ouders</span></span></a><ul class="dynamic">
+                                <li class="dynamic dynamic-children"><a class="dynamic dynamic-children menu-item" href="/ouders/ouderraad/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">Ouderraad</span></span></a><ul class="dynamic">
+                                    <li class="dynamic"><a class="dynamic menu-item" href="/ouders/ouderraad/Paginas/Locatie-JDG.aspx"><span class="additional-background"><span class="menu-item-text">Locatie JDG</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/ouders/ouderraad/Paginas/Locatie-VHB.aspx"><span class="additional-background"><span class="menu-item-text">Locatie VHB</span></span></a></li>
+                                </ul></li><li class="dynamic"><a class="dynamic menu-item" href="/ouders/Paginas/Medezeggenschapsraad.aspx"><span class="additional-background"><span class="menu-item-text">Medezeggenschapsraad</span></span></a></li><li class="dynamic dynamic-children"><a class="dynamic dynamic-children menu-item" href="/ouders/stichtingdvv/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">Stichting &#39;De vrienden van&#39;</span></span></a><ul class="dynamic">
+                                <li class="dynamic"><a class="dynamic menu-item" href="/ouders/stichtingdvv/Paginas/Locatie-JdG.aspx"><span class="additional-background"><span class="menu-item-text">Locatie JdG</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/ouders/stichtingdvv/Paginas/Locatie-VHb.aspx"><span class="additional-background"><span class="menu-item-text">Locatie VHb</span></span></a></li>
+                            </ul></li><li class="dynamic"><a class="dynamic menu-item" href="/ouders/Paginas/Ouderbijdrage.aspx"><span class="additional-background"><span class="menu-item-text">Ouderbijdrage</span></span></a></li><li class="dynamic"><a class="dynamic menu-item" href="/ouders/Paginas/Klachtenregeling.aspx"><span class="additional-background"><span class="menu-item-text">Klachtenregeling</span></span></a></li>
+                            </ul></li><li class="static"><a class="static menu-item" href="/schoolgids/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">Schoolgids</span></span></a></li><li class="static"><a class="static menu-item" title="Contactgegevens" href="/contact/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">Contact</span></span></a></li><li class="static"><a class="static menu-item" href="/inschrijven/Paginas/default.aspx"><span class="additional-background"><span class="menu-item-text">Inschrijven</span></span></a></li>
+                            </ul></li>
+                        </ul>
+                    </div>
+                </div>
+
+
+
+            </td>
+        </tr>
+        <tr class="MainContent">
+            <td class="LeftMenu" style="width:192px">
+                <table class="LeftMenuTop" cellpadding="0" cellspacing="0" width="192px">
+                    <tr style="width:192px">
+                        <td class="LeftMenuTop" valign="top" style="min-height:300px;width:192px;">
+                            <!-- START LEFTNAVIGATION -->
+                            <div id="leftnavigation">
+
+
+
+
+
+
+
+
+
+
+                            </div>
+                            <!-- END LEFTNAVIGATION -->
+                            <div id="search" style="padding:12px;">
+
+
+
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+            <td class="RightContent" valign="top" align="left" style="width:9999px;">
+                <!-- START MAINCONTENT -->
+                <div id="maincontent">
+                    <!---->
+
+                    <a name="mainContent"></a>
+
+                    <table id="TweeKolommenGelijk" width="100%" border="0" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td class="LeftColumn" valign="top">
+                                <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td id="MSOZoneCell_WebPartWPQ4" valign="top" class="s4-wpcell-plain"><table class="s4-wpTopTable" border="0" cellpadding="0" cellspacing="0" width="100%" style="width:500px">
+                                            <tr>
+                                                <td class="ms-WPBorderBorderOnly" valign="top"><div WebPartID="db9b3497-f32d-4d69-b367-f6c9dd749d0e" HasPers="false" id="WebPartWPQ4" class="ms-WPBody noindex" allowDelete="false" style="width:500px;overflow:auto;" ><div class="ms-rteForeColor-3 ms-rteThemeFontFace-2" style="text-align: center"><strong>&#160;</strong><span class="ms-rteFontSize-4"><strong>Jacob de </strong><span><strong>Graefflaan</strong></span></span></div>
+                                                    <div class="ms-rteForeColor-3 ms-rteThemeFontFace-2" style="text-align: center"><span class="ms-rteFontSize-4"><span><img alt="Naamloos-2.jpg" src="/PublishingImages/locatiefoto%20jdg%2001-001kopie.jpg" style="height: 270px; width: 450px; margin: 5px"/> <div class="ms-rteThemeForeColor-4-3" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong></strong></span><span class="ms-rteThemeForeColor-2-1">&#160;</span><span class="ms-rteThemeForeColor-2-1" style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong><a href="/Paginas/Nieuws-JdG.aspx">NIEUWS</a></strong></span></div>
+<div class="ms-rteThemeForeColor-2-1" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong><a href="/Paginas/Agenda-JdG.aspx">AGENDA</a></strong></span></div>
+<div class="ms-rteThemeForeColor-2-1" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong><a href="/groepenjdg">GROEPEN</a></strong></span></div>
+<div class="ms-rteThemeForeColor-2-1" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong><a href="/nieuwbouw/Paginas/default.aspx">NIEUWBOUW</a></strong></span></div></span></span></div></div></td>
+                                            </tr>
+                                        </table><div class="ms-PartSpacingVertical"></div></td>
+                                    </tr><tr>
+                                    <td id="MSOZoneCell_WebPartWPQ3" valign="top" class="s4-wpcell-plain"><table class="s4-wpTopTable" border="0" cellpadding="0" cellspacing="0" width="100%" style="width:500px">
+                                        <tr>
+                                            <td class="ms-WPBorderBorderOnly" valign="top"><div WebPartID="8f8fdcc1-12bf-4552-a3bd-e3a27057b136" HasPers="false" id="WebPartWPQ3" class="ms-WPBody noindex" allowDelete="false" style="width:500px;overflow:auto;" ><div class="ms-rteThemeForeColor-4-3" style="text-align: center"><strong>​</strong></div>
+                                                <div class="ms-rteThemeForeColor-4-3" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong>Jacob de </strong><span class="SpellE"><strong>Graefflaan</strong></span><strong> 10-14</strong></span></div>
+                                                <span class="ms-rteThemeForeColor-4-3" style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;; text-align: center"><div><strong>2517 JM Den Haag</strong></div></span><div class="ms-rteThemeForeColor-4-3" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong>070-3451256</strong></span>&#160;</div></div></td>
+                                        </tr>
+                                    </table></td>
+                                </tr>
+                                </table>
+                            </td>
+                            <td class="RightColumn" valign="top">
+                                <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                    <tr>
+                                        <td id="MSOZoneCell_WebPartWPQ5" valign="top" class="s4-wpcell-plain"><table class="s4-wpTopTable" border="0" cellpadding="0" cellspacing="0" width="100%" style="width:500px">
+                                            <tr>
+                                                <td class="ms-WPBorderBorderOnly" valign="top"><div WebPartID="2aaf0e03-d43c-4103-b334-c48e2fb09a0c" HasPers="false" id="WebPartWPQ5" class="ms-WPBody noindex" allowDelete="false" style="width:500px;overflow:auto;" ><div class="ms-rteForeColor-3 ms-rteFontSize-4" style="text-align: center">​<span style="font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong>Van Hoornbeekstraat</strong></span></div>
+                                                    <div class="ms-rteForeColor-3 ms-rteFontSize-4" style="text-align: center"><span style="font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><img alt="Naamloos-1.jpg" src="/PublishingImages/locatiefoto%20vhb%2001-001kopie.jpg" style="height: 270px; width: 450px; margin: 5px"/>&#160;<div class="ms-rteThemeForeColor-2-1" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong><a href="/Paginas/Nieuws-VHb.aspx">NIEUWS </a></strong></span></div>
+<div class="ms-rteThemeForeColor-2-1" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong><a href="/Paginas/Agenda-VHb.aspx">AGENDA</a></strong></span></div>
+<div class="ms-rteThemeForeColor-2-1" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong><a href="/groepenvhb">GROEPEN</a></strong></span></div>
+<div class="ms-rteThemeForeColor-2-1" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong>&#160;</strong></span></div></span></div></div></td>
+                                            </tr>
+                                        </table><div class="ms-PartSpacingVertical"></div></td>
+                                    </tr><tr>
+                                    <td id="MSOZoneCell_WebPartWPQ2" valign="top" class="s4-wpcell-plain"><table class="s4-wpTopTable" border="0" cellpadding="0" cellspacing="0" width="100%" style="width:500px">
+                                        <tr>
+                                            <td class="ms-WPBorderBorderOnly" valign="top"><div WebPartID="d5b05d78-7be8-4bd2-9ee2-2fc696f74f99" HasPers="false" id="WebPartWPQ2" class="ms-WPBody noindex" allowDelete="false" style="width:500px;overflow:auto;" ><div class="ms-rteThemeForeColor-4-3" style="text-align: center"><strong></strong>&#160;</div>
+                                                <div class="ms-rteThemeForeColor-4-3" style="text-align: center"><strong>​</strong><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong>Van Hoornbeekstraat 5 </strong></span></div>
+                                                <span class="ms-rteThemeForeColor-4-3" style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;; text-align: center"><div><strong>2582 RA Den Haag</strong></div></span><div class="ms-rteThemeForeColor-4-3" style="text-align: center"><span style="font-size: 13.5pt; font-family: &quot;arial&quot;, &quot;sans-serif&quot;"><strong>070-3541460</strong></span></div></div></td>
+                                        </tr>
+                                    </table></td>
+                                </tr>
+                                </table>
+                            </td>
+                        </tr>
+                    </table>
+
+                </div>
+                <!-- END MAINCONTENT -->
+            </td>
+        </tr>
+        <tr>
+            <td class="LeftFooter">
+                &nbsp;
+            </td>
+            <td class="MainFooter">
+                <div class="s4-notdlg" style="clear: both;">
+                    <a href="https://www.dehaagsescholen.nl" target="_new">
+                        <img src="/Style%20Library/dhsNL/images/DHS-keurmerk-wit-100px.jpg" alt="DHS Logo" style="border-width:0px;" />
+                    </a>
+                </div>
+            </td>
+        </tr>
+
+    </table>
+    <!-- START PANEL VISIBLE=FALSE -->
+
+    <!-- END PANEL VISIBLE=FALSE -->
+    <!-- end hs -->
+
+
+
+
+    <div id="ctl00_panelZone">
+        <div style='display:none' id='hidZone'><menu class="ms-SrvMenuUI">
+            <ie:menuitem id="MSOMenu_Help" iconsrc="/_layouts/images/HelpIcon.gif" onmenuclick="MSOWebPartPage_SetNewWindowLocation(MenuWebPart.getAttribute(&#39;helpLink&#39;), MenuWebPart.getAttribute(&#39;helpMode&#39;))" text="Help" type="option" style="display:none">
+
+            </ie:menuitem>
+        </menu></div>
+    </div><input type='hidden' id='_wpcmWpid' name='_wpcmWpid' value='' /><input type='hidden' id='wpcmVal' name='wpcmVal' value=''/>
+
+    <script type="text/javascript">
+        //<![CDATA[
+
+        WebForm_InitCallback();var _spFormDigestRefreshInterval = 1440000;
+        function EnsureScripts(scriptInfoList, finalFunction)
+        {
+            if (scriptInfoList.length == 0)
+            {
+                finalFunction();
+            }
+            else
+            {
+                var scriptInfo = scriptInfoList.shift();
+                var rest = function () { EnsureScripts(scriptInfoList, finalFunction); };
+                var defd;
+                try
+                {
+                    eval('defd = typeof(' + scriptInfo[1] + ');');
+                }
+                catch (e)
+                {
+                    defd = 'undefined';
+                }
+                if (scriptInfo[2])
+                {
+                    EnsureScript(scriptInfo[0], defd, null);
+                    ExecuteOrDelayUntilScriptLoaded(rest, scriptInfo[0]);
+                }
+                else
+                {
+                    EnsureScript(scriptInfo[0], defd, rest);
+                }
+            }
+        }
+        function PublishingRibbonUpdateRibbon()
+        {
+            var pageManager = SP.Ribbon.PageManager.get_instance();
+            if (pageManager)
+            {
+                pageManager.get_commandDispatcher().executeCommand('appstatechanged', null);
+            }
+        }var _fV4UI = true;
+        function _RegisterWebPartPageCUI()
+        {
+            var initInfo = {editable: false,isEditMode: false,allowWebPartAdder: false,listId: "{7a506229-1b72-4548-8333-7876f74456eb}",itemId: 1,recycleBinEnabled: true,enableMinorVersioning: true,enableModeration: false,forceCheckout: true,rootFolderUrl: "\u002fPaginas",itemPermissions:{High:16,Low:196673}};
+            SP.Ribbon.WebPartComponent.registerWithPageManager(initInfo);
+            var wpcomp = SP.Ribbon.WebPartComponent.get_instance();
+            var hid;
+            hid = document.getElementById("_wpSelected");
+            if (hid != null)
+            {
+                var wpid = hid.value;
+                if (wpid.length > 0)
+                {
+                    var zc = document.getElementById(wpid);
+                    if (zc != null)
+                        wpcomp.selectWebPart(zc, false);
+                }
+            }
+            hid = document.getElementById("_wzSelected");
+            if (hid != null)
+            {
+                var wzid = hid.value;
+                if (wzid.length > 0)
+                {
+                    wpcomp.selectWebPartZone(null, wzid);
+                }
+            }
+        }
+        ExecuteOrDelayUntilScriptLoaded(_RegisterWebPartPageCUI, "sp.ribbon.js"); var __wpmExportWarning='This Web Part Page has been personalized. As a result, one or more Web Part properties may contain confidential information. Make sure the properties contain information that is safe for others to read. After exporting this Web Part, view properties in the Web Part description file (.WebPart) by using a text editor such as Microsoft Notepad.';var __wpmCloseProviderWarning='You are about to close this Web Part.  It is currently providing data to other Web Parts, and these connections will be deleted if this Web Part is closed.  To close this Web Part, click OK.  To keep this Web Part, click Cancel.';var __wpmDeleteWarning='You are about to permanently delete this Web Part.  Are you sure you want to do this?  To delete this Web Part, click OK.  To keep this Web Part, click Cancel.';
+        ExecuteOrDelayUntilScriptLoaded(
+                function()
+                {
+                    var initInfo =
+                    {
+                        itemPermMasks: {High:16,Low:196673},
+                        listPermMasks: {High:16,Low:196673},
+                        listId: "7a506229-1b72-4548-8333-7876f74456eb",
+                        itemId: 1,
+                        workflowsAssociated: false,
+                        editable: false,
+                        doNotShowProperties: false,
+                        enableVersioning: true
+                    };
+                    SP.Ribbon.DocLibAspxPageComponent.registerWithPageManager(initInfo);
+                },
+                "sp.ribbon.js");
+        var g_disableCheckoutInEditMode = false;
+        var _spWebPermMasks = {High:16,Low:196673};//]]>
+    </script>
+    <script type="text/javascript">
+        // <![CDATA[
+        // ]]>
+    </script>
+    <script type="text/javascript">RegisterSod("sp.core.js", "\u002f_layouts\u002fsp.core.js?rev=7ByNlH\u00252BvcgRJg\u00252BRCctdC0w\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSod("sp.res.resx", "\u002f_layouts\u002fScriptResx.ashx?culture=nl\u00252Dnl\u0026name=SP\u00252ERes\u0026rev=D\u00252BjtaEy\u00252FEZsy7BOVRiozXw\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSod("sp.ui.dialog.js", "\u002f_layouts\u002fsp.ui.dialog.js?rev=IuXtJ2CrScK6oX4zOTTy\u00252BA\u00253D\u00253D");RegisterSodDep("sp.ui.dialog.js", "sp.core.js");RegisterSodDep("sp.ui.dialog.js", "sp.res.resx");</script>
+    <script type="text/javascript">RegisterSod("core.js", "\u002f_layouts\u002f1043\u002fcore.js?rev=6a4z4xA\u00252BaejN7L9ZHmvLVw\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSod("sp.runtime.js", "\u002f_layouts\u002fsp.runtime.js?rev=9sKdsC9N6p2BiRk3313M7Q\u00253D\u00253D");RegisterSodDep("sp.runtime.js", "sp.core.js");RegisterSodDep("sp.runtime.js", "sp.res.resx");</script>
+    <script type="text/javascript">RegisterSod("sp.js", "\u002f_layouts\u002fsp.js?rev=JmFQMEfR9bYx6G6TrWzSLw\u00253D\u00253D");RegisterSodDep("sp.js", "sp.core.js");RegisterSodDep("sp.js", "sp.runtime.js");RegisterSodDep("sp.js", "sp.ui.dialog.js");RegisterSodDep("sp.js", "sp.res.resx");</script>
+    <script type="text/javascript">RegisterSod("cui.js", "\u002f_layouts\u002fcui.js?rev=wvoVpqlQb30nGo4DjDk8Kg\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSod("inplview", "\u002f_layouts\u002finplview.js?rev=AohvE9XEf\u00252FI78tuaw1TGAA\u00253D\u00253D");RegisterSodDep("inplview", "core.js");RegisterSodDep("inplview", "sp.js");</script>
+    <script type="text/javascript">RegisterSod("ribbon", "\u002f_layouts\u002fsp.ribbon.js?rev=F\u00252BUEJ66rbXzSvpf7nN69wQ\u00253D\u00253D");RegisterSodDep("ribbon", "core.js");RegisterSodDep("ribbon", "sp.core.js");RegisterSodDep("ribbon", "sp.js");RegisterSodDep("ribbon", "cui.js");RegisterSodDep("ribbon", "sp.res.resx");RegisterSodDep("ribbon", "sp.runtime.js");RegisterSodDep("ribbon", "inplview");</script>
+    <script type="text/javascript">RegisterSod("sp.publishing.resources.resx", "\u002f_layouts\u002fScriptResx.ashx?culture=nl\u00252Dnl\u0026name=SP\u00252EPublishing\u00252EResources\u0026rev=fQOCdWn7pdzlVG8cMvY4QQ\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSod("sp.ui.pub.ribbon.js", "\u002f_layouts\u002fsp.ui.pub.ribbon.js?rev=RGQSBI9Dm0E345iq\u00252FxUpHg\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSod("msstring.js", "\u002f_layouts\u002f1043\u002fmsstring.js?rev=g9k988OeFFfwyCj6ebmelg\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSod("browserScript", "\u002f_layouts\u002f1043\u002fie55up.js?rev=aLkCI\u00252BqMbk0\u00252BXpjAY7eBcA\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSod("WPAdderClass", "\u002f_layouts\u002fwpadder.js?rev=hnGJJEMcU5XH\u00252BCq7PlSxJw\u00253D\u00253D");</script>
+    <script type="text/javascript">RegisterSodDep("browserScript", "msstring.js");</script>
+    <script type="text/javascript">
+        //<![CDATA[
+        Sys.Application.initialize();
+        function init_zz1_TopNavigationMenuV4() {$create(SP.UI.AspMenu, null, null, null, $get('zz1_TopNavigationMenuV4'));}ExecuteOrDelayUntilScriptLoaded(init_zz1_TopNavigationMenuV4, 'sp.js');
+        //]]>
+    </script>
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
It is very possible that pages include namespaced tags without
actual namespace definitions. For example, `<ie:menuitem>`

This PR ensures that such malformed elements are gracefully
handled when converting to a w3c object tree.