### PR TITLE
Accept a custom SSL socket factory

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 jsoup changelog
 
 *** Release 1.11.3 [PENDING]
+  * Improvement: accept a custom SSL socket factory
+
   * Improvement: CDATA sections are now treated as whitespace preserving (regardless of the containing element), and are
     round-tripped into output HTML.
     <https://github.com/jhy/jsoup/issues/406>

--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -12,6 +12,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import javax.net.ssl.SSLSocketFactory;
+
 /**
  * A Connection provides a convenient interface to fetch content from the web, and parse them into Documents.
  * <p>
@@ -164,6 +166,13 @@ public interface Connection {
      * disabled.
      */
     Connection validateTLSCertificates(boolean value);
+
+    /**
+     * Set custom SSL socket factory
+     * @param sslSocketFactory custom SSL socket factory
+     * @return this Connection, for chaining
+     */
+    Connection sslSocketFactory(SSLSocketFactory sslSocketFactory);
 
     /**
      * Add a request data parameter. Request parameters are sent in the request query string for GETs, and in the
@@ -603,6 +612,18 @@ public interface Connection {
          * disabled.
          */
         void validateTLSCertificates(boolean value);
+
+        /**
+         * Get the custom SSL socket factory
+         * @return custom SSL socket factory
+         */
+        SSLSocketFactory sslSocketFactory();
+
+        /**
+         * Set custom SSL socket factory.
+         * @param sslSocketFactory SSL socket factory
+         */
+        void sslSocketFactory(SSLSocketFactory sslSocketFactory);
 
         /**
          * Add a data parameter to the request


### PR DESCRIPTION
This way we can still control the SSL handshake, without disabling certification validation altogether.