### PR TITLE
Allow HtmlTreeBuilder subclasses

### DIFF
--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -56,8 +56,6 @@ public class HtmlTreeBuilder extends TreeBuilder {
     private boolean fosterInserts; // if next inserts should be fostered
     private boolean fragmentParsing; // if parsing a fragment of html
 
-    HtmlTreeBuilder() {}
-
     ParseSettings defaultSettings() {
         return ParseSettings.htmlDefault;
     }

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -381,7 +381,7 @@ abstract class Token {
         return type == TokenType.EOF;
     }
 
-    enum TokenType {
+    public enum TokenType {
         Doctype,
         StartTag,
         EndTag,


### PR DESCRIPTION
It would be extremely useful to be able to extend the HTML parser. For example, in our case we want to keep track of the line numbers for each tag in the original HTML output. Rather than adding every possible edge case to the standard HtmlTreeBuilder, it would be nice if people would be allowed to create their own subclasses.

Jsoup is currently a bit consistent in terms of allowing this. XmlTreeBuilder does allow subclasses, but HtmlTreeBuilder has a package-private constructor that prevents subclasses. This obviously has downsides in terms of maintainability from your side: allowing user-defined extensions would increase the chance that those subclasses will break in case of future changes to the HtmlTreeBuilder API. However, from looking at some of the issues it appears that obtaining additional information during HTML parsing is a common use case, so in this case the benefits for users would (IMO) outweigh the potential issues.