### PR TITLE
Parse invalid unicode escapes as Windows-1252 instead [Fixes #1034]

### DIFF
--- a/src/main/java/org/jsoup/parser/Tokeniser.java
+++ b/src/main/java/org/jsoup/parser/Tokeniser.java
@@ -13,6 +13,17 @@ final class Tokeniser {
     static final char replacementChar = '\uFFFD'; // replaces null character
     private static final char[] notCharRefCharsSorted = new char[]{'\t', '\n', '\r', '\f', ' ', '<', '&'};
 
+    // Some illegal character escapes are parsed by browsers as windows-1252 instead. See issue #1034
+    static final int win1252ExtensionsStart = 0x80;
+    static final int[] win1252Extensions = new int[] {
+            // we could build this manually, but Windows-1252 is not a standard java charset so that could break on
+            // some platforms - this table is verified with a test
+            0x20AC, 0x0081, 0x201A, 0x0192, 0x201E, 0x2026, 0x2020, 0x2021,
+            0x02C6, 0x2030, 0x0160, 0x2039, 0x0152, 0x008D, 0x017D, 0x008F,
+            0x0090, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014,
+            0x02DC, 0x2122, 0x0161, 0x203A, 0x0153, 0x009D, 0x017E, 0x0178,
+    };
+
     static {
         Arrays.sort(notCharRefCharsSorted);
     }
@@ -148,6 +159,12 @@ final class Tokeniser {
                 codeRef[0] = replacementChar;
                 return codeRef;
             } else {
+                // fix illegal unicode characters to match browser behavior
+                if (charval >= win1252ExtensionsStart && charval < win1252ExtensionsStart + win1252Extensions.length) {
+                    characterReferenceError("character is not a valid unicode code point");
+                    charval = win1252Extensions[charval - win1252ExtensionsStart];
+                }
+
                 // todo: implement number replacement table
                 // todo: check for extra illegal unicode points as parse errors
                 codeRef[0] = charval;


### PR DESCRIPTION
See #1034