### PR TITLE
Add methods to get all the element siblings before or after current element

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -688,6 +688,26 @@ public class Element extends Node {
     }
 
     /**
+     * Get all the siblings after this element.
+     *
+     * @return  all the siblings after this element, or null if there is no siblings after this
+     */
+    public List<Element> nextElementSiblings() {
+        if (parentNode == null) {
+            return null;
+        }
+
+        List<Element> siblings = parent().childElementsList();
+        int index = indexInList(this, siblings);
+        Validate.notNull(index);
+
+        if (siblings.size() > index + 1) {
+            return siblings.subList(index + 1, siblings.size());
+        }
+        return null;
+    }
+
+    /**
      * Gets the previous element sibling of this element.
      * @return the previous element, or null if there is no previous element
      * @see #nextElementSibling()
@@ -701,6 +721,26 @@ public class Element extends Node {
             return siblings.get(index-1);
         else
             return null;
+    }
+
+    /**
+     * Get all the element siblings before this element.
+     *
+     * @return all the previous element siblings, or null if no previous siblings
+     */
+    public List<Element> previousElementSiblings() {
+        if (parentNode == null) {
+            return null;
+        }
+
+        List<Element> siblings = parent().childElementsList();
+        int index = indexInList(this, siblings);
+        Validate.notNull(index);
+
+        if (index > 0 && index < siblings.size()) {
+            return siblings.subList(0, index);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -690,11 +690,11 @@ public class Element extends Node {
     /**
      * Get all the siblings after this element.
      *
-     * @return  all the siblings after this element, or null if there is no siblings after this
+     * @return  all the siblings after this element, or empty list if there is no siblings after this
      */
     public List<Element> nextElementSiblings() {
         if (parentNode == null) {
-            return null;
+            return Collections.emptyList();
         }
 
         List<Element> siblings = parent().childElementsList();
@@ -704,7 +704,7 @@ public class Element extends Node {
         if (siblings.size() > index + 1) {
             return siblings.subList(index + 1, siblings.size());
         }
-        return null;
+        return Collections.emptyList();
     }
 
     /**
@@ -726,11 +726,11 @@ public class Element extends Node {
     /**
      * Get all the element siblings before this element.
      *
-     * @return all the previous element siblings, or null if no previous siblings
+     * @return all the previous element siblings, or empty list if no previous siblings
      */
     public List<Element> previousElementSiblings() {
         if (parentNode == null) {
-            return null;
+            return Collections.emptyList();
         }
 
         List<Element> siblings = parent().childElementsList();
@@ -740,7 +740,7 @@ public class Element extends Node {
         if (index > 0 && index < siblings.size()) {
             return siblings.subList(0, index);
         }
-        return null;
+        return Collections.emptyList();
     }
 
     /**

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -14,12 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * Tests for Element (DOM stuff mostly).
@@ -1326,31 +1321,81 @@ public class ElementTest {
 
     @Test
     public void testNextElementSiblings() {
-        Document doc = Jsoup.parse("<li id='a'>a</li>" +
+        Document doc = Jsoup.parse("<ul id='ul'>" +
+            "<li id='a'>a</li>" +
             "<li id='b'>b</li>" +
-            "<li id='c'>c</li>");
+            "<li id='c'>c</li>" +
+            "</ul>" +
+            "<div id='div'>" +
+            "<li id='d'>d</li>" +
+            "</div>");
+
         Element element = doc.getElementById("a");
         List<Element> elementSiblings = element.nextElementSiblings();
         assertNotNull(elementSiblings);
         assertEquals(2, elementSiblings.size());
+        assertEquals("b", elementSiblings.get(0).id());
+        assertEquals("c", elementSiblings.get(1).id());
 
-        Element element1 = doc.getElementById("c");
+        Element element1 = doc.getElementById("b");
         List<Element> elementSiblings1 = element1.nextElementSiblings();
-        assertNull(elementSiblings1);
+        assertNotNull(elementSiblings1);
+        assertEquals(1, elementSiblings1.size());
+        assertEquals("c", elementSiblings1.get(0).id());
+
+        Element element2 = doc.getElementById("c");
+        List<Element> elementSiblings2 = element2.nextElementSiblings();
+        assertEquals(0, elementSiblings2.size());
+
+        Element ul = doc.getElementById("ul");
+        List<Element> elementSiblings3 = ul.nextElementSiblings();
+        assertNotNull(elementSiblings3);
+        assertEquals(1, elementSiblings3.size());
+        assertEquals("div", elementSiblings3.get(0).id());
+
+        Element div = doc.getElementById("div");
+        List<Element> elementSiblings4 = div.nextElementSiblings();
+        try {
+            Element elementSibling = elementSiblings4.get(0);
+            fail("This element should has no next siblings");
+        } catch (IndexOutOfBoundsException e) {
+        }
     }
 
     @Test
     public void testPreviousElementSiblings() {
-        Document doc = Jsoup.parse("<li id='a'>a</li>" +
+        Document doc = Jsoup.parse("<ul id='ul'>" +
+            "<li id='a'>a</li>" +
             "<li id='b'>b</li>" +
-            "<li id='c'>c</li>");
+            "<li id='c'>c</li>" +
+            "</ul>" +
+            "<div id='div'>" +
+            "<li id='d'>d</li>" +
+            "</div>");
+
         Element element = doc.getElementById("b");
         List<Element> elementSiblings = element.previousElementSiblings();
         assertNotNull(elementSiblings);
         assertEquals(1, elementSiblings.size());
+        assertEquals("a", elementSiblings.get(0).id());
 
         Element element1 = doc.getElementById("a");
         List<Element> elementSiblings1 = element1.previousElementSiblings();
-        assertNull(elementSiblings1);
+        assertEquals(0, elementSiblings1.size());
+
+        Element element2 = doc.getElementById("c");
+        List<Element> elementSiblings2 = element2.previousElementSiblings();
+        assertNotNull(elementSiblings2);
+        assertEquals(2, elementSiblings2.size());
+        assertEquals("a", elementSiblings2.get(0).id());
+        assertEquals("b", elementSiblings2.get(1).id());
+
+        Element ul = doc.getElementById("ul");
+        List<Element> elementSiblings3 = ul.previousElementSiblings();
+        try {
+            Element element3 = elementSiblings3.get(0);
+            fail("This element should has no previous siblings");
+        } catch (IndexOutOfBoundsException e) {
+        }
     }
 }

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -1324,4 +1324,33 @@ public class ElementTest {
         assertEquals("One Two", doc.text());
     }
 
+    @Test
+    public void testNextElementSiblings() {
+        Document doc = Jsoup.parse("<li id='a'>a</li>" +
+            "<li id='b'>b</li>" +
+            "<li id='c'>c</li>");
+        Element element = doc.getElementById("a");
+        List<Element> elementSiblings = element.nextElementSiblings();
+        assertNotNull(elementSiblings);
+        assertEquals(2, elementSiblings.size());
+
+        Element element1 = doc.getElementById("c");
+        List<Element> elementSiblings1 = element1.nextElementSiblings();
+        assertNull(elementSiblings1);
+    }
+
+    @Test
+    public void testPreviousElementSiblings() {
+        Document doc = Jsoup.parse("<li id='a'>a</li>" +
+            "<li id='b'>b</li>" +
+            "<li id='c'>c</li>");
+        Element element = doc.getElementById("b");
+        List<Element> elementSiblings = element.previousElementSiblings();
+        assertNotNull(elementSiblings);
+        assertEquals(1, elementSiblings.size());
+
+        Element element1 = doc.getElementById("a");
+        List<Element> elementSiblings1 = element1.previousElementSiblings();
+        assertNull(elementSiblings1);
+    }
 }


### PR DESCRIPTION
Currently, element can only get the nearest sibling before or after, but in my actual work, I ofter need to get **all** of it's siblings before or after. So I add this two methods, it's really helpful and convenient.

Hope to merge