### PR TITLE
fix: Non-breakable spaces are collapsed into a single space with .tex…

### DIFF
--- a/src/main/java/org/jsoup/internal/StringUtil.java
+++ b/src/main/java/org/jsoup/internal/StringUtil.java
@@ -127,8 +127,7 @@ public final class StringUtil {
      * @return true if code point is whitespace, false otherwise
      */
     public static boolean isActuallyWhitespace(int c){
-        return c == ' ' || c == '\t' || c == '\n' || c == '\f' || c == '\r' || c == 160;
-        // 160 is &nbsp; (non-breaking space). Not in the spec but expected.
+        return c == ' ' || c == '\t' || c == '\n' || c == '\f' || c == '\r';
     }
 
     public static boolean isInvisibleChar(int c) {

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -1191,20 +1191,20 @@ public class ElementTest {
         assertEquals("", childDoc.body().html()); // got moved out
 	}
 
-	@Test public void testNormalizesNbspInText() {
+	@Test public void testNbspArePreservedInText() {
         String escaped = "You can't always get what you&nbsp;want.";
-        String withNbsp = "You can't always get what you want."; // there is an nbsp char in there
+        String withNbsp = "You can't always get what you\u00a0want."; // there is an nbsp char in there
         Document doc = Jsoup.parse("<p>" + escaped);
         Element p = doc.select("p").first();
-        assertEquals("You can't always get what you want.", p.text()); // text is normalized
+        assertEquals(withNbsp, p.text()); // text is normalized
 
         assertEquals("<p>" + escaped + "</p>", p.outerHtml()); // html / whole text keeps &nbsp;
         assertEquals(withNbsp, p.textNodes().get(0).getWholeText());
         assertEquals(160, withNbsp.charAt(29));
 
-        Element matched = doc.select("p:contains(get what you want)").first();
+        Element matched = doc.select("p:contains(get what you\u00a0want)").first();
         assertEquals("p", matched.nodeName());
-        assertTrue(matched.is(":containsOwn(get what you want)"));
+        assertTrue(matched.is(":containsOwn(get what you\u00a0want)"));
     }
 
     @Test public void testNormalizesInvisiblesInText() {


### PR DESCRIPTION
fixes this issue:
Non-breakable spaces are collapsed into a single space with `.text()` #1063
