### PR TITLE
[Fix Issue #1070] Jsoup parse string not skipping BOM character correctly

### DIFF
--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -238,7 +238,7 @@ public final class DataUtil {
         return StringUtil.releaseBuilder(mime);
     }
 
-    private static BomCharset detectCharsetFromBom(final ByteBuffer byteData) {
+    public static BomCharset detectCharsetFromBom(final ByteBuffer byteData) {
         final Buffer buffer = byteData; // .mark and rewind used to return Buffer, now ByteBuffer, so cast for backward compat
         buffer.mark();
         byte[] bom = new byte[4];
@@ -259,9 +259,9 @@ public final class DataUtil {
         return null;
     }
 
-    private static class BomCharset {
-        private final String charset;
-        private final boolean offset;
+    public static class BomCharset {
+        public final String charset;
+        public final boolean offset;
 
         public BomCharset(String charset, boolean offset) {
             this.charset = charset;

--- a/src/test/java/org/jsoup/helper/DataUtilTest.java
+++ b/src/test/java/org/jsoup/helper/DataUtilTest.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import static org.jsoup.integration.ParseTest.getFile;
 import static org.junit.Assert.assertEquals;
@@ -162,6 +164,19 @@ public class DataUtilTest {
     public void supportsUTF8BOM() throws IOException {
         File in = getFile("/bomtests/bom_utf8.html");
         Document doc = Jsoup.parse(in, null, "http://example.com");
+        assertEquals("OK", doc.head().select("title").text());
+    }
+    
+    @Test
+    public void supportsUTF8BOMWithNormalStringParse() throws IOException {
+        // the difference of this test from the previous supportsUTF8BOM test is
+        // this test case uses Jsoup.parse(String) function
+        // where the string is directly passed into the parser
+        // instead of processed by DataUtil.parseInputStream()
+        
+        File in = getFile("/bomtests/bom_utf8.html");
+        String fileContent = new String(Files.readAllBytes(Paths.get(in.getPath())));
+        Document doc = Jsoup.parse(fileContent);
         assertEquals("OK", doc.head().select("title").text());
     }
 


### PR DESCRIPTION
Issue #1070 shows a case where Jsoup not parsing an HTML page correctly and putting all the <meta> information in the body instead of head. The problem can be reproducible only if use `Jsoup.parse(response.body())`. Using another method `Jsoup.connect(url).get()` won't reproduce the same problem.

After digging around for a while, it turns out that the HTML page has the BOM character `65279` in its first character. The reason that the second method, `Jsoup.connect(url).get()`, internally uses `DataUtil.parseInputStream()`, which handles the BOM character correctly. However, `Jsoup.parse(string)` constructs a `HTMLTreeBuilder` to parse the document directly, therefore the BOM handling process is not there.

This PR fixes this issue by introducing the same handling process in `TreeBuilder` constructor. Before it passes the input reader to the tokenizer, it reuses the same helper function `DataUtil.detectCharsetFromBom` to detect the BOM character, and skip the BOM character if needed.

This PR also adds a new test case in `DataUtilTest` to test if `Jsoup.parse(string)` can work correctly with BOM. After adding the fix, the problem in issue #1070 can produce the correct result.

There are already several efforts to fix the problem caused by the BOM character:
Issue #348 is the first issue mentioning the problem, and it is fixed in commit https://github.com/jhy/jsoup/commit/3f9f33d88355f22aefc7ea402da09fd1950289ce , this commit only fixes the issue in `parseByteData` (which later becomes `parseInputStream`).

Later there are several commits to refactor the BOM handling code, such as https://github.com/jhy/jsoup/commit/c3cbe1b64e7f66ff9f9b53f1388eb135e6693187 , https://github.com/jhy/jsoup/commit/4eb4f2b2e88a2f9e6c5c1e8d0477060954f24218

The latest issue mentioning the problem is Issue #1003, and the corresponding fix is in https://github.com/jhy/jsoup/commit/0f7e0cc373aced32629f5321c9521f81d8248647 , however, this commit still only fixes the function `parseInputStream`, which is not used by `Jsoup.parse(string)`.

@jhy I'm not sure if `TreeBuilder` class is the best place to put in the fix code. I am willing to devote more efforts to improve it if you could give some more advice. Thanks :)



