### PR TITLE
Oracle JDK10 build added to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
     - oraclejdk8
     - oraclejdk9
     - oraclejdk10
+    - oraclejdk11
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
     - openjdk7
     - oraclejdk8
     - oraclejdk9
+    - oraclejdk10
 
 cache:
     directories:


### PR DESCRIPTION
This adds a Oracle JDK10 CI build.

@jhy Does it make sense to add an OpenJDK10 build too?