### PR TITLE
Implemented redirect via HTML meta refresh tag support

### DIFF
--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -120,6 +120,15 @@ public interface Connection {
     Connection followRedirects(boolean followRedirects);
 
     /**
+     * Configures the connection to (not) follow the redirects defined in refresh meta tag of the HTML page.
+     * By default this is <b>false</b>. Note that if {@link #followRedirects(boolean)} is enabled and server redirect
+     * is present - it will override the meta redirect.
+     * @param followMetaRedirects true if meta redirects should be followed.
+     * @return this Connection, for chaining
+     */
+    Connection followMetaRedirects(boolean followMetaRedirects);
+
+    /**
      * Set the request method to use, GET or POST. Default is GET.
      * @param method HTTP request method
      * @return this Connection, for chaining
@@ -542,11 +551,27 @@ public interface Connection {
         boolean followRedirects();
 
         /**
+         * Get the current followMetaRedirects configuration
+         * @return true if followMetaRedirects is enabled.
+         */
+        boolean followMetaRedirects();
+
+        /**
          * Configures the request to (not) follow server redirects. By default this is <b>true</b>.
          * @param followRedirects true if server redirects should be followed.
          * @return this Request, for chaining
          */
         Request followRedirects(boolean followRedirects);
+
+        /**
+         * Configures the request to (not) follow the redirects defined in refresh meta tag of the HTML page.
+         * By default this is <b>false</b>. Note that if {@link #followRedirects(boolean)} is enabled and server redirect
+         * is present - it will override the meta redirect.
+         *
+         * @param followMetaRedirects true if meta redirects should be followed.
+         * @return this Request, for chaining
+         */
+        Request followMetaRedirects(boolean followMetaRedirects);
 
         /**
          * Get the current ignoreHttpErrors configuration.

--- a/src/test/java/org/jsoup/integration/ConnectTest.java
+++ b/src/test/java/org/jsoup/integration/ConnectTest.java
@@ -7,6 +7,7 @@ import org.jsoup.integration.servlets.Deflateservlet;
 import org.jsoup.integration.servlets.EchoServlet;
 import org.jsoup.integration.servlets.HelloServlet;
 import org.jsoup.integration.servlets.InterruptedServlet;
+import org.jsoup.integration.servlets.MetaRedirectServlet;
 import org.jsoup.integration.servlets.RedirectServlet;
 import org.jsoup.integration.servlets.SlowRider;
 import org.jsoup.nodes.Document;
@@ -436,6 +437,14 @@ public class ConnectTest {
             threw = true;
         }
         assertTrue(threw);
+    }
+
+    @Test public void handlesMetaRedirect() throws IOException {
+    	Connection con = Jsoup.connect(MetaRedirectServlet.Url)
+    			.followMetaRedirects(true);
+        Document doc = con.get();
+
+        assertEquals(HelloServlet.Url, doc.location());
     }
 
     @Test public void doesNotPostFor302() throws IOException {

--- a/src/test/java/org/jsoup/integration/servlets/MetaRedirectServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/MetaRedirectServlet.java
@@ -1,0 +1,21 @@
+package org.jsoup.integration.servlets;
+
+import org.jsoup.integration.TestServer;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class MetaRedirectServlet extends BaseServlet {
+    public static final String Url = TestServer.map(MetaRedirectServlet.class);
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        res.setContentType(TextHtml);
+        res.setStatus(HttpServletResponse.SC_OK);
+
+        String doc = "<meta http-equiv=\"refresh\" content=\"0;url=" + HelloServlet.Url + "\">";
+        res.getWriter().write(doc);
+    }
+}


### PR DESCRIPTION
Resolved issue (#371). As @jhy suggested, this feature is optional and disabled by default. Enable it using `Connection.followMetaRedirects(true)`