### PR TITLE
Extensibility of TreeBuilders

### DIFF
--- a/src/main/java/org/jsoup/nodes/CDataNode.java
+++ b/src/main/java/org/jsoup/nodes/CDataNode.java
@@ -27,14 +27,14 @@ public class CDataNode extends TextNode {
     }
 
     @Override
-    void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
+    public void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         accum
             .append("<![CDATA[")
             .append(getWholeText());
     }
 
     @Override
-    void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {
+    public void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {
         try {
             accum.append("]]>");
         } catch (IOException e) {

--- a/src/main/java/org/jsoup/nodes/Comment.java
+++ b/src/main/java/org/jsoup/nodes/Comment.java
@@ -42,7 +42,8 @@ public class Comment extends LeafNode {
         return coreValue();
     }
 
-	void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
+	@Override
+	public void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         if (out.prettyPrint())
             indent(accum, depth, out);
         accum
@@ -51,7 +52,8 @@ public class Comment extends LeafNode {
                 .append("-->");
     }
 
-	void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {}
+	@Override
+	public void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {}
 
     @Override
     public String toString() {

--- a/src/main/java/org/jsoup/nodes/DataNode.java
+++ b/src/main/java/org/jsoup/nodes/DataNode.java
@@ -48,11 +48,13 @@ public class DataNode extends LeafNode {
         return this;
     }
 
-	void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
+    @Override
+	public void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         accum.append(getWholeData()); // data is not escaped in return from data nodes, so " in script, style is plain
     }
 
-	void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {}
+    @Override
+	public void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {}
 
     @Override
     public String toString() {

--- a/src/main/java/org/jsoup/nodes/DocumentType.java
+++ b/src/main/java/org/jsoup/nodes/DocumentType.java
@@ -81,7 +81,7 @@ public class DocumentType extends LeafNode {
     }
 
     @Override
-    void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
+    public void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         if (out.syntax() == Syntax.html && !has(PUBLIC_ID) && !has(SYSTEM_ID)) {
             // looks like a html5 doctype, go lowercase for aesthetics
             accum.append("<!doctype");
@@ -100,7 +100,7 @@ public class DocumentType extends LeafNode {
     }
 
     @Override
-    void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {
+    public void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {
     }
 
     private boolean has(final String attribute) {

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1382,7 +1382,8 @@ public class Element extends Node {
         return this;
     }
 
-    void outerHtmlHead(final Appendable accum, int depth, final Document.OutputSettings out) throws IOException {
+    @Override
+	public void outerHtmlHead(final Appendable accum, int depth, final Document.OutputSettings out) throws IOException {
         if (out.prettyPrint() && (tag.formatAsBlock() || (parent() != null && parent().tag().formatAsBlock()) || out.outline())) {
             if (accum instanceof StringBuilder) {
                 if (((StringBuilder) accum).length() > 0)
@@ -1405,7 +1406,8 @@ public class Element extends Node {
             accum.append('>');
     }
 
-	void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
+    @Override
+	public void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         if (!(childNodes.isEmpty() && tag.isSelfClosing())) {
             if (out.prettyPrint() && (!childNodes.isEmpty() && (
                     tag.formatAsBlock() || (out.outline() && (childNodes.size()>1 || (childNodes.size()==1 && !(childNodes.get(0) instanceof TextNode))))

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -580,9 +580,9 @@ public abstract class Node implements Cloneable {
      @param accum accumulator to place HTML into
      @throws IOException if appending to the given accumulator fails.
      */
-    abstract void outerHtmlHead(final Appendable accum, int depth, final Document.OutputSettings out) throws IOException;
+    public abstract void outerHtmlHead(final Appendable accum, int depth, final Document.OutputSettings out) throws IOException;
 
-    abstract void outerHtmlTail(final Appendable accum, int depth, final Document.OutputSettings out) throws IOException;
+    public abstract void outerHtmlTail(final Appendable accum, int depth, final Document.OutputSettings out) throws IOException;
 
     /**
      * Write this node and its children to the given {@link Appendable}.

--- a/src/main/java/org/jsoup/nodes/PseudoTextElement.java
+++ b/src/main/java/org/jsoup/nodes/PseudoTextElement.java
@@ -13,10 +13,10 @@ public class PseudoTextElement extends Element {
     }
 
     @Override
-    void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) {
+    public void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) {
     }
 
     @Override
-    void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {
+    public void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {
     }
 }

--- a/src/main/java/org/jsoup/nodes/TextNode.java
+++ b/src/main/java/org/jsoup/nodes/TextNode.java
@@ -93,7 +93,8 @@ public class TextNode extends LeafNode {
         return tailNode;
     }
 
-	void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
+    @Override
+	public void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         if (out.prettyPrint() && ((siblingIndex() == 0 && parentNode instanceof Element && ((Element) parentNode).tag().formatAsBlock() && !isBlank()) || (out.outline() && siblingNodes().size()>0 && !isBlank()) ))
             indent(accum, depth, out);
 
@@ -102,7 +103,8 @@ public class TextNode extends LeafNode {
         Entities.escape(accum, coreValue(), out, false, normaliseWhite, false);
     }
 
-	void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {}
+    @Override
+	public void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {}
 
     @Override
     public String toString() {

--- a/src/main/java/org/jsoup/nodes/XmlDeclaration.java
+++ b/src/main/java/org/jsoup/nodes/XmlDeclaration.java
@@ -71,7 +71,8 @@ public class XmlDeclaration extends LeafNode {
         }
     }
 
-    void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
+    @Override
+	public void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         accum
             .append("<")
             .append(isProcessingInstruction ? "!" : "?")
@@ -82,7 +83,8 @@ public class XmlDeclaration extends LeafNode {
             .append(">");
     }
 
-    void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {
+    @Override
+	public void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {
     }
 
     @Override

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -56,7 +56,8 @@ public class HtmlTreeBuilder extends TreeBuilder {
     private boolean fosterInserts; // if next inserts should be fostered
     private boolean fragmentParsing; // if parsing a fragment of html
 
-    ParseSettings defaultSettings() {
+    @Override
+	protected ParseSettings defaultSettings() {
         return ParseSettings.htmlDefault;
     }
 
@@ -79,7 +80,8 @@ public class HtmlTreeBuilder extends TreeBuilder {
         fragmentParsing = false;
     }
 
-    List<Node> parseFragment(String inputFragment, Element context, String baseUri, Parser parser) {
+    @Override
+	protected List<Node> parseFragment(String inputFragment, Element context, String baseUri, Parser parser) {
         // context may be null
         state = HtmlTreeBuilderState.Initial;
         initialiseParse(new StringReader(inputFragment), baseUri, parser);

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -8,13 +8,13 @@ import static org.jsoup.internal.Normalizer.lowerCase;
 /**
  * Parse tokens for the Tokeniser.
  */
-abstract class Token {
+public abstract class Token {
     TokenType type;
 
-    private Token() {
+    protected Token() {
     }
     
-    String tokenType() {
+    public String tokenType() {
         return this.getClass().getSimpleName();
     }
 
@@ -30,14 +30,14 @@ abstract class Token {
         }
     }
 
-    static final class Doctype extends Token {
+    public static final class Doctype extends Token {
         final StringBuilder name = new StringBuilder();
         String pubSysKey = null;
         final StringBuilder publicIdentifier = new StringBuilder();
         final StringBuilder systemIdentifier = new StringBuilder();
         boolean forceQuirks = false;
 
-        Doctype() {
+        public Doctype() {
             type = TokenType.Doctype;
         }
 
@@ -51,15 +51,15 @@ abstract class Token {
             return this;
         }
 
-        String getName() {
+        public String getName() {
             return name.toString();
         }
 
-        String getPubSysKey() {
+        public String getPubSysKey() {
             return pubSysKey;
         }
 
-        String getPublicIdentifier() {
+        public String getPublicIdentifier() {
             return publicIdentifier.toString();
         }
 
@@ -72,7 +72,7 @@ abstract class Token {
         }
     }
 
-    static abstract class Tag extends Token {
+    public static abstract class Tag extends Token {
         protected String tagName;
         protected String normalName; // lc version of tag name, for case insensitive tree build
         private String pendingAttributeName; // attribute names are generally caught in one hop, not accumulated
@@ -130,12 +130,12 @@ abstract class Token {
             }
         }
 
-        final String name() { // preserves case, for input into Tag.valueOf (which may drop case)
+        public final String name() { // preserves case, for input into Tag.valueOf (which may drop case)
             Validate.isFalse(tagName == null || tagName.length() == 0);
             return tagName;
         }
 
-        final String normalName() { // loses case, used in tree building for working out where in tree it should go
+        public final String normalName() { // loses case, used in tree building for working out where in tree it should go
             return normalName;
         }
 
@@ -145,12 +145,12 @@ abstract class Token {
             return this;
         }
 
-        final boolean isSelfClosing() {
+        public final boolean isSelfClosing() {
             return selfClosing;
         }
 
         @SuppressWarnings({"TypeMayBeWeakened"})
-        final Attributes getAttributes() {
+        public final Attributes getAttributes() {
             return attributes;
         }
 
@@ -212,8 +212,8 @@ abstract class Token {
         }
     }
 
-    final static class StartTag extends Tag {
-        StartTag() {
+    public final static class StartTag extends Tag {
+        public StartTag() {
             super();
             attributes = new Attributes();
             type = TokenType.StartTag;
@@ -243,8 +243,8 @@ abstract class Token {
         }
     }
 
-    final static class EndTag extends Tag{
-        EndTag() {
+    public final static class EndTag extends Tag{
+        public EndTag() {
             super();
             type = TokenType.EndTag;
         }
@@ -255,7 +255,7 @@ abstract class Token {
         }
     }
 
-    final static class Comment extends Token {
+    public final static class Comment extends Token {
         final StringBuilder data = new StringBuilder();
         boolean bogus = false;
 
@@ -266,11 +266,11 @@ abstract class Token {
             return this;
         }
 
-        Comment() {
+        public Comment() {
             type = TokenType.Comment;
         }
 
-        String getData() {
+        public String getData() {
             return data.toString();
         }
 
@@ -280,10 +280,10 @@ abstract class Token {
         }
     }
 
-    static class Character extends Token {
+    public static class Character extends Token {
         private String data;
 
-        Character() {
+        public Character() {
             super();
             type = TokenType.Character;
         }
@@ -299,7 +299,7 @@ abstract class Token {
             return this;
         }
 
-        String getData() {
+        public String getData() {
             return data;
         }
 
@@ -309,8 +309,8 @@ abstract class Token {
         }
     }
 
-    final static class CData extends Character {
-        CData(String data) {
+    public final static class CData extends Character {
+        public CData(String data) {
             super();
             this.data(data);
         }
@@ -322,8 +322,8 @@ abstract class Token {
 
     }
 
-    final static class EOF extends Token {
-        EOF() {
+    public final static class EOF extends Token {
+        public EOF() {
             type = Token.TokenType.EOF;
         }
 
@@ -333,51 +333,51 @@ abstract class Token {
         }
     }
 
-    final boolean isDoctype() {
+    public final boolean isDoctype() {
         return type == TokenType.Doctype;
     }
 
-    final Doctype asDoctype() {
+    public final Doctype asDoctype() {
         return (Doctype) this;
     }
 
-    final boolean isStartTag() {
+    public final boolean isStartTag() {
         return type == TokenType.StartTag;
     }
 
-    final StartTag asStartTag() {
+    public final StartTag asStartTag() {
         return (StartTag) this;
     }
 
-    final boolean isEndTag() {
+    public final boolean isEndTag() {
         return type == TokenType.EndTag;
     }
 
-    final EndTag asEndTag() {
+    public final EndTag asEndTag() {
         return (EndTag) this;
     }
 
-    final boolean isComment() {
+    public final boolean isComment() {
         return type == TokenType.Comment;
     }
 
-    final Comment asComment() {
+    public final Comment asComment() {
         return (Comment) this;
     }
 
-    final boolean isCharacter() {
+    public final boolean isCharacter() {
         return type == TokenType.Character;
     }
 
-    final boolean isCData() {
+    public final boolean isCData() {
         return this instanceof CData;
     }
 
-    final Character asCharacter() {
+    public final Character asCharacter() {
         return (Character) this;
     }
 
-    final boolean isEOF() {
+    public final boolean isEOF() {
         return type == TokenType.EOF;
     }
 

--- a/src/main/java/org/jsoup/parser/TreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilder.java
@@ -13,7 +13,7 @@ import java.util.List;
 /**
  * @author Jonathan Hedley
  */
-abstract class TreeBuilder {
+public abstract class TreeBuilder {
     protected Parser parser;
     CharacterReader reader;
     Tokeniser tokeniser;
@@ -25,7 +25,7 @@ abstract class TreeBuilder {
 
     private Token.StartTag start = new Token.StartTag(); // start tag to process
     private Token.EndTag end  = new Token.EndTag();
-    abstract ParseSettings defaultSettings();
+    protected abstract ParseSettings defaultSettings();
 
     protected void initialiseParse(Reader input, String baseUri, Parser parser) {
         Validate.notNull(input, "String input must not be null");
@@ -42,13 +42,13 @@ abstract class TreeBuilder {
         this.baseUri = baseUri;
     }
 
-    Document parse(Reader input, String baseUri, Parser parser) {
+    protected Document parse(Reader input, String baseUri, Parser parser) {
         initialiseParse(input, baseUri, parser);
         runParser();
         return doc;
     }
 
-    abstract List<Node> parseFragment(String inputFragment, Element context, String baseUri, Parser parser);
+    protected abstract List<Node> parseFragment(String inputFragment, Element context, String baseUri, Parser parser);
 
     protected void runParser() {
         while (true) {

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -22,7 +22,8 @@ import java.util.List;
  * @author Jonathan Hedley
  */
 public class XmlTreeBuilder extends TreeBuilder {
-    ParseSettings defaultSettings() {
+    @Override
+	protected ParseSettings defaultSettings() {
         return ParseSettings.preserveCase;
     }
 
@@ -33,11 +34,11 @@ public class XmlTreeBuilder extends TreeBuilder {
         doc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
     }
 
-    Document parse(Reader input, String baseUri) {
+    protected Document parse(Reader input, String baseUri) {
         return parse(input, baseUri, new Parser(this));
     }
 
-    Document parse(String input, String baseUri) {
+    protected Document parse(String input, String baseUri) {
         return parse(new StringReader(input), baseUri, new Parser(this));
     }
 
@@ -72,7 +73,7 @@ public class XmlTreeBuilder extends TreeBuilder {
         currentElement().appendChild(node);
     }
 
-    Element insert(Token.StartTag startTag) {
+    protected Element insert(Token.StartTag startTag) {
         Tag tag = Tag.valueOf(startTag.name(), settings);
         // todo: wonder if for xml parsing, should treat all tags as unknown? because it's not html.
         Element el = new Element(tag, baseUri, settings.normalizeAttributes(startTag.attributes));
@@ -86,7 +87,7 @@ public class XmlTreeBuilder extends TreeBuilder {
         return el;
     }
 
-    void insert(Token.Comment commentToken) {
+    protected void insert(Token.Comment commentToken) {
         Comment comment = new Comment(commentToken.getData());
         Node insert = comment;
         if (commentToken.bogus && comment.isXmlDeclaration()) {
@@ -99,12 +100,12 @@ public class XmlTreeBuilder extends TreeBuilder {
         insertNode(insert);
     }
 
-    void insert(Token.Character token) {
+    protected void insert(Token.Character token) {
         final String data = token.getData();
         insertNode(token.isCData() ? new CDataNode(data) : new TextNode(data));
     }
 
-    void insert(Token.Doctype d) {
+    protected void insert(Token.Doctype d) {
         DocumentType doctypeNode = new DocumentType(settings.normalizeTag(d.getName()), d.getPublicIdentifier(), d.getSystemIdentifier());
         doctypeNode.setPubSysKey(d.getPubSysKey());
         insertNode(doctypeNode);
@@ -139,13 +140,14 @@ public class XmlTreeBuilder extends TreeBuilder {
     }
 
 
-    List<Node> parseFragment(String inputFragment, String baseUri, Parser parser) {
+    protected List<Node> parseFragment(String inputFragment, String baseUri, Parser parser) {
         initialiseParse(new StringReader(inputFragment), baseUri, parser);
         runParser();
         return doc.childNodes();
     }
 
-    List<Node> parseFragment(String inputFragment, Element context, String baseUri, Parser parser) {
+    @Override
+	protected List<Node> parseFragment(String inputFragment, Element context, String baseUri, Parser parser) {
         return parseFragment(inputFragment, baseUri, parser);
     }
 }


### PR DESCRIPTION
These changes allow subclassing the TreeBuilder (focus is especially on the `XmlTreeBuilder`, not so much on the `HtmlTreeBuilder`, where I didn't change any of the package-private methods). This includes changing methods of the `Token` class from package-private to public.

Also, I made `outerHtmlHead` and `outerHtmlTail` from `Node` public, to allow building custom toString representations of a Document from custom code.

See related tickets here:

- https://github.com/jhy/jsoup/issues/600
- https://github.com/jhy/jsoup/issues/943

My specific use case: I wanted to process HTML documents for pretty-printing them, but don't want jsoup to modify the existing page structure. Therefore I went with `XmlTreeBuilder` instead of `HtmlTreeBuilder`. The problem: Multiline `<script>` and `<style>` tags would be transformed to a single line with `XmlTreeBuilder`, that's why I needed to create my own customized subclass which would handle those tags the same way as `HtmlTreeBuilder`.