### PR TITLE
Add "center" to list of block tags

### DIFF
--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -235,7 +235,7 @@ public class Tag {
             "ul", "ol", "pre", "div", "blockquote", "hr", "address", "figure", "figcaption", "form", "fieldset", "ins",
             "del", "dl", "dt", "dd", "li", "table", "caption", "thead", "tfoot", "tbody", "colgroup", "col", "tr", "th",
             "td", "video", "audio", "canvas", "details", "menu", "plaintext", "template", "article", "main",
-            "svg", "math"
+            "svg", "math", "center"
     };
     private static final String[] inlineTags = {
             "object", "base", "font", "tt", "i", "b", "u", "big", "small", "em", "strong", "dfn", "code", "samp", "kbd",


### PR DESCRIPTION
This adds `center` to the list of block tags.

This fixes `Element.text()` for elements that have `<center>`s. For example:

```java
Jsoup.parse("<center>hello</center><center>goodbye</center>").body().text()
```

Before this change, this code evaluates to `hellogoodbye`. With this change, it evaluates to `hello goodbye`.

I tested the change with `mvn test` and it looks like everything is still happy. I also checked the call hierarchy of `Tag.isBlock()` and it looks like this change should be innocuous. Fingers crossed.