### PR TITLE
Store and remember the quote type of attribute values

### DIFF
--- a/src/main/java/org/jsoup/nodes/BooleanAttribute.java
+++ b/src/main/java/org/jsoup/nodes/BooleanAttribute.java
@@ -10,7 +10,7 @@ public class BooleanAttribute extends Attribute {
      * @param key attribute key
      */
     public BooleanAttribute(String key) {
-        super(key, null);
+        super(key, null, null);
     }
 
     @Override

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -75,16 +75,30 @@ public abstract class Node implements Cloneable {
     public abstract Attributes attributes();
 
     /**
+     * Set an attribute (key=value) with the given quote type (double-quoted, single-quoted, or unquoted). If the
+     * attribute already exists, it is replaced. The attribute key comparison is <b>case insensitive</b>. The key will
+     * be set with case sensitivity as set in the parser settings.
+     * @param attributeKey The attribute key.
+     * @param attributeValue The attribute value.
+     * @param attributeQuoteType The attribute value's quote type.
+     * @return this (for chaining)
+     */
+    public Node attr(String attributeKey, String attributeValue, Attribute.QuoteType attributeQuoteType) {
+        attributeKey = NodeUtils.parser(this).settings().normalizeAttribute(attributeKey);
+        attributes().putIgnoreCase(attributeKey, attributeValue, attributeQuoteType);
+        return this;
+    }
+
+    /**
      * Set an attribute (key=value). If the attribute already exists, it is replaced. The attribute key comparison is
-     * <b>case insensitive</b>. The key will be set with case sensitivity as set in the parser settings.
+     * <b>case insensitive</b>. The key will be set with case sensitivity as set in the parser settings. The attribute's
+     * value's quote type is not set.
      * @param attributeKey The attribute key.
      * @param attributeValue The attribute value.
      * @return this (for chaining)
      */
     public Node attr(String attributeKey, String attributeValue) {
-        attributeKey = NodeUtils.parser(this).settings().normalizeAttribute(attributeKey);
-        attributes().putIgnoreCase(attributeKey, attributeValue);
-        return this;
+        return attr(attributeKey, attributeValue, null);
     }
 
     /**

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -1,6 +1,7 @@
 package org.jsoup.parser;
 
 import org.jsoup.helper.Validate;
+import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Attributes;
 
 import static org.jsoup.internal.Normalizer.lowerCase;
@@ -78,6 +79,7 @@ abstract class Token {
         private String pendingAttributeName; // attribute names are generally caught in one hop, not accumulated
         private StringBuilder pendingAttributeValue = new StringBuilder(); // but values are accumulated, from e.g. & in hrefs
         private String pendingAttributeValueS; // try to get attr vals in one shot, vs Builder
+        private Attribute.QuoteType pendingAttributeValueQuoteType; // remember how attribute values are quoted
         private boolean hasEmptyAttributeValue = false; // distinguish boolean attribute from empty string value
         private boolean hasPendingAttributeValue = false;
         boolean selfClosing = false;
@@ -90,6 +92,7 @@ abstract class Token {
             pendingAttributeName = null;
             reset(pendingAttributeValue);
             pendingAttributeValueS = null;
+            pendingAttributeValueQuoteType = null;
             hasEmptyAttributeValue = false;
             hasPendingAttributeValue = false;
             selfClosing = false;
@@ -112,7 +115,7 @@ abstract class Token {
                         value = "";
                     else
                         value = null;
-                    attributes.put(pendingAttributeName, value);
+                    attributes.put(pendingAttributeName, value, pendingAttributeValueQuoteType);
                 }
             }
             pendingAttributeName = null;
@@ -120,6 +123,7 @@ abstract class Token {
             hasPendingAttributeValue = false;
             reset(pendingAttributeValue);
             pendingAttributeValueS = null;
+            pendingAttributeValueQuoteType = null;
         }
 
         final void finaliseTag() {
@@ -196,6 +200,10 @@ abstract class Token {
             for (int codepoint : appendCodepoints) {
                 pendingAttributeValue.appendCodePoint(codepoint);
             }
+        }
+
+        final void appendAttributeQuoteType(Attribute.QuoteType append) {
+            pendingAttributeValueQuoteType = append;
         }
         
         final void setEmptyAttributeValue() {

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -1,5 +1,6 @@
 package org.jsoup.parser;
 
+import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.DocumentType;
 
 /**
@@ -738,8 +739,10 @@ enum TokeniserState {
     AttributeValue_doubleQuoted {
         void read(Tokeniser t, CharacterReader r) {
             String value = r.consumeToAny(attributeDoubleValueCharsSorted);
-            if (value.length() > 0)
+            if (value.length() > 0) {
                 t.tagPending.appendAttributeValue(value);
+                t.tagPending.appendAttributeQuoteType(Attribute.QuoteType.DOUBLE_QUOTED);
+            }
             else
                 t.tagPending.setEmptyAttributeValue();
 
@@ -771,8 +774,10 @@ enum TokeniserState {
     AttributeValue_singleQuoted {
         void read(Tokeniser t, CharacterReader r) {
             String value = r.consumeToAny(attributeSingleValueCharsSorted);
-            if (value.length() > 0)
+            if (value.length() > 0) {
                 t.tagPending.appendAttributeValue(value);
+                t.tagPending.appendAttributeQuoteType(Attribute.QuoteType.SINGLE_QUOTED);
+            }
             else
                 t.tagPending.setEmptyAttributeValue();
 
@@ -804,8 +809,10 @@ enum TokeniserState {
     AttributeValue_unquoted {
         void read(Tokeniser t, CharacterReader r) {
             String value = r.consumeToAnySorted(attributeValueUnquoted);
-            if (value.length() > 0)
+            if (value.length() > 0) {
                 t.tagPending.appendAttributeValue(value);
+                t.tagPending.appendAttributeQuoteType(Attribute.QuoteType.UNQUOTED);
+            }
 
             char c = r.consume();
             switch (c) {

--- a/src/test/java/org/jsoup/nodes/AttributeTest.java
+++ b/src/test/java/org/jsoup/nodes/AttributeTest.java
@@ -1,20 +1,42 @@
 package org.jsoup.nodes;
 
+import org.jsoup.Jsoup;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class AttributeTest {
     @Test public void html() {
-        Attribute attr = new Attribute("key", "value &");
+        Attribute attr = new Attribute("key", "value &", Attribute.QuoteType.DOUBLE_QUOTED);
         assertEquals("key=\"value &amp;\"", attr.html());
         assertEquals(attr.html(), attr.toString());
     }
 
     @Test public void testWithSupplementaryCharacterInAttributeKeyAndValue() {
         String s = new String(Character.toChars(135361));
-        Attribute attr = new Attribute(s, "A" + s + "B");
+        Attribute attr = new Attribute(s, "A" + s + "B", Attribute.QuoteType.DOUBLE_QUOTED);
         assertEquals(s + "=\"A" + s + "B\"", attr.html());
         assertEquals(attr.html(), attr.toString());
+    }
+
+    @Test public void testParseUnquotedAttributeValue() {
+        Document doc = Jsoup.parse("<html><head></head><body><a name=test>...</a></body></html>");
+
+        Attributes attr = doc.select("a").first().attributes();
+        assertEquals(Attribute.QuoteType.UNQUOTED, attr.getQuoteType("name"));
+    }
+
+    @Test public void testParseSingleQuotedAttributeValue() {
+        Document doc = Jsoup.parse("<html><head></head><body><a name='test'>...</a></body></html>");
+
+        Attributes attr = doc.select("a").first().attributes();
+        assertEquals(Attribute.QuoteType.SINGLE_QUOTED, attr.getQuoteType("name"));
+    }
+
+    @Test public void testParseDoubleQuotedAttributeValue() {
+        Document doc = Jsoup.parse("<html><head></head><body><a name=\"test\">...</a></body></html>");
+
+        Attributes attr = doc.select("a").first().attributes();
+        assertEquals(Attribute.QuoteType.DOUBLE_QUOTED, attr.getQuoteType("name"));
     }
 }


### PR DESCRIPTION
I'm using jsoup to parse HTML documents and perform some analysis on them.

Unfortunately, I discovered that jsoup does not remember the quote type used for attribute values during parsing. In other words, parsing the following strings:

```
Document foo = Jsoup.parse("<html><body><a name=\"value\"></body></html>");
Document bar = Jsoup.parse("<html><body><a name='value'></body></html>");
Document baz = Jsoup.parse("<html><body><a name=value></body></html>");
```

produces three identical documents, with no way to retrieve the information what quote types where used for the value of the `name` atrribute of the `a` element (double quotes, single quotes, or no quotes).

Though I do understand how one may want to abstract away such information in a DOM tree, I think it would be useful to at least make the information optionally available to the user. For instance, when analyzing an HTML document for potential XSS weaknesses, this information can be highly relevant. I see that [jsoup already does a few things to help users in preventing XSS vulnerabilties](https://jsoup.org/cookbook/cleaning-html/whitelist-sanitizer), so making this information available to users would be in line with that spirit.

This PR makes it so that each attribute's value's quote type is stored in each attribute during parsing, and this information is made available to the user via an appropriate getter method that returns an enum element (`DOUBLE_QUOTED`, `SINGLE_QUOTED`, or `UNQUOTED`).

I personally dearly need this information, so it would be great if this PR could make it into a future release. I am new to jsoup, so I may have forgotten about some other locations where code should be changed. If that is the case, please let me know, I can obviously change things. For instance, this information could potentially be used to improve the `html()` and similar methods to produce output that is closer related to the originally parsed source code by re-using the original quote types for each attribute during printing. (It would also allow users to manipulate and control the quote types used for each attribute). For the moment I did not do so, and all attribute name/value pairs are still printed out using double quotes as before, as I was not sure whether such a behavior is desired and what consequences it may have in other applications.
