### PR TITLE
Support nextUntil(String) and prevUntil(String) methods in org.jsoup.select.Elements

### DIFF
--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -528,6 +528,16 @@ public class Elements extends ArrayList<Element> {
     }
 
     /**
+     * Get each of the following element siblings of each element in this list, until match the query.
+     *
+     * @param query CSS query to match siblings against
+     * @return all following element siblings.
+     */
+    public Elements nextUntil(String query) {
+        return siblingsUtil(query, true);
+    }
+
+    /**
      * Get the immediate previous element sibling of each element in this list.
      * @return previous element siblings.
      */
@@ -553,6 +563,16 @@ public class Elements extends ArrayList<Element> {
     }
 
     /**
+     * Get the immediate previous element sibling of each element in this list, until by the query.
+     *
+     * @param query CSS query to match siblings against
+     * @return previous element siblings.
+     */
+    public Elements prevUntil(String query) {
+        return siblingsUtil(query, false);
+    }
+
+    /**
      * Get each of the previous element siblings of each element in this list, that match the query.
      * @param query CSS query to match siblings against
      * @return all previous element siblings.
@@ -574,6 +594,23 @@ public class Elements extends ArrayList<Element> {
                     els.add(sib);
                 e = sib;
             } while (all);
+        }
+        return els;
+    }
+
+    private Elements siblingsUtil(String query, boolean next) {
+        Elements els = new Elements();
+        Evaluator eval = query != null ? QueryParser.parse(query) : null;
+        for (Element e : this) {
+            do {
+                Element sib = next ? e.nextElementSibling() : e.previousElementSibling();
+                if (sib == null) break;
+                if (eval == null || !sib.is(eval))
+                    els.add(sib);
+                else if (sib.is(eval))
+                    break;
+                e = sib;
+            } while (true);
         }
         return els;
     }

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -534,7 +534,7 @@ public class Elements extends ArrayList<Element> {
      * @return all following element siblings.
      */
     public Elements nextUntil(String query) {
-        return siblingsUtil(query, true);
+        return siblingsUntil(query, true);
     }
 
     /**
@@ -569,7 +569,7 @@ public class Elements extends ArrayList<Element> {
      * @return previous element siblings.
      */
     public Elements prevUntil(String query) {
-        return siblingsUtil(query, false);
+        return siblingsUntil(query, false);
     }
 
     /**
@@ -598,7 +598,7 @@ public class Elements extends ArrayList<Element> {
         return els;
     }
 
-    private Elements siblingsUtil(String query, boolean next) {
+    private Elements siblingsUntil(String query, boolean next) {
         Elements els = new Elements();
         Evaluator eval = query != null ? QueryParser.parse(query) : null;
         for (Element e : this) {

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -348,6 +348,20 @@ public class ElementsTest {
         assertEquals("1", prevAF.first().text());
     }
 
+    @Test public void siblingsUtil() {
+        Document doc = Jsoup.parse("<p>1<p>2<p>3<p>4<p>5<p>6<p>7<p>8<p>9");
+
+        Elements els0 = doc.select("p:eq(1)");
+        assertEquals(4, els0.nextUntil("p:eq(6)").size());
+        assertEquals("3", els0.nextUntil("p:eq(6)").first().text());
+        assertEquals("6", els0.nextUntil("p:eq(6)").last().text());
+
+        Elements els8 = doc.select("p:eq(6)");
+        assertEquals(4, els8.prevUntil("p:eq(1)").size());
+        assertEquals("6", els8.prevUntil("p:eq(1)").first().text());
+        assertEquals("3", els8.prevUntil("p:eq(1)").last().text());
+    }
+
     @Test public void eachText() {
         Document doc = Jsoup.parse("<div><p>1<p>2<p>3<p>4<p>5<p>6</div><div><p>7<p>8<p>9<p>10<p>11<p>12<p></p></div>");
         List<String> divText = doc.select("div").eachText();

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -348,7 +348,7 @@ public class ElementsTest {
         assertEquals("1", prevAF.first().text());
     }
 
-    @Test public void siblingsUtil() {
+    @Test public void siblingsUntil() {
         Document doc = Jsoup.parse("<p>1<p>2<p>3<p>4<p>5<p>6<p>7<p>8<p>9");
 
         Elements els0 = doc.select("p:eq(1)");


### PR DESCRIPTION
Adding two methods use like jQuery api [nextUntil](https://api.jquery.com/nextUntil/) and [prevUntil](https://api.jquery.com/prevUntil/), unit tests please see org.jsoup.select.ElementsTest#siblingsUntil()