### PR TITLE
 Oracle JDK10 and JDK11 build added to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
     - openjdk7
     - oraclejdk8
     - oraclejdk9
-    - oraclejdk10
+    - openjdk10
     - oraclejdk11
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
     - oraclejdk8
     - oraclejdk9
     - oraclejdk10
+    - oraclejdk11
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ jdk:
     - openjdk7
     - oraclejdk8
     - oraclejdk9
+    - oraclejdk10
 
 cache:
     directories:


### PR DESCRIPTION
This adds  Oracle JDK10  and JDK11 CI build. This PR supersedes #1078 (branch deleted accidentally)

@jhy Does it make sense to add an OpenJDKs build too?