### PR TITLE
redirect when 3xx, enabled, and with Location

### DIFF
--- a/src/test/java/org/jsoup/integration/servlets/RedirectServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/RedirectServlet.java
@@ -2,10 +2,8 @@ package org.jsoup.integration.servlets;
 
 import org.jsoup.integration.TestServer;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 public class RedirectServlet extends BaseServlet {
     public static final String Url = TestServer.map(RedirectServlet.class);
@@ -14,22 +12,26 @@ public class RedirectServlet extends BaseServlet {
     private static final int DefaultCode = HttpServletResponse.SC_MOVED_TEMPORARILY;
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws IOException {
-        String location = req.getParameter(LocationParam);
-        if (location == null)
-            location = "";
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) {
+        String[] locations = req.getParameterValues(LocationParam);
+        if (locations == null || locations.length == 0) {
+            res.setHeader("Location", "");
+        } else {
+            for (final String location : locations) {
+                res.addHeader("Location", location);
+            }
+        }
 
         int intCode = DefaultCode;
         String code = req.getParameter(CodeParam);
         if (code != null)
             intCode = Integer.parseInt(code);
 
-        res.setHeader("Location", location);
         res.setStatus(intCode);
     }
 
     @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+    protected void doPost(HttpServletRequest req, HttpServletResponse res) {
         doGet(req, res);
     }
 }


### PR DESCRIPTION
Motivation

The HTTP status codes 300, 301, 303, 307, and 308 allow for client
redirect to the request URL specified in the "Location" header. We
should only redirect when the following conditions are met:
- redirects are enabled (true by default)
- status code is 300, 301, 303, 307, or 308
- a single "Location" header is present in the response

Changes
- Add logic to restrict redirect for the above conditions.
- Updated integration test to check these conditions hold.
- Updated RedirectServlet to allow for multiple "loc" params to be
  configured. This will set multiple "Location" headers in the
  response.