### PR TITLE
fix case sensitive parse bugs #1149

### DIFF
--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -686,7 +686,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
             Element next = formattingElements.get(pos);
             if (next == null) // scope marker
                 break;
-            else if (next.nodeName().equals(nodeName))
+            else if (next.nodeName().equalsIgnoreCase(nodeName))
                 return next;
         }
         return null;


### PR DESCRIPTION
when call this method param nodeName is normalName() which in lowercase，
when Element tag name is case sensitive, it should use 
```java
node.nodeName().equalsIgnoreCase(nodeName)
```
HtmlTreeBuilder
```java
Element getActiveFormattingElement(String nodeName) {
        for (int pos = formattingElements.size() -1; pos >= 0; pos--) {
            Element next = formattingElements.get(pos);
            if (next == null) // scope marker
                break;
            else if (next.nodeName().equals(nodeName))
                return next;
        }
        return null;
    }
```