### PR TITLE
fix Parser bugs when use ParseSettings.preserveCase settings #1149

### DIFF
--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -211,6 +211,11 @@ public class Document extends Element {
         return "#document";
     }
     
+    @Override
+    public String normalName() {
+        return "#document";
+    }
+    
     /**
      * Sets the charset used in this document. This method is equivalent
      * to {@link OutputSettings#charset(java.nio.charset.Charset)

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -131,6 +131,15 @@ public class Element extends Node {
     public String tagName() {
         return tag.getName();
     }
+    
+    /**
+     * Get the name of the tag for this element in lower case
+     * 
+     * @return the lower case tag name
+     */
+    public String normalName() {
+        return tag.normalTagName();
+    }
 
     /**
      * Change the tag of this element. For example, convert a {@code <span>} to a {@code <div>} with

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -570,7 +570,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
      process, then the UA must perform the above steps as if that element was not in the above list.
      */
     void generateImpliedEndTags(String excludeTag) {
-        while ((excludeTag != null && !currentElement().nodeName().equals(excludeTag)) &&
+        while ((excludeTag != null && !currentElement().normalName().equals(excludeTag)) &&
                 inSorted(currentElement().normalName(), TagSearchEndTags))
             pop();
     }

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -92,7 +92,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
                 doc.quirksMode(context.ownerDocument().quirksMode());
 
             // initialise the tokeniser state:
-            String contextTag = context.tagName();
+            String contextTag = context.normalName();
             if (StringUtil.in(contextTag, "title", "textarea"))
                 tokeniser.transition(TokeniserState.Rcdata);
             else if (StringUtil.in(contextTag, "iframe", "noembed", "noframes", "style", "xmp"))
@@ -254,7 +254,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     void insert(Token.Character characterToken) {
         Node node;
         // characters in script and style go in as datanodes, not text nodes
-        final String tagName = currentElement().tagName();
+        final String tagName = currentElement().normalName();
         final String data = characterToken.getData();
 
         if (characterToken.isCData())
@@ -312,7 +312,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     Element getFromStack(String elName) {
         for (int pos = stack.size() -1; pos >= 0; pos--) {
             Element next = stack.get(pos);
-            if (next.nodeName().equals(elName)) {
+            if (next.normalName().equals(elName)) {
                 return next;
             }
         }
@@ -334,7 +334,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
         for (int pos = stack.size() -1; pos >= 0; pos--) {
             Element next = stack.get(pos);
             stack.remove(pos);
-            if (next.nodeName().equals(elName))
+            if (next.normalName().equals(elName))
                 break;
         }
     }
@@ -344,7 +344,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
         for (int pos = stack.size() -1; pos >= 0; pos--) {
             Element next = stack.get(pos);
             stack.remove(pos);
-            if (inSorted(next.nodeName(), elNames))
+            if (inSorted(next.normalName(), elNames))
                 break;
         }
     }
@@ -352,7 +352,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     void popStackToBefore(String elName) {
         for (int pos = stack.size() -1; pos >= 0; pos--) {
             Element next = stack.get(pos);
-            if (next.nodeName().equals(elName)) {
+            if (next.normalName().equals(elName)) {
                 break;
             } else {
                 stack.remove(pos);
@@ -375,7 +375,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     private void clearStackToContext(String... nodeNames) {
         for (int pos = stack.size() -1; pos >= 0; pos--) {
             Element next = stack.get(pos);
-            if (StringUtil.in(next.nodeName(), nodeNames) || next.nodeName().equals("html"))
+            if (StringUtil.in(next.normalName(), nodeNames) || next.normalName().equals("html"))
                 break;
             else
                 stack.remove(pos);
@@ -417,7 +417,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
                 last = true;
                 node = contextElement;
             }
-            String name = node.nodeName();
+            String name = node.normalName();
             if ("select".equals(name)) {
                 transition(HtmlTreeBuilderState.InSelect);
                 break; // frag
@@ -473,7 +473,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
         // don't walk too far up the tree
 
         for (int pos = bottom; pos >= top; pos--) {
-            final String elName = stack.get(pos).nodeName();
+            final String elName = stack.get(pos).normalName();
             if (inSorted(elName, targetNames))
                 return true;
             if (inSorted(elName, baseTypes))
@@ -514,7 +514,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     boolean inSelectScope(String targetName) {
         for (int pos = stack.size() -1; pos >= 0; pos--) {
             Element el = stack.get(pos);
-            String elName = el.nodeName();
+            String elName = el.normalName();
             if (elName.equals(targetName))
                 return true;
             if (!inSorted(elName, TagSearchSelectScope)) // all elements except
@@ -571,7 +571,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
      */
     void generateImpliedEndTags(String excludeTag) {
         while ((excludeTag != null && !currentElement().nodeName().equals(excludeTag)) &&
-                inSorted(currentElement().nodeName(), TagSearchEndTags))
+                inSorted(currentElement().normalName(), TagSearchEndTags))
             pop();
     }
 
@@ -582,7 +582,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     boolean isSpecial(Element el) {
         // todo: mathml's mi, mo, mn
         // todo: svg's foreigObject, desc, title
-        String name = el.nodeName();
+        String name = el.normalName();
         return inSorted(name, TagSearchSpecial);
     }
 
@@ -601,7 +601,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     // active formatting elements
     void pushActiveFormattingElements(Element in) {
         int numSeen = 0;
-        for (int pos = formattingElements.size() -1; pos >= 0; pos--) {
+        for (int pos = formattingElements.size() - 1; pos >= 0; pos--) {
             Element el = formattingElements.get(pos);
             if (el == null) // marker
                 break;
@@ -690,7 +690,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
             Element next = formattingElements.get(pos);
             if (next == null) // scope marker
                 break;
-            else if (next.nodeName().equalsIgnoreCase(nodeName))
+            else if (next.normalName().equals(nodeName))
                 return next;
         }
         return null;

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -690,7 +690,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
             Element next = formattingElements.get(pos);
             if (next == null) // scope marker
                 break;
-            else if (next.nodeName().equals(nodeName))
+            else if (next.nodeName().equalsIgnoreCase(nodeName))
                 return next;
         }
         return null;

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -312,11 +312,11 @@ enum HtmlTreeBuilderState {
                         ArrayList<Element> stack = tb.getStack();
                         for (int i = stack.size() - 1; i > 0; i--) {
                             Element el = stack.get(i);
-                            if (el.nodeName().equals("li")) {
+                            if (el.normalName().equals("li")) {
                                 tb.processEndTag("li");
                                 break;
                             }
-                            if (tb.isSpecial(el) && !StringUtil.inSorted(el.nodeName(), Constants.InBodyStartLiBreakers))
+                            if (tb.isSpecial(el) && !StringUtil.inSorted(el.normalName(), Constants.InBodyStartLiBreakers))
                                 break;
                         }
                         if (tb.inButtonScope("p")) {
@@ -336,7 +336,7 @@ enum HtmlTreeBuilderState {
                     } else if (name.equals("body")) {
                         tb.error(this);
                         ArrayList<Element> stack = tb.getStack();
-                        if (stack.size() == 1 || (stack.size() > 2 && !stack.get(1).nodeName().equals("body"))) {
+                        if (stack.size() == 1 || (stack.size() > 2 && !stack.get(1).normalName().equals("body"))) {
                             // only in fragment case
                             return false; // ignore
                         } else {
@@ -350,7 +350,7 @@ enum HtmlTreeBuilderState {
                     } else if (name.equals("frameset")) {
                         tb.error(this);
                         ArrayList<Element> stack = tb.getStack();
-                        if (stack.size() == 1 || (stack.size() > 2 && !stack.get(1).nodeName().equals("body"))) {
+                        if (stack.size() == 1 || (stack.size() > 2 && !stack.get(1).normalName().equals("body"))) {
                             // only in fragment case
                             return false; // ignore
                         } else if (!tb.framesetOk()) {
@@ -369,7 +369,7 @@ enum HtmlTreeBuilderState {
                         if (tb.inButtonScope("p")) {
                             tb.processEndTag("p");
                         }
-                        if (StringUtil.inSorted(tb.currentElement().nodeName(), Constants.Headings)) {
+                        if (StringUtil.inSorted(tb.currentElement().normalName(), Constants.Headings)) {
                             tb.error(this);
                             tb.pop();
                         }
@@ -395,11 +395,11 @@ enum HtmlTreeBuilderState {
                         ArrayList<Element> stack = tb.getStack();
                         for (int i = stack.size() - 1; i > 0; i--) {
                             Element el = stack.get(i);
-                            if (StringUtil.inSorted(el.nodeName(), Constants.DdDt)) {
-                                tb.processEndTag(el.nodeName());
+                            if (StringUtil.inSorted(el.normalName(), Constants.DdDt)) {
+                                tb.processEndTag(el.normalName());
                                 break;
                             }
-                            if (tb.isSpecial(el) && !StringUtil.inSorted(el.nodeName(), Constants.InBodyStartLiBreakers))
+                            if (tb.isSpecial(el) && !StringUtil.inSorted(el.normalName(), Constants.InBodyStartLiBreakers))
                                 break;
                         }
                         if (tb.inButtonScope("p")) {
@@ -528,14 +528,14 @@ enum HtmlTreeBuilderState {
                         else
                             tb.transition(InSelect);
                     } else if (StringUtil.inSorted(name, Constants.InBodyStartOptions)) {
-                        if (tb.currentElement().nodeName().equals("option"))
+                        if (tb.currentElement().normalName().equals("option"))
                             tb.processEndTag("option");
                         tb.reconstructFormattingElements();
                         tb.insert(startTag);
                     } else if (StringUtil.inSorted(name, Constants.InBodyStartRuby)) {
                         if (tb.inScope("ruby")) {
                             tb.generateImpliedEndTags();
-                            if (!tb.currentElement().nodeName().equals("ruby")) {
+                            if (!tb.currentElement().normalName().equals("ruby")) {
                                 tb.error(this);
                                 tb.popStackToBefore("ruby"); // i.e. close up to but not include name
                             }
@@ -571,7 +571,7 @@ enum HtmlTreeBuilderState {
                                 tb.error(this);
                                 tb.removeFromActiveFormattingElements(formatEl);
                                 return true;
-                            } else if (!tb.inScope(formatEl.nodeName())) {
+                            } else if (!tb.inScope(formatEl.normalName())) {
                                 tb.error(this);
                                 return false;
                             } else if (tb.currentElement() != formatEl)
@@ -595,7 +595,7 @@ enum HtmlTreeBuilderState {
                                 }
                             }
                             if (furthestBlock == null) {
-                                tb.popStackToClose(formatEl.nodeName());
+                                tb.popStackToClose(formatEl.normalName());
                                 tb.removeFromActiveFormattingElements(formatEl);
                                 return true;
                             }
@@ -630,7 +630,7 @@ enum HtmlTreeBuilderState {
                                 lastNode = node;
                             }
 
-                            if (StringUtil.inSorted(commonAncestor.nodeName(), Constants.InBodyEndTableFosters)) {
+                            if (StringUtil.inSorted(commonAncestor.normalName(), Constants.InBodyEndTableFosters)) {
                                 if (lastNode.parent() != null)
                                     lastNode.remove();
                                 tb.insertInFosterParent(lastNode);
@@ -659,7 +659,7 @@ enum HtmlTreeBuilderState {
                             return false;
                         } else {
                             tb.generateImpliedEndTags();
-                            if (!tb.currentElement().nodeName().equals(name))
+                            if (!tb.currentElement().normalName().equals(name))
                                 tb.error(this);
                             tb.popStackToClose(name);
                         }
@@ -672,7 +672,7 @@ enum HtmlTreeBuilderState {
                             return false;
                         } else {
                             tb.generateImpliedEndTags(name);
-                            if (!tb.currentElement().nodeName().equals(name))
+                            if (!tb.currentElement().normalName().equals(name))
                                 tb.error(this);
                             tb.popStackToClose(name);
                         }
@@ -696,7 +696,7 @@ enum HtmlTreeBuilderState {
                             return false;
                         } else {
                             tb.generateImpliedEndTags();
-                            if (!tb.currentElement().nodeName().equals(name))
+                            if (!tb.currentElement().normalName().equals(name))
                                 tb.error(this);
                             // remove currentForm from stack. will shift anything under up.
                             tb.removeFromStack(currentForm);
@@ -708,7 +708,7 @@ enum HtmlTreeBuilderState {
                             return tb.process(endTag);
                         } else {
                             tb.generateImpliedEndTags(name);
-                            if (!tb.currentElement().nodeName().equals(name))
+                            if (!tb.currentElement().normalName().equals(name))
                                 tb.error(this);
                             tb.popStackToClose(name);
                         }
@@ -718,7 +718,7 @@ enum HtmlTreeBuilderState {
                             return false;
                         } else {
                             tb.generateImpliedEndTags(name);
-                            if (!tb.currentElement().nodeName().equals(name))
+                            if (!tb.currentElement().normalName().equals(name))
                                 tb.error(this);
                             tb.popStackToClose(name);
                         }
@@ -728,7 +728,7 @@ enum HtmlTreeBuilderState {
                             return false;
                         } else {
                             tb.generateImpliedEndTags(name);
-                            if (!tb.currentElement().nodeName().equals(name))
+                            if (!tb.currentElement().normalName().equals(name))
                                 tb.error(this);
                             tb.popStackToClose(Constants.Headings);
                         }
@@ -742,7 +742,7 @@ enum HtmlTreeBuilderState {
                                 return false;
                             }
                             tb.generateImpliedEndTags();
-                            if (!tb.currentElement().nodeName().equals(name))
+                            if (!tb.currentElement().normalName().equals(name))
                                 tb.error(this);
                             tb.popStackToClose(name);
                             tb.clearFormattingElementsToLastMarker();
@@ -773,7 +773,7 @@ enum HtmlTreeBuilderState {
                     tb.generateImpliedEndTags(name);
                     if (!name.equals(tb.currentElement().nodeName()))
                         tb.error(this);
-                    tb.popStackToClose(name);
+                    tb.popStackToClose(name.toLowerCase());
                     break;
                 } else {
                     if (tb.isSpecial(node)) {
@@ -884,7 +884,7 @@ enum HtmlTreeBuilderState {
                 }
                 return true; // todo: as above todo
             } else if (t.isEOF()) {
-                if (tb.currentElement().nodeName().equals("html"))
+                if (tb.currentElement().normalName().equals("html"))
                     tb.error(this);
                 return true; // stops parsing
             }
@@ -894,7 +894,7 @@ enum HtmlTreeBuilderState {
         boolean anythingElse(Token t, HtmlTreeBuilder tb) {
             tb.error(this);
             boolean processed;
-            if (StringUtil.in(tb.currentElement().nodeName(), "table", "tbody", "tfoot", "thead", "tr")) {
+            if (StringUtil.in(tb.currentElement().normalName(), "table", "tbody", "tfoot", "thead", "tr")) {
                 tb.setFosterInserts(true);
                 processed = tb.process(t, InBody);
                 tb.setFosterInserts(false);
@@ -923,7 +923,7 @@ enum HtmlTreeBuilderState {
                             if (!isWhitespace(character)) {
                                 // InTable anything else section:
                                 tb.error(this);
-                                if (StringUtil.in(tb.currentElement().nodeName(), "table", "tbody", "tfoot", "thead", "tr")) {
+                                if (StringUtil.in(tb.currentElement().normalName(), "table", "tbody", "tfoot", "thead", "tr")) {
                                     tb.setFosterInserts(true);
                                     tb.process(new Token.Character().data(character), InBody);
                                     tb.setFosterInserts(false);
@@ -951,7 +951,7 @@ enum HtmlTreeBuilderState {
                     return false;
                 } else {
                     tb.generateImpliedEndTags();
-                    if (!tb.currentElement().nodeName().equals("caption"))
+                    if (!tb.currentElement().normalName().equals("caption"))
                         tb.error(this);
                     tb.popStackToClose("caption");
                     tb.clearFormattingElementsToLastMarker();
@@ -1004,7 +1004,7 @@ enum HtmlTreeBuilderState {
                 case EndTag:
                     Token.EndTag endTag = t.asEndTag();
                     if (endTag.normalName.equals("colgroup")) {
-                        if (tb.currentElement().nodeName().equals("html")) { // frag case
+                        if (tb.currentElement().normalName().equals("html")) { // frag case
                             tb.error(this);
                             return false;
                         } else {
@@ -1015,7 +1015,7 @@ enum HtmlTreeBuilderState {
                         return anythingElse(t, tb);
                     break;
                 case EOF:
-                    if (tb.currentElement().nodeName().equals("html"))
+                    if (tb.currentElement().normalName().equals("html"))
                         return true; // stop parsing; frag case
                     else
                         return anythingElse(t, tb);
@@ -1086,7 +1086,7 @@ enum HtmlTreeBuilderState {
                 return false;
             }
             tb.clearStackToTableBodyContext();
-            tb.processEndTag(tb.currentElement().nodeName()); // tbody, tfoot, thead
+            tb.processEndTag(tb.currentElement().normalName()); // tbody, tfoot, thead
             return tb.process(t);
         }
 
@@ -1170,7 +1170,7 @@ enum HtmlTreeBuilderState {
                         return false;
                     }
                     tb.generateImpliedEndTags();
-                    if (!tb.currentElement().nodeName().equals(name))
+                    if (!tb.currentElement().normalName().equals(name))
                         tb.error(this);
                     tb.popStackToClose(name);
                     tb.clearFormattingElementsToLastMarker();
@@ -1238,13 +1238,13 @@ enum HtmlTreeBuilderState {
                     if (name.equals("html"))
                         return tb.process(start, InBody);
                     else if (name.equals("option")) {
-                        if (tb.currentElement().nodeName().equals("option"))
+                        if (tb.currentElement().normalName().equals("option"))
                             tb.processEndTag("option");
                         tb.insert(start);
                     } else if (name.equals("optgroup")) {
-                        if (tb.currentElement().nodeName().equals("option"))
+                        if (tb.currentElement().normalName().equals("option"))
                             tb.processEndTag("option");
-                        else if (tb.currentElement().nodeName().equals("optgroup"))
+                        else if (tb.currentElement().normalName().equals("optgroup"))
                             tb.processEndTag("optgroup");
                         tb.insert(start);
                     } else if (name.equals("select")) {
@@ -1267,15 +1267,15 @@ enum HtmlTreeBuilderState {
                     name = end.normalName();
                     switch (name) {
                         case "optgroup":
-                            if (tb.currentElement().nodeName().equals("option") && tb.aboveOnStack(tb.currentElement()) != null && tb.aboveOnStack(tb.currentElement()).nodeName().equals("optgroup"))
+                            if (tb.currentElement().normalName().equals("option") && tb.aboveOnStack(tb.currentElement()) != null && tb.aboveOnStack(tb.currentElement()).normalName().equals("optgroup"))
                                 tb.processEndTag("option");
-                            if (tb.currentElement().nodeName().equals("optgroup"))
+                            if (tb.currentElement().normalName().equals("optgroup"))
                                 tb.pop();
                             else
                                 tb.error(this);
                             break;
                         case "option":
-                            if (tb.currentElement().nodeName().equals("option"))
+                            if (tb.currentElement().normalName().equals("option"))
                                 tb.pop();
                             else
                                 tb.error(this);
@@ -1294,7 +1294,7 @@ enum HtmlTreeBuilderState {
                     }
                     break;
                 case EOF:
-                    if (!tb.currentElement().nodeName().equals("html"))
+                    if (!tb.currentElement().normalName().equals("html"))
                         tb.error(this);
                     break;
                 default:
@@ -1381,17 +1381,17 @@ enum HtmlTreeBuilderState {
                         return false;
                 }
             } else if (t.isEndTag() && t.asEndTag().normalName().equals("frameset")) {
-                if (tb.currentElement().nodeName().equals("html")) { // frag
+                if (tb.currentElement().normalName().equals("html")) { // frag
                     tb.error(this);
                     return false;
                 } else {
                     tb.pop();
-                    if (!tb.isFragmentParsing() && !tb.currentElement().nodeName().equals("frameset")) {
+                    if (!tb.isFragmentParsing() && !tb.currentElement().normalName().equals("frameset")) {
                         tb.transition(AfterFrameset);
                     }
                 }
             } else if (t.isEOF()) {
-                if (!tb.currentElement().nodeName().equals("html")) {
+                if (!tb.currentElement().normalName().equals("html")) {
                     tb.error(this);
                     return true;
                 }

--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -14,6 +14,7 @@ public class Tag {
     private static final Map<String, Tag> tags = new HashMap<>(); // map of known tags
 
     private String tagName;
+    private String normalTagName;
     private boolean isBlock = true; // block or inline
     private boolean formatAsBlock = true; // should be formatted as a block
     private boolean canContainInline = true; // only pcdata if not
@@ -25,6 +26,7 @@ public class Tag {
 
     private Tag(String tagName) {
         this.tagName = tagName;
+        this.normalTagName =  tagName.toLowerCase();
     }
 
     /**
@@ -34,6 +36,15 @@ public class Tag {
      */
     public String getName() {
         return tagName;
+    }
+    
+    /**
+     * Get this tag's name in lower case
+     * 
+     * @return the tag's lower case name
+     */
+    public String normalTagName() {
+        return normalTagName;
     }
 
     /**


### PR DESCRIPTION
Change:
* add normalName() to Element and Tag
* change HtmlTreeBuilder and HtmlTreeBuilderState to use element's normalName()