### PR TITLE
simplify state sorting status unit test - avoid duplicated code in HtmlTreeBuilderStateTest.java

### DIFF
--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -1497,7 +1497,7 @@ enum HtmlTreeBuilderState {
 
     // lists of tags to search through. A little harder to read here, but causes less GC than dynamic varargs.
     // was contributing around 10% of parse GC load.
-    // must make sure these are sorted, as used in findSorted. MUST update HtmlTreebuilderStateTest if more arrays added.
+    // must make sure these are sorted, as used in findSorted.
     static final class Constants {
         static final String[] InBodyStartToHead = new String[]{"base", "basefont", "bgsound", "command", "link", "meta", "noframes", "script", "style", "title"};
         static final String[] InBodyStartPClosers = new String[]{"address", "article", "aside", "blockquote", "center", "details", "dir", "div", "dl",

--- a/src/test/java/org/jsoup/parser/HtmlTreeBuilderStateTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlTreeBuilderStateTest.java
@@ -1,38 +1,27 @@
 package org.jsoup.parser;
 
-import org.jsoup.parser.HtmlTreeBuilderState.Constants;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 
 public class HtmlTreeBuilderStateTest {
     @Test
-    public void ensureArraysAreSorted() {
-        String[][] arrays = {
-            Constants.InBodyStartToHead,
-            Constants.InBodyStartPClosers,
-            Constants.Headings,
-            Constants.InBodyStartPreListing,
-            Constants.InBodyStartLiBreakers,
-            Constants.DdDt,
-            Constants.Formatters,
-            Constants.InBodyStartApplets,
-            Constants.InBodyStartEmptyFormatters,
-            Constants.InBodyStartMedia,
-            Constants.InBodyStartInputAttribs,
-            Constants.InBodyStartOptions,
-            Constants.InBodyStartRuby,
-            Constants.InBodyStartDrop,
-            Constants.InBodyEndClosers,
-            Constants.InBodyEndAdoptionFormatters,
-            Constants.InBodyEndTableFosters,
-            Constants.InCellNames,
-            Constants.InCellBody,
-            Constants.InCellTable,
-            Constants.InCellCol,
-        };
+    public void ensureArraysAreSorted() throws ClassNotFoundException, IllegalAccessException {
+        Class constants = Class.forName("org.jsoup.parser.HtmlTreeBuilderState$Constants");
+        Field[] fields = constants.getDeclaredFields();
+        List<String[]> arrays = new ArrayList<>(fields.length);
+        for (Field field : fields) {
+            int modifiers = field.getModifiers();
+            if (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers) && field.getType() == String[].class) {
+                arrays.add((String[]) field.get(null));
+            }
+        }
 
         for (String[] array : arrays) {
             String[] copy = Arrays.copyOf(array, array.length);


### PR DESCRIPTION
In test file **HtmlTreeBuilderStateTest** it duplicated tags to search through and there is also a special hint to remind maintainer to synchronize these arrays whenever there is any newly added.

So I made a small improvement to access these arrays via reflection and I tested that the uni test execution time just slow down very little as I executed tests before and after several times.