### PR TITLE
optimize toArray via change length to 0 directly - Avoid calling list.toArray(new X[list.size()])

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -450,7 +450,7 @@ public class Element extends Node {
         Validate.isTrue(index >= 0 && index <= currentSize, "Insert position out of bounds.");
 
         ArrayList<Node> nodes = new ArrayList<>(children);
-        Node[] nodeArray = nodes.toArray(new Node[nodes.size()]);
+        Node[] nodeArray = nodes.toArray(new Node[0]);
         addChildren(index, nodeArray);
         return this;
     }
@@ -535,7 +535,7 @@ public class Element extends Node {
     public Element append(String html) {
         Validate.notNull(html);
         List<Node> nodes = NodeUtils.parser(this).parseFragmentInput(html, this, baseUri());
-        addChildren(nodes.toArray(new Node[nodes.size()]));
+        addChildren(nodes.toArray(new Node[0]));
         return this;
     }
     
@@ -548,7 +548,7 @@ public class Element extends Node {
     public Element prepend(String html) {
         Validate.notNull(html);
         List<Node> nodes = NodeUtils.parser(this).parseFragmentInput(html, this, baseUri());
-        addChildren(0, nodes.toArray(new Node[nodes.size()]));
+        addChildren(0, nodes.toArray(new Node[0]));
         return this;
     }
 

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -230,7 +230,7 @@ public abstract class Node implements Cloneable {
     public abstract int childNodeSize();
 
     protected Node[] childNodesAsArray() {
-        return ensureChildNodes().toArray(new Node[childNodeSize()]);
+        return ensureChildNodes().toArray(new Node[0]);
     }
 
     /**
@@ -333,7 +333,7 @@ public abstract class Node implements Cloneable {
 
         Element context = parent() instanceof Element ? (Element) parent() : null;
         List<Node> nodes = NodeUtils.parser(this).parseFragmentInput(html, context, baseUri());
-        parentNode.addChildren(index, nodes.toArray(new Node[nodes.size()]));
+        parentNode.addChildren(index, nodes.toArray(new Node[0]));
     }
 
     /**

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -642,7 +642,7 @@ enum HtmlTreeBuilderState {
 
                             Element adopter = new Element(formatEl.tag(), tb.getBaseUri());
                             adopter.attributes().addAll(formatEl.attributes());
-                            Node[] childNodes = furthestBlock.childNodes().toArray(new Node[furthestBlock.childNodeSize()]);
+                            Node[] childNodes = furthestBlock.childNodes().toArray(new Node[0]);
                             for (Node childNode : childNodes) {
                                 adopter.appendChild(childNode); // append will reparent. thus the clone to avoid concurrent mod.
                             }

--- a/src/main/java/org/jsoup/parser/Parser.java
+++ b/src/main/java/org/jsoup/parser/Parser.java
@@ -164,7 +164,7 @@ public class Parser {
         Document doc = Document.createShell(baseUri);
         Element body = doc.body();
         List<Node> nodeList = parseFragment(bodyHtml, body, baseUri);
-        Node[] nodes = nodeList.toArray(new Node[nodeList.size()]); // the node list gets modified when re-parented
+        Node[] nodes = nodeList.toArray(new Node[0]); // the node list gets modified when re-parented
         for (int i = nodes.length - 1; i > 0; i--) {
             nodes[i].remove();
         }


### PR DESCRIPTION
Based on ["Arrays of Wisdom of the Ancients"](https://shipilev.net/blog/2016/arrays-wisdom-ancients/) and  similar issues submitted in other projects like this one ["Avoid calling list.toArray(new X[list.size()]) for performance"](https://github.com/h2database/h2database/issues/311), I would recommend jsoup also reuse this optimization since it's a library used so widely.