### PR TITLE
Adding a text method with separator to allow splitting of results

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1042,9 +1042,7 @@ public class Element extends Node {
      * For example, given HTML {@code <p>Hello  <b>there</b> now! </p>}, {@code p.text()} returns {@code "Hello there now!"}
      *
      * @return unencoded, normalized text, or empty string if none.
-     * @see #wholeText() if you don't want the text to be normalized.
-     * @see #ownText()
-     * @see #textNodes()
+     * @see #textWithSeparator(String)
      */
     public String text() {
         return textWithSeparator(" ");

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1035,6 +1035,7 @@ public class Element extends Node {
         return Collector.collect(new Evaluator.AllElements(), this);
     }
 
+
     /**
      * Gets the combined text of this element and all its children. Whitespace is normalized and trimmed.
      * <p>
@@ -1046,6 +1047,21 @@ public class Element extends Node {
      * @see #textNodes()
      */
     public String text() {
+        return textWithSeparator(" ");
+    }
+
+    /**
+     * Gets the combined text of this element and all its children and combines them via the given separator. Whitespace is normalized and trimmed.
+     * <p>
+     * For example, given HTML {@code <p>Hello  <b>there</b> now! </p>}, {@code p.textWithSeparator(",,")} returns {@code "Hello,,there,,now!"}
+     *
+     * @param sep, the separator to separate each text result.
+     * @return unencoded, normalized text, or empty string if none.
+     * @see #wholeText() if you don't want the text to be normalized.
+     * @see #ownText()
+     * @see #textNodes()
+     */
+    public String textWithSeparator(final String sep) {
         final StringBuilder accum = StringUtil.borrowBuilder();
         NodeTraversor.traverse(new NodeVisitor() {
             public void head(Node node, int depth) {
@@ -1057,7 +1073,7 @@ public class Element extends Node {
                     if (accum.length() > 0 &&
                         (element.isBlock() || element.tag.getName().equals("br")) &&
                         !TextNode.lastCharIsWhitespace(accum))
-                        accum.append(' ');
+                        accum.append(sep);
                 }
             }
 
@@ -1066,13 +1082,13 @@ public class Element extends Node {
                 if (node instanceof Element) {
                     Element element = (Element) node;
                     if (element.isBlock() && (node.nextSibling() instanceof TextNode) && !TextNode.lastCharIsWhitespace(accum))
-                        accum.append(' ');
+                        accum.append(sep);
                 }
 
             }
         }, this);
 
-        return StringUtil.releaseBuilder(accum).trim();
+        return StringUtil.releaseBuilder(accum).trim().replaceAll(sep + "$", "");
     }
 
     /**

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -72,6 +72,12 @@ public class ElementTest {
         assertEquals("Another element", doc.getElementsByTag("p").get(1).text());
     }
 
+    @Test public void testGetTextWihSeparator() {
+        Document doc = Jsoup.parse(reference);
+        assertEquals("Hello,,Another element", doc.textWithSeparator(",,"));
+        assertEquals("Another element", doc.getElementsByTag("p").get(1).textWithSeparator("XXX"));
+    }
+
     @Test public void testGetChildText() {
         Document doc = Jsoup.parse("<p>Hello <b>there</b> now");
         Element p = doc.select("p").first();


### PR DESCRIPTION
I came across the use case of needing to split the result of the text() method but didn't want to extend element and thought this may be a useful addition