### PR TITLE
Clone attributes in shallowClone()

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1468,7 +1468,7 @@ public class Element extends Node {
     @Override
     public Element shallowClone() {
         // simpler than implementing a clone version with no child copy
-        return new Element(tag, baseUri, attributes);
+        return new Element(tag, baseUri, attributes == null ? null : attributes.clone());
     }
 
     @Override

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -668,10 +668,13 @@ public class ElementTest {
 
         assertEquals(1, p.childNodeSize());
         assertEquals(0, p2.childNodeSize());
+
         assertEquals("", p2.text());
+        assertEquals("One", t2.text());
 
         assertEquals("two", p2.className());
-        assertEquals("One", t2.text());
+        p2.removeClass("two");
+        assertEquals("two", p.className());
 
         d2.append("<p id=3>Three");
         assertEquals(1, d2.childNodeSize());


### PR DESCRIPTION
Fix for issue #1201 .

When you shallow clone an element you would expect that modifying the attributes of the clone would have no effect on the original element but this is not the case. shallowClone() reuses the same Attributes object from the original element. We should be cloning the Attributes instead.