### PR TITLE
JDK 12 CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
     - oraclejdk9
     - openjdk10
     - oraclejdk11
+    - openjdk12
 
 cache:
     directories:


### PR DESCRIPTION
OpenJDK 12 CI build added. OracleJDK is no longer possible due to license changes.