### PR TITLE
Jdk11 / Jdk12 JavaDoc generation fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,9 +73,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.1.0</version>
         <configuration>
-            <additionalparam>-Xdoclint:none</additionalparam>
+            <doclint>none</doclint>
             <source>7</source>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,8 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.0.0-M1</version>
         <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
+            <additionalparam>-Xdoclint:none</additionalparam>
+            <source>7</source>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Fix for the JavaDoc generation failure on JDK11 and JDK12 (OpenJDK bug [**JDK-8212233**](https://bugs.openjdk.java.net/browse/JDK-8212233)).

In addition, update to _Maven JavaDoc Plugin v3.1.0_ and the new `doclint` option, introduced with v3.0.0.