### PR TITLE
Proposed fix for #1218 ("Mark invalid" error message)

### DIFF
--- a/src/main/java/org/jsoup/parser/Tokeniser.java
+++ b/src/main/java/org/jsoup/parser/Tokeniser.java
@@ -147,6 +147,7 @@ final class Tokeniser {
                 reader.rewindToMark();
                 return null;
             }
+            reader.releaseMark();
             if (!reader.matchConsume(";"))
                 characterReferenceError("missing semicolon"); // missing semi
             int charval = -1;
@@ -189,6 +190,7 @@ final class Tokeniser {
                 reader.rewindToMark();
                 return null;
             }
+            reader.releaseMark();
             if (!reader.matchConsume(";"))
                 characterReferenceError("missing semicolon"); // missing semi
             int numChars = Entities.codepointsForName(nameRef, multipointHolder);

--- a/src/test/java/org/jsoup/parser/CharacterReaderTest.java
+++ b/src/test/java/org/jsoup/parser/CharacterReaderTest.java
@@ -3,6 +3,9 @@ package org.jsoup.parser;
 import org.junit.Test;
 
 import java.io.BufferedReader;
+import java.io.FilterReader;
+import java.io.IOException;
+import java.io.Reader;
 import java.io.StringReader;
 
 import static org.junit.Assert.assertEquals;
@@ -305,6 +308,24 @@ public class CharacterReaderTest {
         }
 
         assertTrue(r.isEmpty());
+    }
+    
+    @Test public void rewindWorksAcrossReadCalls() {
+        String text = "one two three four";
+        final int readLimit = 3;
+        Reader obstructiveReader = new FilterReader(new StringReader(text)) {
+            @Override
+            public int read(char[] cbuf, int off, int len) throws IOException {
+                return super.read(cbuf, off, Math.min(len, readLimit));
+            }
+        };
+        CharacterReader r = new CharacterReader(obstructiveReader);
+        
+        r.mark();
+        r.consumeTo("four");
+        r.rewindToMark();
+        
+        assertEquals("one", r.consumeTo(' '));
     }
 
 


### PR DESCRIPTION
The current parsing code gives up parsing in certain cases instead of reading more data from the underlying reader. This can cause valid markup to be misparsed. Additionally, marks can be invalidated when more data is pulled into the buffer, so marking and rewinding works unreliably.

My attempt of fixing is required some refactoring, so the various consumeXxx() methods keep going after reaching the end of the buffer, maintaining a temporary StringBuilder to hold the data seen so far. To fix marking and rewinding, all the data past the marked position is kept in the buffer when reading more data. Now the client needs to explicitly release the mark to stop it from being kept in the buffer.

Unit tests are still all green, but this definitely needs a review from someone more familiar with the project.