### PR TITLE
fix for bug #1279

### DIFF
--- a/src/main/java/org/jsoup/internal/Normalizer.java
+++ b/src/main/java/org/jsoup/internal/Normalizer.java
@@ -14,4 +14,8 @@ public final class Normalizer {
     public static String normalize(final String input) {
         return lowerCase(input).trim();
     }
+
+    public static String normalize(final String input, boolean isStringLiteral) {
+        return isStringLiteral ? lowerCase(input) : normalize(input);
+    }
 }

--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -217,7 +217,7 @@ public abstract class Evaluator {
      */
     public static final class AttributeWithValueStarting extends AttributeKeyPair {
         public AttributeWithValueStarting(String key, String value) {
-            super(key, value);
+            super(key, value, false);
         }
 
         @Override
@@ -304,15 +304,21 @@ public abstract class Evaluator {
         String value;
 
         public AttributeKeyPair(String key, String value) {
+            this(key, value, true);
+        }
+
+        public AttributeKeyPair(String key, String value, boolean trimValue) {
             Validate.notEmpty(key);
             Validate.notEmpty(value);
 
             this.key = normalize(key);
-            if (value.startsWith("\"") && value.endsWith("\"")
-                    || value.startsWith("'") && value.endsWith("'")) {
+            boolean isStringLiteral = value.startsWith("'") && value.endsWith("'")
+                                        || value.startsWith("\"") && value.endsWith("\"");
+            if (isStringLiteral) {
                 value = value.substring(1, value.length()-1);
             }
-            this.value = normalize(value);
+
+            this.value = trimValue ? normalize(value) : normalize(value, isStringLiteral);
         }
     }
 

--- a/src/test/java/org/jsoup/select/SelectorTest.java
+++ b/src/test/java/org/jsoup/select/SelectorTest.java
@@ -814,4 +814,11 @@ public class SelectorTest {
         assertEquals(1, els.size());
         assertEquals("Two", els.text());
     }
+
+    @Test public void startswithBeginsWithSpace() {
+        Document doc = Jsoup.parse("<small><a href=\" mailto:abc@def.net\">(jdvp@fct.unl.pt)</a></small>");
+        Elements els = doc.select("a[href^=' mailto']");
+
+        assertEquals(1, els.size());
+    }
 }


### PR DESCRIPTION
The general idea is that the value of the `startswith`-selector may contain spaces if it is inside quotes, in which case we don't trim the value.