### PR TITLE
Added new method childrenCount complementary to child(int)

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -265,6 +265,18 @@ public class Element extends Node {
     }
 
     /**
+     * Get the number of child nodes that are elements.
+     * <p>
+     * This method works on the same filtered list like {@link #child(int)}.
+     * </p>
+     * @return the number of child nodes that are elements
+     * @see #child(int)
+     */
+    public int childrenCount() {
+        return childElementsList().size();
+    }
+
+    /**
      * Get this element's child elements.
      * <p>
      * This is effectively a filter on {@link #childNodes()} to get Element nodes.

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -1482,4 +1482,12 @@ public class ElementTest {
 
         assertSame(div, div2);
     }
+
+    @Test
+    public void testChildMixedContent() {
+        Document doc = Jsoup.parse("<table><tbody>\n<tr>\n<td>15:00</td>\n<td>sport</td>\n</tr>\n</tbody></table>");
+        Element row = doc.selectFirst("table tbody tr");
+        assertSame(2, row.childrenCount());
+        assertFalse(row.childrenCount() == row.childNodeSize());
+    }
 }


### PR DESCRIPTION
There is no easy way in the Element to find out a number of children available via the method child(int). The method childNodeSize() acts on list of all children while child(int) acts on the filtered list of the children. This trivial patch adds new method childrenCount() that is complementary to child(int) as it works on the same filtered list. A unit test is provided.

My observation: https://stackoverflow.com/questions/59547574/jsoup-how-to-find-out-elements-size

Thank you for this wonderful library and for consideration of merging this proposal.