### PR TITLE
Not add line break when pretty printing inline tags

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1394,7 +1394,7 @@ public class Element extends Node {
     }
 
     void outerHtmlHead(final Appendable accum, int depth, final Document.OutputSettings out) throws IOException {
-        if (out.prettyPrint() && (tag.formatAsBlock() || (parent() != null && parent().tag().formatAsBlock()) || out.outline())) {
+        if (out.prettyPrint() && isFormatAsBlock(out) && !isInlineable(out)) {
             if (accum instanceof StringBuilder) {
                 if (((StringBuilder) accum).length() > 0)
                     indent(accum, depth, out);
@@ -1416,7 +1416,7 @@ public class Element extends Node {
             accum.append('>');
     }
 
-	void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
+    void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         if (!(childNodes.isEmpty() && tag.isSelfClosing())) {
             if (out.prettyPrint() && (!childNodes.isEmpty() && (
                     tag.formatAsBlock() || (out.outline() && (childNodes.size()>1 || (childNodes.size()==1 && !(childNodes.get(0) instanceof TextNode))))
@@ -1520,5 +1520,17 @@ public class Element extends Node {
         public void onContentsChanged() {
             owner.nodelistChanged();
         }
+    }
+
+    private boolean isFormatAsBlock(Document.OutputSettings out) {
+        return tag.formatAsBlock() || (parent() != null && parent().tag().formatAsBlock()) || out.outline();
+    }
+
+    private boolean isInlineable(Document.OutputSettings out) {
+        return tag().isInline()
+                && !tag().isEmpty()
+                && parent().isBlock()
+                && previousElementSibling() != null
+                && !out.outline();
     }
 }

--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -16,7 +16,7 @@ public class Tag {
 
     private String tagName;
     private String normalName; // always the lower case version of this tag, regardless of case preservation mode
-    private boolean isBlock = true; // block or inline
+    private boolean isBlock = true; // block
     private boolean formatAsBlock = true; // should be formatted as a block
     private boolean canContainInline = true; // only pcdata if not
     private boolean empty = false; // can hold nothing; e.g. img
@@ -24,6 +24,7 @@ public class Tag {
     private boolean preserveWhitespace = false; // for pre, textarea, script etc
     private boolean formList = false; // a control that appears in forms: input, textarea, output etc
     private boolean formSubmit = false; // a control that can be submitted in a form: input etc
+    private boolean inlineTag = false; // an inline tag
 
     private Tag(String tagName) {
         this.tagName = tagName;
@@ -122,7 +123,7 @@ public class Tag {
      * @return if this tag is an inline tag.
      */
     public boolean isInline() {
-        return !isBlock;
+        return inlineTag;
     }
 
     /**
@@ -216,7 +217,8 @@ public class Tag {
         if (preserveWhitespace != tag.preserveWhitespace) return false;
         if (selfClosing != tag.selfClosing) return false;
         if (formList != tag.formList) return false;
-        return formSubmit == tag.formSubmit;
+        if (formSubmit != tag.formSubmit) return false;
+        return inlineTag == tag.inlineTag;
     }
 
     @Override
@@ -230,6 +232,7 @@ public class Tag {
         result = 31 * result + (preserveWhitespace ? 1 : 0);
         result = 31 * result + (formList ? 1 : 0);
         result = 31 * result + (formSubmit ? 1 : 0);
+        result = 31 * result + (inlineTag ? 1 : 0);
         return result;
     }
 
@@ -286,6 +289,7 @@ public class Tag {
             Tag tag = new Tag(tagName);
             tag.isBlock = false;
             tag.formatAsBlock = false;
+            tag.inlineTag = true;
             register(tag);
         }
 

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -346,6 +346,29 @@ public class ElementTest {
         Element div = doc.select("div").first();
         assertEquals("   \n<p>Hello\n there\n</p>", div.html());
     }
+
+    @Test public void testNotPrettyWithEnDashBody() {
+        String html = "<div><span>1:15</span>&ndash;<span>2:15</span>&nbsp;p.m.</div>";
+        Document document = Jsoup.parse(html);
+        document.outputSettings().prettyPrint(false);
+
+        assertEquals("<div><span>1:15</span>–<span>2:15</span>&nbsp;p.m.</div>", document.body().html());
+    }
+
+    @Test public void testPrettyWithEnDashBody() {
+        String html = "<div><span>1:15</span>&ndash;<span>2:15</span>&nbsp;p.m.</div>";
+        Document document = Jsoup.parse(html);
+
+        assertEquals("<div>\n <span>1:15</span>–<span>2:15</span>&nbsp;p.m.\n</div>", document.body().html());
+    }
+
+    @Test public void testPrettyAndOutlineWithEnDashBody() {
+        String html = "<div><span>1:15</span>&ndash;<span>2:15</span>&nbsp;p.m.</div>";
+        Document document = Jsoup.parse(html);
+        document.outputSettings().outline(true);
+
+        assertEquals("<div>\n <span>1:15</span>\n –\n <span>2:15</span>\n &nbsp;p.m.\n</div>", document.body().html());
+    }
     
     @Test public void testEmptyElementFormatHtml() {
         // don't put newlines into empty blocks
@@ -1135,8 +1158,7 @@ public class ElementTest {
         assertEquals("Another", els3.get(2).text());
 
         assertEquals("<p><a>One</a></p>\n" +
-            "<p>P3</p>\n" +
-            "<span>Another</span>\n" +
+            "<p>P3</p><span>Another</span>\n" +
             "<p><a>Two</a></p>\n" +
             "<p>P4</p>Three", div.html());
     }

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -694,8 +694,7 @@ public class HtmlParserTest {
         // and the <i> inside the table and does not leak out.
         String h = "<p><b>One</p> <table><tr><td><p><i>Three<p>Four</i></td></tr></table> <p>Five</p>";
         Document doc = Jsoup.parse(h);
-        String want = "<p><b>One</b></p>\n" +
-            "<b> \n" +
+        String want = "<p><b>One</b></p><b> \n" +
             " <table>\n" +
             "  <tbody>\n" +
             "   <tr>\n" +
@@ -1033,7 +1032,7 @@ public class HtmlParserTest {
     @Test public void testNormalisesIsIndex() {
         Document doc = Jsoup.parse("<body><isindex action='/submit'></body>");
         String html = doc.outerHtml();
-        assertEquals("<form action=\"/submit\"> <hr> <label>This is a searchable index. Enter search keywords: <input name=\"isindex\"></label> <hr> </form>",
+        assertEquals("<form action=\"/submit\"> <hr><label>This is a searchable index. Enter search keywords: <input name=\"isindex\"></label> <hr> </form>",
             StringUtil.normaliseWhitespace(doc.body().html()));
     }
 

--- a/src/test/java/org/jsoup/parser/TagTest.java
+++ b/src/test/java/org/jsoup/parser/TagTest.java
@@ -64,7 +64,7 @@ public class TagTest {
         Tag foo2 = Tag.valueOf("FOO");
 
         assertEquals(foo, foo2);
-        assertTrue(foo.isInline());
+        assertFalse(foo.isInline());
         assertTrue(foo.formatAsBlock());
     }
 

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -310,6 +310,6 @@ public class CleanerTest {
         String dirty = "<a>One</a> <a href>Two</a>";
         Whitelist relaxedWithAnchor = Whitelist.relaxed().addProtocols("a", "href", "#");
         String clean = Jsoup.clean(dirty, relaxedWithAnchor);
-        assertEquals("<a>One</a> \n<a>Two</a>", clean);
+        assertEquals("<a>One</a> <a>Two</a>", clean);
     }
 }


### PR DESCRIPTION
This is a fix for issue #1305.