### PR TITLE
Apply attribute normalization to void tags

### DIFF
--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -231,7 +231,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
 
     Element insertEmpty(Token.StartTag startTag) {
         Tag tag = Tag.valueOf(startTag.name(), settings);
-        Element el = new Element(tag, null, startTag.attributes);
+        Element el = new Element(tag, null, settings.normalizeAttributes(startTag.attributes));
         insertNode(el);
         if (startTag.isSelfClosing()) {
             if (tag.isKnownTag()) {

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1090,6 +1090,12 @@ public class HtmlParserTest {
         assertEquals("<tag>One</tag>", TextUtil.stripNewlines(div.nextElementSibling().outerHtml()));
     }
 
+    @Test public void testHtmlLowerCaseOfVoidTags() {
+        String html = "<!doctype HTML><IMG ALT=One></DIV>";
+        Document doc = Jsoup.parse(html);
+        assertEquals("<!doctype html> <html> <head></head> <body> <img alt=\"One\"> </body> </html>", StringUtil.normaliseWhitespace(doc.outerHtml()));
+    }
+
     @Test public void canPreserveTagCase() {
         Parser parser = Parser.htmlParser();
         parser.settings(new ParseSettings(true, false));


### PR DESCRIPTION
Fix missing attribute normalization In the `insertEmpty` method of `HtmlTreeBuilder`.

Solves the same problem as #1224 but more naturally respecting case sensitivity settings for xml parsers.