### PR TITLE
the issue 986 is fixed

### DIFF
--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -264,11 +264,15 @@ public class TokenQueue {
         char last = 0;
         boolean inSingleQuote = false;
         boolean inDoubleQuote = false;
-
+        boolean isQE = false;
         do {
             if (isEmpty()) break;
             char c = consume();
-            if (last == 0 || last != ESC) {
+            if(last==ESC && c=='Q')
+                isQE=true;
+            else if(last==ESC && c=='E')
+                isQE=false;
+            if ( (last == 0 || last != ESC) && (!isQE)) {
                 if (c == '\'' && c != open && !inDoubleQuote)
                     inSingleQuote = !inSingleQuote;
                 else if (c == '"' && c != open && !inSingleQuote)
@@ -284,7 +288,6 @@ public class TokenQueue {
                 else if (c == close)
                     depth--;
             }
-
             if (depth > 0 && last != 0)
                 end = pos; // don't include the outer match pair in the return
             last = c;


### PR DESCRIPTION
fix the bug 986. The bug is that  chompBalance() did not ignore the bracket in \Q \E and leads to unbalanced brackets error .  It should ignore. So I modify the chompBalance() by ignoring the brackets which are between \Q \E.