### PR TITLE
basic fix for Issue 1117

### DIFF
--- a/src/main/java/org/jsoup/nodes/Comment.java
+++ b/src/main/java/org/jsoup/nodes/Comment.java
@@ -14,6 +14,7 @@ public class Comment extends LeafNode {
      Create a new comment node.
      @param data The contents of the comment
      */
+    boolean isDownLevelRevealed = false;
     public Comment(String data) {
         value = data;
     }
@@ -38,10 +39,18 @@ public class Comment extends LeafNode {
 	void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         if (out.prettyPrint() && ((siblingIndex() == 0 && parentNode instanceof Element && ((Element) parentNode).tag().formatAsBlock()) || (out.outline() )))
             indent(accum, depth, out);
-        accum
-                .append("<!--")
-                .append(getData())
-                .append("-->");
+        if(isDownLevelRevealed){
+            accum
+                    .append("<!")
+                    .append(getData())
+                    .append(">");
+        }
+        else{
+            accum
+                    .append("<!--")
+                    .append(getData())
+                    .append("-->");
+        }
     }
 
 	void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {}
@@ -79,5 +88,9 @@ public class Comment extends LeafNode {
             decl.attributes().addAll(el.attributes());
         }
         return decl;
+    }
+
+    public void setDownLevelRevealed(boolean flag){
+        isDownLevelRevealed = flag;
     }
 }

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -212,7 +212,6 @@ public class HtmlTreeBuilder extends TreeBuilder {
             tokeniser.emit(emptyEnd.reset().name(el.tagName()));  // ensure we get out of whatever state we are in. emitted for yielded processing
             return el;
         }
-
         Element el = new Element(Tag.valueOf(startTag.name(), settings), null, settings.normalizeAttributes(startTag.attributes));
         insert(el);
         return el;
@@ -254,8 +253,13 @@ public class HtmlTreeBuilder extends TreeBuilder {
         return el;
     }
 
+    /**
+     * From a comment token build a Comment node and inset it to stack.
+     * @param commentToken The corresponding comment token
+     */
     void insert(Token.Comment commentToken) {
         Comment comment = new Comment(commentToken.getData());
+        comment.setDownLevelRevealed(commentToken.isDownLevelRevealed);
         insertNode(comment);
     }
 

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -260,12 +260,14 @@ abstract class Token {
         private final StringBuilder data = new StringBuilder();
         private String dataS; // try to get in one shot
         boolean bogus = false;
+        boolean isDownLevelRevealed = false;
 
         @Override
         Token reset() {
             reset(data);
             dataS = null;
             bogus = false;
+            isDownLevelRevealed = false;
             return this;
         }
 
@@ -301,12 +303,31 @@ abstract class Token {
             }
         }
 
+        public void setDownLevelRevealed(boolean flag){
+            isDownLevelRevealed = flag;
+        }
 
+        /**
+         * According to the attribute isDownLevelRevealed, return the whole string of token.
+         * @return The whole string of this token,
+         */
         @Override
         public String toString() {
-            return "<!--" + getData() + "-->";
+            return isDownLevelRevealed ? "<!" + getData() + ">":"<!--" + getData() + "-->";
         }
     }
+
+//    final static class DownLevelRevealed extends Comment {
+//
+////        DownLevelRevealed() {
+////            type = TokenType.Comment;
+////        }
+//
+//        @Override
+//        public String toString() {
+//            return "<!" + getData() + ">";
+//        }
+//    }
 
     static class Character extends Token {
         private String data;

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -317,18 +317,6 @@ abstract class Token {
         }
     }
 
-//    final static class DownLevelRevealed extends Comment {
-//
-////        DownLevelRevealed() {
-////            type = TokenType.Comment;
-////        }
-//
-//        @Override
-//        public String toString() {
-//            return "<!" + getData() + ">";
-//        }
-//    }
-
     static class Character extends Token {
         private String data;
 

--- a/src/test/java/org/jsoup/DownLevelTest.java
+++ b/src/test/java/org/jsoup/DownLevelTest.java
@@ -1,0 +1,53 @@
+package org.jsoup;
+
+import org.jsoup.nodes.Comment;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Node;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DownLevelTest {
+    @Test
+    void downLevelRevealedTokenTest(){
+        Comment cmt = new Comment("[if true]>1<![endif]");
+        assertEquals("<!--[if true]>1<![endif]-->", cmt.outerHtml());
+        cmt.setDownLevelRevealed(true);
+        assertEquals("<![if true]>1<![endif]>", cmt.outerHtml());
+    }
+
+    @Test
+    void outputTest() {
+        String html = "<div>"
+                + "<![if true]>1<![endif]>" // downlevel-revealed
+                + "<!--[if true]>2<![endif]-->" // downlevel-hidden
+                + "</div>";
+        Document document = Jsoup.parse(html);
+        String expected  = "<html>\n" +
+                " <head></head>\n" +
+                " <body>\n" +
+                "  <div>\n" +
+                "   <![if true]>1<![endif]><!--[if true]>2<![endif]-->\n" +
+                "  </div>\n" +
+                " </body>\n" +
+                "</html>";
+        assertEquals(expected, document.html());
+    }
+
+    @Test
+    void typeTest() {
+        String html = "<div>"
+                + "<![if true]>1<![endif]>" // downlevel-revealed
+                + "<!--[if true]>2<![endif]-->" // downlevel-hidden
+                + "</div>";
+        Document document = Jsoup.parse(html);
+        List<Node> nodes = document.select("div").first().childNodes();
+        assertEquals(2, nodes.size());
+        for(Node nd: nodes){
+            assertTrue(nd instanceof Comment);
+        }
+    }
+}


### PR DESCRIPTION
I tried a basic fix for issue 1117. The down level revealed will be parse into a whole Comment node with an additional atrribute "isDownLevelRevealed=true". And now both the result of token.toString and document.html will show down level revealed like "<!if true>1<!endif>" but not " <!--[if true]-->1<!--[endif]-->" any more.