### PR TITLE
Fix Issue #1361 may bring higher performance

### DIFF
--- a/src/main/java/org/jsoup/parser/HtmlShrinker.java
+++ b/src/main/java/org/jsoup/parser/HtmlShrinker.java
@@ -1,0 +1,83 @@
+package org.jsoup.parser;
+
+import java.util.Vector;
+
+/**
+ Increase efficiency: Shrink html text by ignoring specified content.
+ An additional feature provided to users.
+ Can reduce amount of Textnode by ignore "\n" to speed up parse.*/
+public class HtmlShrinker {
+
+    private static int[] getNext(String aim) {
+        char[] aimArray = aim.toCharArray();
+        int[] next = new int[aimArray.length];
+        next[0] = -1;
+        int j = 0;
+        int k = -1;
+        while (j < aimArray.length - 1) {
+            if (k == -1 || aimArray[j] == aimArray[k]) {
+                next[j+1] = k+1;
+                j++;
+                k++;
+            } else {
+                k = next[k];
+            }
+        }
+        return next;
+    }
+
+    private static Vector<Integer> KMP(String essay, String aim) {
+        char[] t = essay.toCharArray();
+        char[] p = aim.toCharArray();
+        int i = 0, j = 0;
+        Vector<Integer> appear = new Vector<>();
+        int[] next = getNext(aim);
+        while (i < t.length && j < p.length) {
+            if (j == -1) {
+                i++;
+                j=0;
+            }
+            else if(t[i] == p[j]){
+                i++;
+                j++;
+                if (j == p.length) {
+                    appear.addElement(Integer.valueOf(i-j+1));
+                    j=next[j-1];
+                    i= i - 1;
+                }
+            }
+            else {
+                j = next[j];
+            }
+        }
+        return appear;
+    }
+
+    /**
+     * Delete Strings need to be ignored from original html text
+     * @param html current html text
+     * @param shrinkTarget ignored content
+     * @return this, new html without ignored contents.
+     */
+    public static String htmlShrink(String html, String shrinkTarget){
+        Vector<Integer> appearList = KMP(html,shrinkTarget);
+        char[] htmlChars = html.toCharArray();
+        StringBuffer shrinkedHtml = new StringBuffer();
+        int htmlLength = htmlChars.length;
+        int targetLength = shrinkTarget.length();
+        int appearTimes = appearList.size();
+        if(appearTimes == 0) return html;
+        int count = 0;
+        boolean shrinkFinish = false;
+        for(int i=0; i<htmlLength; i++){
+            if(shrinkFinish==false && i == (appearList.get(count)-1) && (i==0 || htmlChars[i-1]!='\\')) {
+                i = i + (targetLength -1);
+                count++;
+                if(count == appearTimes) shrinkFinish=true;
+                continue;
+            }
+            shrinkedHtml.append(htmlChars[i]);
+        }
+        return shrinkedHtml.toString();
+    }
+}

--- a/src/test/java/org/jsoup/parser/ShrinkTest.java
+++ b/src/test/java/org/jsoup/parser/ShrinkTest.java
@@ -1,0 +1,86 @@
+package org.jsoup.parser;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Node;
+import org.jsoup.select.NodeTraversor;
+import org.jsoup.select.NodeVisitor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/**
+ * Tests for HtmlShrinker.
+ *
+ */
+public class ShrinkTest {
+    @Test
+    public void shrinkTest(){
+        String A = "AB\\nCD\nADBCAB\n\n\n";
+        String B = "\n";
+        assertEquals("AB\\nCDADBCAB",HtmlShrinker.htmlShrink(A,B));
+    }
+    @Test
+    public void withoutShrinkTest(){
+        String html = "<html>\n" +
+                "<head>\n" +
+                "<title>Example - Text Formating Tags</title>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "test\n" +
+                "</body>\n" +
+                "</html>";
+        final StringBuilder accum = new StringBuilder();
+        final Document doc = Jsoup.parse(html);
+        NodeTraversor.traverse(new NodeVisitor() {
+            @Override
+            public void head(Node node, int depth) {
+                accum.append("<").append(node.nodeName()).append(">");
+                return;
+            }
+
+            @Override
+            public void tail(Node node, int depth) {
+                accum.append("</").append(node.nodeName()).append(">");
+                return;
+            }
+        }, doc.root());
+
+        assertEquals("<#document><html><#text></#text><head><#text></#text><title>" +
+                "<#text></#text></title><#text></#text></head><#text></#text><body><#text>" +
+                "</#text><#text></#text></body></html></#document>",accum.toString());
+    }
+    @Test
+    public void shrinkHtmlTest() {
+        String html = "<html>\n" +
+                "<head>\n" +
+                "<title>Example - Text Formating Tags</title>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                "test\n" +
+                "</body>\n" +
+                "</html>";
+        html = HtmlShrinker.htmlShrink(html,"\n");
+        assertEquals("<html><head><title>Example - Text Formating Tags</title></head><body>test</body>" +
+                "</html>",html);
+        final StringBuilder accum = new StringBuilder();
+        final Document doc = Jsoup.parse(html);
+        NodeTraversor.traverse(new NodeVisitor() {
+            @Override
+            public void head(Node node, int depth) {
+                accum.append("<").append(node.nodeName()).append(">");
+                return;
+            }
+
+            @Override
+            public void tail(Node node, int depth) {
+                accum.append("</").append(node.nodeName()).append(">");
+                return;
+            }
+        }, doc.root());
+        assertEquals("<#document><html><head><title><#text></#text>" +
+                "</title></head><body><#text></#text></body></html></#document>",accum.toString());
+    }
+
+}


### PR DESCRIPTION
Add  Class HtmlShrinker(org.jsoup.parser.HtmlShrinker)  and its corresponding test(org.jsoup.parser.ShrinkTest):

Issue #1361 shows parser generate spare empty TextNode for "\n".
Ignore "\n" can reduce amount of nodes, thus increase performance each time traverse the Tree.

To be extend, I add a class HtmlShrinker used to ignore any content string specified by users. Not only "\n", this feature may help users to filter sometext they think useless in html text.