### PR TITLE
I fix the bug in 986 and add corresponding test.

### DIFF
--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -264,18 +264,25 @@ public class TokenQueue {
         char last = 0;
         boolean inSingleQuote = false;
         boolean inDoubleQuote = false;
-
+        boolean isQE = false;
         do {
             if (isEmpty()) break;
             char c = consume();
-            if (last == 0 || last != ESC) {
+            if(last==ESC){
+                if(c=='Q'){
+                    isQE=true;
+                }
+                if(c=='E'){
+                    isQE=false;
+                }
+            }
+            if ( (last == 0 || last != ESC) && (!isQE)) {
                 if (c == '\'' && c != open && !inDoubleQuote)
                     inSingleQuote = !inSingleQuote;
                 else if (c == '"' && c != open && !inSingleQuote)
                     inDoubleQuote = !inDoubleQuote;
                 if (inSingleQuote || inDoubleQuote)
                     continue;
-
                 if (c == open) {
                     depth++;
                     if (start == -1)
@@ -284,7 +291,6 @@ public class TokenQueue {
                 else if (c == close)
                     depth--;
             }
-
             if (depth > 0 && last != 0)
                 end = pos; // don't include the outer match pair in the return
             last = c;

--- a/src/test/java/org/jsoup/parser/TokenQueueTest.java
+++ b/src/test/java/org/jsoup/parser/TokenQueueTest.java
@@ -1,10 +1,12 @@
 package org.jsoup.parser;
 
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Token queue tests.
@@ -38,6 +40,14 @@ public class TokenQueueTest {
         tq.consumeTo("(");
         String match = tq.chompBalanced('(', ')');
         assertEquals("something(or another)", match);
+    }
+    @Test public void chompBalanceWhenBracketInQE() {
+        final Document doc = Jsoup.parse("<div>1) foo</div>");
+        assertNotEquals("",doc.select("div:matches(" + Pattern.quote("1)")+ ")").toString());
+    }
+    @Test public void chompBalanceWhenManyBracketInQE() {
+        final Document doc = Jsoup.parse("<div>1) foo</div>");
+        assertEquals("",doc.select("div:matches(" + Pattern.quote("1)))")+ ")").toString());
     }
 
     @Test public void unescape() {


### PR DESCRIPTION
I fix the bug in 986 and add corresponding test. I modify the chompBalance() by ignoring the brackets which are between \Q \E. Then it work well. 