### PR TITLE
Fix for issue #876

### DIFF
--- a/src/main/java/org/jsoup/internal/Normalizer.java
+++ b/src/main/java/org/jsoup/internal/Normalizer.java
@@ -12,7 +12,7 @@ public final class Normalizer {
     }
 
     public static String normalize(final String input) {
-        return lowerCase(input).trim();
+        return lowerCase(input.trim());
     }
 
     public static String normalize(final String input, boolean isStringLiteral) {

--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -656,11 +656,11 @@ public abstract class Evaluator {
 	 * Evaluator for matching Element (and its descendants) text
 	 */
 	public static final class ContainsText extends Evaluator {
-		private static final Pattern doubleSpaces = Pattern.compile("  +");
+		private static final Pattern multipleSpaces = Pattern.compile("  +");
 		private String searchText;
 
 		public ContainsText(String searchText) {
-			this.searchText = doubleSpaces.matcher(normalize(searchText)).replaceAll(" ");
+			this.searchText = multipleSpaces.matcher(normalize(searchText)).replaceAll(" ");
 		}
 
 		@Override

--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -652,26 +652,27 @@ public abstract class Evaluator {
         }
     }
 
-    /**
-     * Evaluator for matching Element (and its descendants) text
-     */
-    public static final class ContainsText extends Evaluator {
-        private String searchText;
+	/**
+	 * Evaluator for matching Element (and its descendants) text
+	 */
+	public static final class ContainsText extends Evaluator {
+		private static final Pattern doubleSpaces = Pattern.compile("  +");
+		private String searchText;
 
-        public ContainsText(String searchText) {
-            this.searchText = lowerCase(searchText);
-        }
+		public ContainsText(String searchText) {
+			this.searchText = doubleSpaces.matcher(normalize(searchText)).replaceAll(" ");
+		}
 
-        @Override
-        public boolean matches(Element root, Element element) {
-            return lowerCase(element.text()).contains(searchText);
-        }
+		@Override
+		public boolean matches(Element root, Element element) {
+			return lowerCase(element.text()).contains(searchText);
+		}
 
-        @Override
-        public String toString() {
-            return String.format(":contains(%s)", searchText);
-        }
-    }
+		@Override
+		public String toString() {
+			return String.format(":contains(%s)", searchText);
+		}
+	}
 
     /**
      * Evaluator for matching Element (and its descendants) data

--- a/src/test/java/org/jsoup/select/SelectorTest.java
+++ b/src/test/java/org/jsoup/select/SelectorTest.java
@@ -617,6 +617,14 @@ public class SelectorTest {
         assertEquals("2", ps2.first().id());
     }
 
+    @Test public void testPseudoContainsWithMultipleSpaces() {
+        String html = "<p> <span> <i> One  </i>  </span>  <span>  Two </span>   </p>";
+        Document doc = Jsoup.parse(html);
+        Elements els = doc.select("p:contains(    One  Two  )");
+        assertEquals(1, els.size());
+        assertEquals("One Two", els.text());
+    }
+
     @MultiLocaleTest
     public void containsOwn(Locale locale) {
         Locale.setDefault(locale);


### PR DESCRIPTION
https://github.com/jhy/jsoup/issues/876

Added a compiled RegEx, for maximum performance, for checking and removing multiple spaces.

Though not directly related to the issue, I also modified `Normalizer.normalize(String)`; by doing `trim()` before `toLowerCase()`, it means potentially less characters to iterate over in `toLowerCase()`.