### PR TITLE
Fix the issue 1006

### DIFF
--- a/src/main/java/org/jsoup/parser/CharacterReader.java
+++ b/src/main/java/org/jsoup/parser/CharacterReader.java
@@ -505,10 +505,20 @@ public final class CharacterReader {
         return !isEmpty() && Arrays.binarySearch(seq, charBuf[bufPos]) >= 0;
     }
 
+    private boolean isChinese(char c){
+        int x = c;
+        if(x >= 0x4e00 && x <= 0x9fbb){
+            return true;
+        }
+        return false;
+    }
     boolean matchesLetter() {
         if (isEmpty())
             return false;
         char c = charBuf[bufPos];
+        if(isChinese(c)){
+            return false;
+        }
         return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || Character.isLetter(c);
     }
 

--- a/src/test/java/org/jsoup/ExampleTest.java
+++ b/src/test/java/org/jsoup/ExampleTest.java
@@ -1,0 +1,30 @@
+package org.jsoup;
+import org.jsoup.Jsoup;
+import org.jsoup.internal.StringUtil;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+public class ExampleTest {
+    @Test
+    public void testChineseTag() {
+        String s = "<p><一></p>";
+        Document doc =Jsoup.parse(s);
+        assertEquals("<一>",doc.text());
+    }
+    @Test
+    public void testAlphabetTag() {
+        for(int i=0;i<26;i++){
+            char c = (char)('a'+i);
+            String s = "<p><"+c+"></p>";
+            Document doc =Jsoup.parse(s);
+            assertEquals("",doc.text());
+            c = (char)('A'+i);
+            s = "<p><"+c+"></p>";
+            doc =Jsoup.parse(s);
+            assertEquals("",doc.text());
+        }
+
+
+    }
+}


### PR DESCRIPTION
Fix the issue 1006. In old version, Chinese character is also considered as legal tag. e.g<一></一> this is not allow in chrome. String "<一>"will be mistaken as unclosed tag and be replace by <一></一>. The reason is that Character.isLetter() will consider all character in all language as letter.