### PR TITLE
Fix incorrect template element xml serialization

### DIFF
--- a/src/main/java/org/jsoup/parser/TemplateTest.java
+++ b/src/main/java/org/jsoup/parser/TemplateTest.java
@@ -1,0 +1,71 @@
+package org.jsoup.parser;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TemplateTest {
+    @Test
+    public void testParseTemplateWithTrTd() {
+        String html = "<template id=\"lorem-ipsum\">\n" +
+                " <tr>\n" +
+                "    <td>Lorem</td>\n" +
+                "    <td>Ipsum</td>\n" +
+                " </tr>\n" +
+                "</template>";
+
+
+        Document doc = Jsoup.parse(html);
+        doc.outputSettings().prettyPrint(false);
+        doc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+
+
+        assertEquals("<html><head></head><body><template id=\"lorem-ipsum\">\n" +
+                " <tr>\n" +
+                "    <td>Lorem</td>\n" +
+                "    <td>Ipsum</td>\n" +
+                " </tr>\n" +
+                "</template></body></html>", doc.outerHtml());
+        System.out.println(doc.outerHtml());
+    }
+
+    @Test
+    public void testParseTemplateWidthTd() {
+        String html = "<template id=\"lorem-ipsum\">\n" +
+                "    <td>Lorem</td>\n" +
+                "    <td>Ipsum</td>\n" +
+                "</template>";
+
+
+        Document doc = Jsoup.parse(html);
+        doc.outputSettings().prettyPrint(false);
+        doc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+
+
+        assertEquals("<html><head></head><body><template id=\"lorem-ipsum\">\n" +
+                "    <td>Lorem</td>\n" +
+                "    <td>Ipsum</td>\n" +
+                "</template></body></html>", doc.outerHtml());
+        System.out.println(doc.outerHtml());
+    }
+    
+    @Test
+    public void testParseTemplateWidthTr() {
+        String html = "<template id=\"lorem-ipsum\">\n" +
+                "    <tr>Lorem</tr>\n" +
+                "</template>";
+
+
+        Document doc = Jsoup.parse(html);
+        doc.outputSettings().prettyPrint(false);
+        doc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+
+
+        assertEquals("<html><head></head><body><template id=\"lorem-ipsum\">\n" +
+                "    <tr>Lorem</tr>\n" +
+                "</template></body></html>", doc.outerHtml());
+        System.out.println(doc.outerHtml());
+    }
+}

--- a/src/test/java/org/jsoup/parser/TemplateTest.java
+++ b/src/test/java/org/jsoup/parser/TemplateTest.java
@@ -1,0 +1,60 @@
+package org.jsoup.parser;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TemplateTest {
+    @Test
+    public void testParseTemplateWidthTd() {
+        String html = "<template id=\"lorem-ipsum\">\n" +
+                "    <td>Lorem</td>\n" +
+                "    <td>Ipsum</td>\n" +
+                "</template>";
+
+
+        Document doc = Jsoup.parse(html);
+        doc.outputSettings().prettyPrint(false);
+        doc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+
+        assertEquals("<html><head></head><body><template id=\"lorem-ipsum\">\n" +
+                "    <td>Lorem</td>\n" +
+                "    <td>Ipsum</td>\n" +
+                "</template></body></html>", doc.outerHtml());
+        System.out.println(doc.outerHtml());
+    }
+
+    @Test
+    public void testParseTemplateWidthTr() {
+        String html = "<template id=\"lorem-ipsum\">\n" +
+                "    <tr>Lorem</tr>\n" +
+                "</template>";
+
+
+        Document doc = Jsoup.parse(html);
+        doc.outputSettings().prettyPrint(false);
+        doc.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+
+
+        assertEquals("<html><head></head><body><template id=\"lorem-ipsum\">\n" +
+                "    <tr>Lorem</tr>\n" +
+                "</template></body></html>", doc.outerHtml());
+        System.out.println(doc.outerHtml());
+    }
+
+    @Test
+    public void parseXml() {
+        String html =
+                "<table id=\"lorem-ipsum\">\n" +
+                        "  <tr>\n" +
+                        "    <td>Lorem</td>\n" +
+                        "    <td>Ipsum</td>\n" +
+                        "  </tr>\n" +
+                        "</table>";
+
+        Document doc = Jsoup.parse(html);
+        System.out.println(doc);
+    }
+}


### PR DESCRIPTION
Fix #1315 

After parsing the HTML fragment, the inner start/end tags is included.