### PR TITLE
Fix regression on Elements.forms()

### DIFF
--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -636,7 +636,11 @@ public class Elements extends ArrayList<Element> {
      * no forms.
      */
     public List<FormElement> forms() {
-        return nodesOfType(FormElement.class);
+        ArrayList<FormElement> forms = new ArrayList<>();
+        for (Element el: this)
+            if (el instanceof FormElement)
+                forms.add((FormElement) el);
+        return forms;
     }
 
     /**
@@ -644,7 +648,7 @@ public class Elements extends ArrayList<Element> {
      * @return Comment nodes, or an empty list if none.
      */
     public List<Comment> comments() {
-        return nodesOfType(Comment.class);
+        return childNodesOfType(Comment.class);
     }
 
     /**
@@ -652,7 +656,7 @@ public class Elements extends ArrayList<Element> {
      * @return TextNode nodes, or an empty list if none.
      */
     public List<TextNode> textNodes() {
-        return nodesOfType(TextNode.class);
+        return childNodesOfType(TextNode.class);
     }
 
     /**
@@ -661,20 +665,16 @@ public class Elements extends ArrayList<Element> {
      * @return Comment nodes, or an empty list if none.
      */
     public List<DataNode> dataNodes() {
-        return nodesOfType(DataNode.class);
+        return childNodesOfType(DataNode.class);
     }
 
-    private <T extends Node> List<T> nodesOfType(Class<T> tClass) {
+    private <T extends Node> List<T> childNodesOfType(Class<T> tClass) {
         ArrayList<T> nodes = new ArrayList<>();
         for (Element el: this) {
-            if (el.getClass().isInstance(tClass)) { // Handles FormElements
-                nodes.add(tClass.cast(el));
-            } else if (Node.class.isAssignableFrom(tClass)) { // check if child nodes match
-                for (int i = 0; i < el.childNodeSize(); i++) {
-                    Node node = el.childNode(i);
-                    if (tClass.isInstance(node))
-                        nodes.add(tClass.cast(node));
-                }
+            for (int i = 0; i < el.childNodeSize(); i++) {
+                Node node = el.childNode(i);
+                if (tClass.isInstance(node))
+                    nodes.add(tClass.cast(node));
             }
         }
         return nodes;

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -282,8 +282,8 @@ public class ElementsTest {
 
     @Test public void forms() {
         Document doc = Jsoup.parse("<form id=1><input name=q></form><div /><form id=2><input name=f></form>");
-        Elements els = doc.select("*");
-        assertEquals(9, els.size());
+        Elements els = doc.select("form, div");
+        assertEquals(3, els.size());
 
         List<FormElement> forms = els.forms();
         assertEquals(2, forms.size());
@@ -335,11 +335,6 @@ public class ElementsTest {
     @Test public void nodesEmpty() {
         Document doc = Jsoup.parse("<p>");
         assertEquals(0, doc.select("form").textNodes().size());
-    }
-
-    @Test public void formElementsDescendButNotAccumulate() {
-        Document doc = Jsoup.parse("<div><div><form id=1>");
-        assertEquals(1, doc.select("div").forms().size());
     }
 
     @Test public void classWithHyphen() {


### PR DESCRIPTION
the `Elements.forms()` method used to return FormElement-s that are directly in the Elements collection. This behaviour was broken since a657ae0240b875a703a1e4909d56ad59997d362d. See https://github.com/jhy/jsoup/issues/1384

I wrote the fix accordingly to what's written in the javadocs of the methods involved:
* `comments`, `textNodes` and `dataNodes` says they return direct child nodes. I specialized the private `nodesOfType` method to handle child node lookup only (and renamed it `childNodesOfType`)
* `forms()` doc says it returns the forms elements present in the selected elements, not child nodes. I removed the use of `nodesOfType` and put back the previous code.