### PR TITLE
Rename whitelist to allowlist

### DIFF
--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -3,7 +3,7 @@ package org.jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import org.jsoup.safety.Cleaner;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Allowlist;
 import org.jsoup.helper.DataUtil;
 import org.jsoup.helper.HttpConnection;
 
@@ -189,14 +189,14 @@ public class Jsoup {
 
      @param bodyHtml  input untrusted HTML (body fragment)
      @param baseUri   URL to resolve relative URLs against
-     @param whitelist white-list of permitted HTML elements
+     @param allowlist white-list of permitted HTML elements
      @return safe HTML (body fragment)
 
      @see Cleaner#clean(Document)
      */
-    public static String clean(String bodyHtml, String baseUri, Whitelist whitelist) {
+    public static String clean(String bodyHtml, String baseUri, Allowlist allowlist) {
         Document dirty = parseBodyFragment(bodyHtml, baseUri);
-        Cleaner cleaner = new Cleaner(whitelist);
+        Cleaner cleaner = new Cleaner(allowlist);
         Document clean = cleaner.clean(dirty);
         return clean.body().html();
     }
@@ -206,13 +206,13 @@ public class Jsoup {
      tags and attributes.
 
      @param bodyHtml  input untrusted HTML (body fragment)
-     @param whitelist white-list of permitted HTML elements
+     @param allowlist white-list of permitted HTML elements
      @return safe HTML (body fragment)
 
      @see Cleaner#clean(Document)
      */
-    public static String clean(String bodyHtml, Whitelist whitelist) {
-        return clean(bodyHtml, "", whitelist);
+    public static String clean(String bodyHtml, Allowlist allowlist) {
+        return clean(bodyHtml, "", allowlist);
     }
 
     /**
@@ -224,14 +224,14 @@ public class Jsoup {
      *
      * @param bodyHtml input untrusted HTML (body fragment)
      * @param baseUri URL to resolve relative URLs against
-     * @param whitelist white-list of permitted HTML elements
+     * @param allowlist white-list of permitted HTML elements
      * @param outputSettings document output settings; use to control pretty-printing and entity escape modes
      * @return safe HTML (body fragment)
      * @see Cleaner#clean(Document)
      */
-    public static String clean(String bodyHtml, String baseUri, Whitelist whitelist, Document.OutputSettings outputSettings) {
+    public static String clean(String bodyHtml, String baseUri, Allowlist allowlist, Document.OutputSettings outputSettings) {
         Document dirty = parseBodyFragment(bodyHtml, baseUri);
-        Cleaner cleaner = new Cleaner(whitelist);
+        Cleaner cleaner = new Cleaner(allowlist);
         Document clean = cleaner.clean(dirty);
         clean.outputSettings(outputSettings);
         return clean.body().html();
@@ -242,12 +242,12 @@ public class Jsoup {
      <p>The input HTML should still be run through the cleaner to set up enforced attributes, and to tidy the output.
      <p>Assumes the HTML is a body fragment (i.e. will be used in an existing HTML document body.)
      @param bodyHtml HTML to test
-     @param whitelist whitelist to test against
+     @param allowlist whitelist to test against
      @return true if no tags or attributes were removed; false otherwise
-     @see #clean(String, org.jsoup.safety.Whitelist) 
+     @see #clean(String, Allowlist)
      */
-    public static boolean isValid(String bodyHtml, Whitelist whitelist) {
-        return new Cleaner(whitelist).isValidBodyHtml(bodyHtml);
+    public static boolean isValid(String bodyHtml, Allowlist allowlist) {
+        return new Cleaner(allowlist).isValidBodyHtml(bodyHtml);
     }
     
 }

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -189,7 +189,7 @@ public class Jsoup {
 
      @param bodyHtml  input untrusted HTML (body fragment)
      @param baseUri   URL to resolve relative URLs against
-     @param allowlist white-list of permitted HTML elements
+     @param allowlist list of allowed HTML elements
      @return safe HTML (body fragment)
 
      @see Cleaner#clean(Document)
@@ -206,7 +206,7 @@ public class Jsoup {
      tags and attributes.
 
      @param bodyHtml  input untrusted HTML (body fragment)
-     @param allowlist white-list of permitted HTML elements
+     @param allowlist list of allowed HTML elements
      @return safe HTML (body fragment)
 
      @see Cleaner#clean(Document)
@@ -216,15 +216,15 @@ public class Jsoup {
     }
 
     /**
-     * Get safe HTML from untrusted input HTML, by parsing input HTML and filtering it through a white-list of
-     * permitted tags and attributes.
+     * Get safe HTML from untrusted input HTML, by parsing input HTML and filtering it through a list of
+     * allowed tags and attributes.
      * <p>The HTML is treated as a body fragment; it's expected the cleaned HTML will be used within the body of an
      * existing document. If you want to clean full documents, use {@link Cleaner#clean(Document)} instead, and add
      * structural tags (<code>html, head, body</code> etc) to the allowlist.
      *
      * @param bodyHtml input untrusted HTML (body fragment)
      * @param baseUri URL to resolve relative URLs against
-     * @param allowlist white-list of permitted HTML elements
+     @param allowlist list of allowed HTML elements
      * @param outputSettings document output settings; use to control pretty-printing and entity escape modes
      * @return safe HTML (body fragment)
      * @see Cleaner#clean(Document)

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -220,7 +220,7 @@ public class Jsoup {
      * permitted tags and attributes.
      * <p>The HTML is treated as a body fragment; it's expected the cleaned HTML will be used within the body of an
      * existing document. If you want to clean full documents, use {@link Cleaner#clean(Document)} instead, and add
-     * structural tags (<code>html, head, body</code> etc) to the whitelist.
+     * structural tags (<code>html, head, body</code> etc) to the allowlist.
      *
      * @param bodyHtml input untrusted HTML (body fragment)
      * @param baseUri URL to resolve relative URLs against
@@ -238,11 +238,11 @@ public class Jsoup {
     }
 
     /**
-     Test if the input body HTML has only tags and attributes allowed by the Whitelist. Useful for form validation.
+     Test if the input body HTML has only tags and attributes allowed by the Allowlist. Useful for form validation.
      <p>The input HTML should still be run through the cleaner to set up enforced attributes, and to tidy the output.
      <p>Assumes the HTML is a body fragment (i.e. will be used in an existing HTML document body.)
      @param bodyHtml HTML to test
-     @param allowlist whitelist to test against
+     @param allowlist allowlist to test against
      @return true if no tags or attributes were removed; false otherwise
      @see #clean(String, Allowlist)
      */

--- a/src/main/java/org/jsoup/safety/Allowlist.java
+++ b/src/main/java/org/jsoup/safety/Allowlist.java
@@ -2,7 +2,7 @@ package org.jsoup.safety;
 
 /*
     Thank you to Ryan Grove (wonko.com) for the Ruby HTML cleaner http://github.com/rgrove/sanitize/, which inspired
-    this whitelist configuration, and the initial defaults.
+    this allowlist configuration, and the initial defaults.
  */
 
 import org.jsoup.helper.Validate;
@@ -19,7 +19,7 @@ import static org.jsoup.internal.Normalizer.lowerCase;
 
 
 /**
- Whitelists define what HTML (elements and attributes) to allow through the cleaner. Everything else is removed.
+ Allowlists define what HTML (elements and attributes) to allow through the cleaner. Everything else is removed.
  <p>
  Start with one of the defaults:
  </p>
@@ -31,7 +31,7 @@ import static org.jsoup.internal.Normalizer.lowerCase;
  <li>{@link #relaxed}
  </ul>
  <p>
- If you need to allow more through (please be careful!), tweak a base whitelist with:
+ If you need to allow more through (please be careful!), tweak a base allowlist with:
  </p>
  <ul>
  <li>{@link #addTags}
@@ -40,7 +40,7 @@ import static org.jsoup.internal.Normalizer.lowerCase;
  <li>{@link #addProtocols}
  </ul>
  <p>
- You can remove any setting from an existing whitelist with:
+ You can remove any setting from an existing allowlist with:
  </p>
  <ul>
  <li>{@link #removeTags}
@@ -50,9 +50,9 @@ import static org.jsoup.internal.Normalizer.lowerCase;
  </ul>
  
  <p>
- The cleaner and these whitelists assume that you want to clean a <code>body</code> fragment of HTML (to add user
+ The cleaner and these allowlists assume that you want to clean a <code>body</code> fragment of HTML (to add user
  supplied HTML into a templated page), and not to clean a full HTML document. If the latter is the case, either wrap the
- document HTML around the cleaned body HTML, or create a whitelist that allows <code>html</code> and <code>head</code>
+ document HTML around the cleaned body HTML, or create an allowlist that allows <code>html</code> and <code>head</code>
  elements as appropriate.
  </p>
  <p>

--- a/src/main/java/org/jsoup/safety/Allowlist.java
+++ b/src/main/java/org/jsoup/safety/Allowlist.java
@@ -56,14 +56,14 @@ import static org.jsoup.internal.Normalizer.lowerCase;
  elements as appropriate.
  </p>
  <p>
- If you are going to extend a whitelist, please be very careful. Make sure you understand what attributes may lead to
+ If you are going to extend an allowlist, please be very careful. Make sure you understand what attributes may lead to
  XSS attack vectors. URL attributes are particularly vulnerable and require careful validation. See 
  http://ha.ckers.org/xss.html for some XSS attack examples.
  </p>
 
  @author Jonathan Hedley
  */
-public class Whitelist {
+public class Allowlist {
     private Set<TagName> tagNames; // tags allowed, lower case. e.g. [p, br, span]
     private Map<TagName, Set<AttributeKey>> attributes; // tag -> attribute[]. allowed attributes [href] for a tag.
     private Map<TagName, Map<AttributeKey, AttributeValue>> enforcedAttributes; // always set these attribute values
@@ -71,29 +71,29 @@ public class Whitelist {
     private boolean preserveRelativeLinks; // option to preserve relative links
 
     /**
-     This whitelist allows only text nodes: all HTML will be stripped.
+     This allowlist allows only text nodes: all HTML will be stripped.
 
-     @return whitelist
+     @return allowlist
      */
-    public static Whitelist none() {
-        return new Whitelist();
+    public static Allowlist none() {
+        return new Allowlist();
     }
 
     /**
-     This whitelist allows only simple text formatting: <code>b, em, i, strong, u</code>. All other HTML (tags and
+     This allowlist allows only simple text formatting: <code>b, em, i, strong, u</code>. All other HTML (tags and
      attributes) will be removed.
 
-     @return whitelist
+     @return allowlist
      */
-    public static Whitelist simpleText() {
-        return new Whitelist()
+    public static Allowlist simpleText() {
+        return new Allowlist()
                 .addTags("b", "em", "i", "strong", "u")
                 ;
     }
 
     /**
      <p>
-     This whitelist allows a fuller range of text nodes: <code>a, b, blockquote, br, cite, code, dd, dl, dt, em, i, li,
+     This allowlist allows a fuller range of text nodes: <code>a, b, blockquote, br, cite, code, dd, dl, dt, em, i, li,
      ol, p, pre, q, small, span, strike, strong, sub, sup, u, ul</code>, and appropriate attributes.
      </p>
      <p>
@@ -104,10 +104,10 @@ public class Whitelist {
      Does not allow images.
      </p>
 
-     @return whitelist
+     @return allowlist
      */
-    public static Whitelist basic() {
-        return new Whitelist()
+    public static Allowlist basic() {
+        return new Allowlist()
                 .addTags(
                         "a", "b", "blockquote", "br", "cite", "code", "dd", "dl", "dt", "em",
                         "i", "li", "ol", "p", "pre", "q", "small", "span", "strike", "strong", "sub",
@@ -127,12 +127,12 @@ public class Whitelist {
     }
 
     /**
-     This whitelist allows the same text tags as {@link #basic}, and also allows <code>img</code> tags, with appropriate
+     This allowlist allows the same text tags as {@link #basic}, and also allows <code>img</code> tags, with appropriate
      attributes, with <code>src</code> pointing to <code>http</code> or <code>https</code>.
 
-     @return whitelist
+     @return allowlist
      */
-    public static Whitelist basicWithImages() {
+    public static Allowlist basicWithImages() {
         return basic()
                 .addTags("img")
                 .addAttributes("img", "align", "alt", "height", "src", "title", "width")
@@ -141,17 +141,17 @@ public class Whitelist {
     }
 
     /**
-     This whitelist allows a full range of text and structural body HTML: <code>a, b, blockquote, br, caption, cite,
+     This allowlist allows a full range of text and structural body HTML: <code>a, b, blockquote, br, caption, cite,
      code, col, colgroup, dd, div, dl, dt, em, h1, h2, h3, h4, h5, h6, i, img, li, ol, p, pre, q, small, span, strike, strong, sub,
      sup, table, tbody, td, tfoot, th, thead, tr, u, ul</code>
      <p>
      Links do not have an enforced <code>rel=nofollow</code> attribute, but you can add that if desired.
      </p>
 
-     @return whitelist
+     @return allowlist
      */
-    public static Whitelist relaxed() {
-        return new Whitelist()
+    public static Allowlist relaxed() {
+        return new Allowlist()
                 .addTags(
                         "a", "b", "blockquote", "br", "caption", "cite", "code", "col",
                         "colgroup", "dd", "div", "dl", "dt", "em", "h1", "h2", "h3", "h4", "h5", "h6",
@@ -182,14 +182,14 @@ public class Whitelist {
     }
 
     /**
-     Create a new, empty whitelist. Generally it will be better to start with a default prepared whitelist instead.
+     Create a new, empty allowlist. Generally it will be better to start with a default prepared allowlist instead.
 
      @see #basic()
      @see #basicWithImages()
      @see #simpleText()
      @see #relaxed()
      */
-    public Whitelist() {
+    public Allowlist() {
         tagNames = new HashSet<>();
         attributes = new HashMap<>();
         enforcedAttributes = new HashMap<>();
@@ -198,12 +198,12 @@ public class Whitelist {
     }
 
     /**
-     Add a list of allowed elements to a whitelist. (If a tag is not allowed, it will be removed from the HTML.)
+     Add a list of allowed elements to an allowlist. (If a tag is not allowed, it will be removed from the HTML.)
 
      @param tags tag names to allow
      @return this (for chaining)
      */
-    public Whitelist addTags(String... tags) {
+    public Allowlist addTags(String... tags) {
         Validate.notNull(tags);
 
         for (String tagName : tags) {
@@ -214,12 +214,12 @@ public class Whitelist {
     }
 
     /**
-     Remove a list of allowed elements from a whitelist. (If a tag is not allowed, it will be removed from the HTML.)
+     Remove a list of allowed elements from an allowlist. (If a tag is not allowed, it will be removed from the HTML.)
 
      @param tags tag names to disallow
      @return this (for chaining)
      */
-    public Whitelist removeTags(String... tags) {
+    public Allowlist removeTags(String... tags) {
         Validate.notNull(tags);
 
         for(String tag: tags) {
@@ -250,7 +250,7 @@ public class Whitelist {
      @param attributes List of valid attributes for the tag
      @return this (for chaining)
      */
-    public Whitelist addAttributes(String tag, String... attributes) {
+    public Allowlist addAttributes(String tag, String... attributes) {
         Validate.notEmpty(tag);
         Validate.notNull(attributes);
         Validate.isTrue(attributes.length > 0, "No attribute names supplied.");
@@ -286,7 +286,7 @@ public class Whitelist {
      @param attributes List of invalid attributes for the tag
      @return this (for chaining)
      */
-    public Whitelist removeAttributes(String tag, String... attributes) {
+    public Allowlist removeAttributes(String tag, String... attributes) {
         Validate.notEmpty(tag);
         Validate.notNull(attributes);
         Validate.isTrue(attributes.length > 0, "No attribute names supplied.");
@@ -328,7 +328,7 @@ public class Whitelist {
      @param value The enforced attribute value
      @return this (for chaining)
      */
-    public Whitelist addEnforcedAttribute(String tag, String attribute, String value) {
+    public Allowlist addEnforcedAttribute(String tag, String attribute, String value) {
         Validate.notEmpty(tag);
         Validate.notEmpty(attribute);
         Validate.notEmpty(value);
@@ -355,7 +355,7 @@ public class Whitelist {
      @param attribute   The attribute name
      @return this (for chaining)
      */
-    public Whitelist removeEnforcedAttribute(String tag, String attribute) {
+    public Allowlist removeEnforcedAttribute(String tag, String attribute) {
         Validate.notEmpty(tag);
         Validate.notEmpty(attribute);
 
@@ -372,7 +372,7 @@ public class Whitelist {
     }
 
     /**
-     * Configure this Whitelist to preserve relative links in an element's URL attribute, or convert them to absolute
+     * Configure this allowlist to preserve relative links in an element's URL attribute, or convert them to absolute
      * links. By default, this is <b>false</b>: URLs will be  made absolute (e.g. start with an allowed protocol, like
      * e.g. {@code http://}.
      * <p>
@@ -383,10 +383,10 @@ public class Whitelist {
      * </p>
      *
      * @param preserve {@code true} to allow relative links, {@code false} (default) to deny
-     * @return this Whitelist, for chaining.
+     * @return this allowlist, for chaining.
      * @see #addProtocols
      */
-    public Whitelist preserveRelativeLinks(boolean preserve) {
+    public Allowlist preserveRelativeLinks(boolean preserve) {
         preserveRelativeLinks = preserve;
         return this;
     }
@@ -407,7 +407,7 @@ public class Whitelist {
      @param protocols List of valid protocols
      @return this, for chaining
      */
-    public Whitelist addProtocols(String tag, String attribute, String... protocols) {
+    public Allowlist addProtocols(String tag, String attribute, String... protocols) {
         Validate.notEmpty(tag);
         Validate.notEmpty(attribute);
         Validate.notNull(protocols);
@@ -449,7 +449,7 @@ public class Whitelist {
      @param removeProtocols List of invalid protocols
      @return this, for chaining
      */
-    public Whitelist removeProtocols(String tag, String attribute, String... removeProtocols) {
+    public Allowlist removeProtocols(String tag, String attribute, String... removeProtocols) {
         Validate.notEmpty(tag);
         Validate.notEmpty(attribute);
         Validate.notNull(removeProtocols);
@@ -478,7 +478,7 @@ public class Whitelist {
     }
 
     /**
-     * Test if the supplied tag is allowed by this whitelist
+     * Test if the supplied tag is allowed by this allowlist
      * @param tag test tag
      * @return true if allowed
      */
@@ -487,7 +487,7 @@ public class Whitelist {
     }
 
     /**
-     * Test if the supplied attribute is allowed by this whitelist for this tag
+     * Test if the supplied attribute is allowed by this allowlist for this tag
      * @param tagName tag to consider allowing the attribute in
      * @param el element under test, to confirm protocol
      * @param attr attribute under test

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -21,7 +21,7 @@ import java.util.List;
  The allowlist based HTML cleaner. Use to ensure that end-user provided HTML contains only the elements and attributes
  that you are expecting; no junk, and no cross-site scripting attacks!
  <p>
- The HTML cleaner parses the input as HTML and then runs it through a white-list, so the output HTML can only contain
+ The HTML cleaner parses the input as HTML and then runs it through an allow-list, so the output HTML can only contain
  HTML that is allowed by the allowlist.
  </p>
  <p>

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -18,11 +18,11 @@ import java.util.List;
 
 
 /**
- The whitelist based HTML cleaner. Use to ensure that end-user provided HTML contains only the elements and attributes
+ The allowlist based HTML cleaner. Use to ensure that end-user provided HTML contains only the elements and attributes
  that you are expecting; no junk, and no cross-site scripting attacks!
  <p>
  The HTML cleaner parses the input as HTML and then runs it through a white-list, so the output HTML can only contain
- HTML that is allowed by the whitelist.
+ HTML that is allowed by the allowlist.
  </p>
  <p>
  It is assumed that the input HTML is a body fragment; the clean methods only pull from the source's body, and the
@@ -36,7 +36,7 @@ public class Cleaner {
     private Allowlist allowlist;
 
     /**
-     Create a new cleaner, that sanitizes documents using the supplied whitelist.
+     Create a new cleaner, that sanitizes documents using the supplied allowlist.
      @param allowlist white-list to clean with
      */
     public Cleaner(Allowlist allowlist) {
@@ -45,7 +45,7 @@ public class Cleaner {
     }
 
     /**
-     Creates a new, clean document, from the original dirty document, containing only elements allowed by the whitelist.
+     Creates a new, clean document, from the original dirty document, containing only elements allowed by the allowlist.
      The original document is not modified. Only elements from the dirt document's <code>body</code> are used.
      @param dirtyDocument Untrusted base document to clean.
      @return cleaned document.
@@ -61,8 +61,8 @@ public class Cleaner {
     }
 
     /**
-     Determines if the input document <b>body</b>is valid, against the whitelist. It is considered valid if all the tags and attributes
-     in the input HTML are allowed by the whitelist, and that there is no content in the <code>head</code>.
+     Determines if the input document <b>body</b>is valid, against the allowlist. It is considered valid if all the tags and attributes
+     in the input HTML are allowed by the allowlist, and that there is no content in the <code>head</code>.
      <p>
      This method can be used as a validator for user input. An invalid document will still be cleaned successfully
      using the {@link #clean(Document)} document. If using as a validator, it is recommended to still clean the document

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -33,15 +33,15 @@ import java.util.List;
  </p>
  */
 public class Cleaner {
-    private Whitelist whitelist;
+    private Allowlist allowlist;
 
     /**
      Create a new cleaner, that sanitizes documents using the supplied whitelist.
-     @param whitelist white-list to clean with
+     @param allowlist white-list to clean with
      */
-    public Cleaner(Whitelist whitelist) {
-        Validate.notNull(whitelist);
-        this.whitelist = whitelist;
+    public Cleaner(Allowlist allowlist) {
+        Validate.notNull(allowlist);
+        this.allowlist = allowlist;
     }
 
     /**
@@ -107,7 +107,7 @@ public class Cleaner {
             if (source instanceof Element) {
                 Element sourceEl = (Element) source;
 
-                if (whitelist.isSafeTag(sourceEl.normalName())) { // safe, clone and copy safe attrs
+                if (allowlist.isSafeTag(sourceEl.normalName())) { // safe, clone and copy safe attrs
                     ElementMeta meta = createSafeElement(sourceEl);
                     Element destChild = meta.el;
                     destination.appendChild(destChild);
@@ -121,7 +121,7 @@ public class Cleaner {
                 TextNode sourceText = (TextNode) source;
                 TextNode destText = new TextNode(sourceText.getWholeText());
                 destination.appendChild(destText);
-            } else if (source instanceof DataNode && whitelist.isSafeTag(source.parent().nodeName())) {
+            } else if (source instanceof DataNode && allowlist.isSafeTag(source.parent().nodeName())) {
               DataNode sourceData = (DataNode) source;
               DataNode destData = new DataNode(sourceData.getWholeData());
               destination.appendChild(destData);
@@ -131,7 +131,7 @@ public class Cleaner {
         }
 
         public void tail(Node source, int depth) {
-            if (source instanceof Element && whitelist.isSafeTag(source.nodeName())) {
+            if (source instanceof Element && allowlist.isSafeTag(source.nodeName())) {
                 destination = destination.parent(); // would have descended, so pop destination stack
             }
         }
@@ -151,12 +151,12 @@ public class Cleaner {
 
         Attributes sourceAttrs = sourceEl.attributes();
         for (Attribute sourceAttr : sourceAttrs) {
-            if (whitelist.isSafeAttribute(sourceTag, sourceEl, sourceAttr))
+            if (allowlist.isSafeAttribute(sourceTag, sourceEl, sourceAttr))
                 destAttrs.put(sourceAttr);
             else
                 numDiscarded++;
         }
-        Attributes enforcedAttrs = whitelist.getEnforcedAttributes(sourceTag);
+        Attributes enforcedAttrs = allowlist.getEnforcedAttributes(sourceTag);
         destAttrs.addAll(enforcedAttrs);
 
         return new ElementMeta(dest, numDiscarded);

--- a/src/main/java/org/jsoup/safety/Whitelist.java
+++ b/src/main/java/org/jsoup/safety/Whitelist.java
@@ -1,0 +1,8 @@
+package org.jsoup.safety;
+
+/**
+ * This class is deprecated and will be removed in a future version. Please change your code to use the class {@link Allowlist} instead.
+ */
+@Deprecated
+public class Whitelist extends Allowlist {
+}

--- a/src/main/java/org/jsoup/safety/package-info.java
+++ b/src/main/java/org/jsoup/safety/package-info.java
@@ -1,4 +1,4 @@
 /**
- Contains the jsoup HTML cleaner, and whitelist definitions.
+ Contains the jsoup HTML cleaner, and allowlist definitions.
  */
 package org.jsoup.safety;

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -5,7 +5,7 @@ import org.jsoup.TextUtil;
 import org.jsoup.integration.ParseTest;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.*;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Allowlist;
 import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -1142,8 +1142,8 @@ public class HtmlParserTest {
         parser.parseInput(html, "");
         assertEquals(0, parser.getErrors().size());
 
-        assertTrue(Jsoup.isValid(html, Whitelist.basic()));
-        String clean = Jsoup.clean(html, Whitelist.basic());
+        assertTrue(Jsoup.isValid(html, Allowlist.basic()));
+        String clean = Jsoup.clean(html, Allowlist.basic());
         assertEquals("<p>test<br>test<br></p>", clean);
     }
 
@@ -1154,8 +1154,8 @@ public class HtmlParserTest {
         assertEquals(1, parser.getErrors().size());
         assertEquals("18: Tag cannot be self closing; not a void tag", parser.getErrors().get(0).toString());
 
-        assertFalse(Jsoup.isValid(html, Whitelist.relaxed()));
-        String clean = Jsoup.clean(html, Whitelist.relaxed());
+        assertFalse(Jsoup.isValid(html, Allowlist.relaxed()));
+        String clean = Jsoup.clean(html, Allowlist.relaxed());
         assertEquals("<p>test</p> <div></div> <div> Two </div>", StringUtil.normaliseWhitespace(clean));
     }
 
@@ -1278,7 +1278,7 @@ public class HtmlParserTest {
     public void testH20() {
         // https://github.com/jhy/jsoup/issues/731
         String html = "H<sub>2</sub>O";
-        String clean = Jsoup.clean(html, Whitelist.basic());
+        String clean = Jsoup.clean(html, Allowlist.basic());
         assertEquals("H<sub>2</sub>O", clean);
 
         Document doc = Jsoup.parse(html);
@@ -1289,7 +1289,7 @@ public class HtmlParserTest {
     public void testUNewlines() {
         // https://github.com/jhy/jsoup/issues/851
         String html = "t<u>es</u>t <b>on</b> <i>f</i><u>ir</u>e";
-        String clean = Jsoup.clean(html, Whitelist.basic());
+        String clean = Jsoup.clean(html, Allowlist.basic());
         assertEquals("t<u>es</u>t <b>on</b> <i>f</i><u>ir</u>e", clean);
 
         Document doc = Jsoup.parse(html);

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -81,7 +81,7 @@ public class CleanerTest {
     }
 
     @MultiLocaleTest
-    public void whitelistedProtocolShouldBeRetained(Locale locale) {
+    public void allowlistedProtocolShouldBeRetained(Locale locale) {
         Locale.setDefault(locale);
 
         Allowlist allowlist = Allowlist.none()
@@ -128,14 +128,14 @@ public class CleanerTest {
         String validAnchor = "<a href=\"#valid\">Valid anchor</a>";
         String invalidAnchor = "<a href=\"#anchor with spaces\">Invalid anchor</a>";
 
-        // A Whitelist that does not allow anchors will strip them out.
+        // An Allowlist that does not allow anchors will strip them out.
         String cleanHtml = Jsoup.clean(validAnchor, Allowlist.relaxed());
         assertEquals("<a>Valid anchor</a>", cleanHtml);
 
         cleanHtml = Jsoup.clean(invalidAnchor, Allowlist.relaxed());
         assertEquals("<a>Invalid anchor</a>", cleanHtml);
 
-        // A Whitelist that allows them will keep them.
+        // An Allowlist that allows them will keep them.
         Allowlist relaxedWithAnchor = Allowlist.relaxed().addProtocols("a", "href", "#");
 
         cleanHtml = Jsoup.clean(validAnchor, relaxedWithAnchor);
@@ -234,7 +234,7 @@ public class CleanerTest {
         String html = "<p class='foo' src='bar'>One</p>";
         Allowlist allowlist = new Allowlist()
             .addAttributes("p", "class");
-        // ^^ whitelist does not have explicit tag add for p, inferred from add attributes.
+        // ^^ allowlist does not have explicit tag add for p, inferred from add attributes.
         String clean = Jsoup.clean(html, allowlist);
         assertEquals("<p class=\"foo\">One</p>", clean);
     }
@@ -278,7 +278,7 @@ public class CleanerTest {
     }
 
     @Test
-    public void testScriptTagInWhiteList() {
+    public void testScriptTagInAllowList() {
         Allowlist allowlist = Allowlist.relaxed();
         allowlist.addTags( "script" );
         assertTrue( Jsoup.isValid("Hello<script>alert('Doh')</script>World !", allowlist) );

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -18,21 +18,21 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CleanerTest {
     @Test public void simpleBehaviourTest() {
         String h = "<div><p class=foo><a href='http://evil.com'>Hello <b id=bar>there</b>!</a></div>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.simpleText());
+        String cleanHtml = Jsoup.clean(h, Allowlist.simpleText());
 
         assertEquals("Hello <b>there</b>!", TextUtil.stripNewlines(cleanHtml));
     }
 
     @Test public void simpleBehaviourTest2() {
         String h = "Hello <b>there</b>!";
-        String cleanHtml = Jsoup.clean(h, Whitelist.simpleText());
+        String cleanHtml = Jsoup.clean(h, Allowlist.simpleText());
 
         assertEquals("Hello <b>there</b>!", TextUtil.stripNewlines(cleanHtml));
     }
 
     @Test public void basicBehaviourTest() {
         String h = "<div><p><a href='javascript:sendAllMoney()'>Dodgy</a> <A HREF='HTTP://nice.com'>Nice</a></p><blockquote>Hello</blockquote>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.basic());
+        String cleanHtml = Jsoup.clean(h, Allowlist.basic());
 
         assertEquals("<p><a rel=\"nofollow\">Dodgy</a> <a href=\"http://nice.com\" rel=\"nofollow\">Nice</a></p><blockquote>Hello</blockquote>",
                 TextUtil.stripNewlines(cleanHtml));
@@ -40,33 +40,33 @@ public class CleanerTest {
 
     @Test public void basicWithImagesTest() {
         String h = "<div><p><img src='http://example.com/' alt=Image></p><p><img src='ftp://ftp.example.com'></p></div>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.basicWithImages());
+        String cleanHtml = Jsoup.clean(h, Allowlist.basicWithImages());
         assertEquals("<p><img src=\"http://example.com/\" alt=\"Image\"></p><p><img></p>", TextUtil.stripNewlines(cleanHtml));
     }
 
     @Test public void testRelaxed() {
         String h = "<h1>Head</h1><table><tr><td>One<td>Two</td></tr></table>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.relaxed());
+        String cleanHtml = Jsoup.clean(h, Allowlist.relaxed());
         assertEquals("<h1>Head</h1><table><tbody><tr><td>One</td><td>Two</td></tr></tbody></table>", TextUtil.stripNewlines(cleanHtml));
     }
 
     @Test public void testRemoveTags() {
         String h = "<div><p><A HREF='HTTP://nice.com'>Nice</a></p><blockquote>Hello</blockquote>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.basic().removeTags("a"));
+        String cleanHtml = Jsoup.clean(h, Allowlist.basic().removeTags("a"));
 
         assertEquals("<p>Nice</p><blockquote>Hello</blockquote>", TextUtil.stripNewlines(cleanHtml));
     }
 
     @Test public void testRemoveAttributes() {
         String h = "<div><p>Nice</p><blockquote cite='http://example.com/quotations'>Hello</blockquote>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.basic().removeAttributes("blockquote", "cite"));
+        String cleanHtml = Jsoup.clean(h, Allowlist.basic().removeAttributes("blockquote", "cite"));
 
         assertEquals("<p>Nice</p><blockquote>Hello</blockquote>", TextUtil.stripNewlines(cleanHtml));
     }
 
     @Test public void testRemoveEnforcedAttributes() {
         String h = "<div><p><A HREF='HTTP://nice.com'>Nice</a></p><blockquote>Hello</blockquote>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.basic().removeEnforcedAttribute("a", "rel"));
+        String cleanHtml = Jsoup.clean(h, Allowlist.basic().removeEnforcedAttribute("a", "rel"));
 
         assertEquals("<p><a href=\"http://nice.com\">Nice</a></p><blockquote>Hello</blockquote>",
                 TextUtil.stripNewlines(cleanHtml));
@@ -74,7 +74,7 @@ public class CleanerTest {
 
     @Test public void testRemoveProtocols() {
         String h = "<p>Contact me <a href='mailto:info@example.com'>here</a></p>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.basic().removeProtocols("a", "href", "ftp", "mailto"));
+        String cleanHtml = Jsoup.clean(h, Allowlist.basic().removeProtocols("a", "href", "ftp", "mailto"));
 
         assertEquals("<p>Contact me <a rel=\"nofollow\">here</a></p>",
                 TextUtil.stripNewlines(cleanHtml));
@@ -84,43 +84,43 @@ public class CleanerTest {
     public void whitelistedProtocolShouldBeRetained(Locale locale) {
         Locale.setDefault(locale);
 
-        Whitelist whitelist = Whitelist.none()
+        Allowlist allowlist = Allowlist.none()
                 .addTags("a")
                 .addAttributes("a", "href")
                 .addProtocols("a", "href", "something");
 
-        String cleanHtml = Jsoup.clean("<a href=\"SOMETHING://x\"></a>", whitelist);
+        String cleanHtml = Jsoup.clean("<a href=\"SOMETHING://x\"></a>", allowlist);
 
         assertEquals("<a href=\"SOMETHING://x\"></a>", TextUtil.stripNewlines(cleanHtml));
     }
 
     @Test public void testDropComments() {
         String h = "<p>Hello<!-- no --></p>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.relaxed());
+        String cleanHtml = Jsoup.clean(h, Allowlist.relaxed());
         assertEquals("<p>Hello</p>", cleanHtml);
     }
 
     @Test public void testDropXmlProc() {
         String h = "<?import namespace=\"xss\"><p>Hello</p>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.relaxed());
+        String cleanHtml = Jsoup.clean(h, Allowlist.relaxed());
         assertEquals("<p>Hello</p>", cleanHtml);
     }
 
     @Test public void testDropScript() {
         String h = "<SCRIPT SRC=//ha.ckers.org/.j><SCRIPT>alert(/XSS/.source)</SCRIPT>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.relaxed());
+        String cleanHtml = Jsoup.clean(h, Allowlist.relaxed());
         assertEquals("", cleanHtml);
     }
 
     @Test public void testDropImageScript() {
         String h = "<IMG SRC=\"javascript:alert('XSS')\">";
-        String cleanHtml = Jsoup.clean(h, Whitelist.relaxed());
+        String cleanHtml = Jsoup.clean(h, Allowlist.relaxed());
         assertEquals("<img>", cleanHtml);
     }
 
     @Test public void testCleanJavascriptHref() {
         String h = "<A HREF=\"javascript:document.location='http://www.google.com/'\">XSS</A>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.relaxed());
+        String cleanHtml = Jsoup.clean(h, Allowlist.relaxed());
         assertEquals("<a>XSS</a>", cleanHtml);
     }
 
@@ -129,14 +129,14 @@ public class CleanerTest {
         String invalidAnchor = "<a href=\"#anchor with spaces\">Invalid anchor</a>";
 
         // A Whitelist that does not allow anchors will strip them out.
-        String cleanHtml = Jsoup.clean(validAnchor, Whitelist.relaxed());
+        String cleanHtml = Jsoup.clean(validAnchor, Allowlist.relaxed());
         assertEquals("<a>Valid anchor</a>", cleanHtml);
 
-        cleanHtml = Jsoup.clean(invalidAnchor, Whitelist.relaxed());
+        cleanHtml = Jsoup.clean(invalidAnchor, Allowlist.relaxed());
         assertEquals("<a>Invalid anchor</a>", cleanHtml);
 
         // A Whitelist that allows them will keep them.
-        Whitelist relaxedWithAnchor = Whitelist.relaxed().addProtocols("a", "href", "#");
+        Allowlist relaxedWithAnchor = Allowlist.relaxed().addProtocols("a", "href", "#");
 
         cleanHtml = Jsoup.clean(validAnchor, relaxedWithAnchor);
         assertEquals(validAnchor, cleanHtml);
@@ -148,13 +148,13 @@ public class CleanerTest {
 
     @Test public void testDropsUnknownTags() {
         String h = "<p><custom foo=true>Test</custom></p>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.relaxed());
+        String cleanHtml = Jsoup.clean(h, Allowlist.relaxed());
         assertEquals("<p>Test</p>", cleanHtml);
     }
 
     @Test public void testHandlesEmptyAttributes() {
         String h = "<img alt=\"\" src= unknown=''>";
-        String cleanHtml = Jsoup.clean(h, Whitelist.basicWithImages());
+        String cleanHtml = Jsoup.clean(h, Allowlist.basicWithImages());
         assertEquals("<img alt=\"\">", cleanHtml);
     }
 
@@ -168,74 +168,74 @@ public class CleanerTest {
         String nok5 = "<p>Test <b><a href='http://example.com/' rel='nofollowme'>OK</a></b></p>";
         String nok6 = "<p>Test <b><a href='http://example.com/'>OK</b></p>"; // missing close tag
         String nok7 = "</div>What";
-        assertTrue(Jsoup.isValid(ok, Whitelist.basic()));
-        assertTrue(Jsoup.isValid(ok1, Whitelist.basic()));
-        assertFalse(Jsoup.isValid(nok1, Whitelist.basic()));
-        assertFalse(Jsoup.isValid(nok2, Whitelist.basic()));
-        assertFalse(Jsoup.isValid(nok3, Whitelist.basic()));
-        assertFalse(Jsoup.isValid(nok4, Whitelist.basic()));
-        assertFalse(Jsoup.isValid(nok5, Whitelist.basic()));
-        assertFalse(Jsoup.isValid(nok6, Whitelist.basic()));
-        assertFalse(Jsoup.isValid(ok, Whitelist.none()));
-        assertFalse(Jsoup.isValid(nok7, Whitelist.basic()));
+        assertTrue(Jsoup.isValid(ok, Allowlist.basic()));
+        assertTrue(Jsoup.isValid(ok1, Allowlist.basic()));
+        assertFalse(Jsoup.isValid(nok1, Allowlist.basic()));
+        assertFalse(Jsoup.isValid(nok2, Allowlist.basic()));
+        assertFalse(Jsoup.isValid(nok3, Allowlist.basic()));
+        assertFalse(Jsoup.isValid(nok4, Allowlist.basic()));
+        assertFalse(Jsoup.isValid(nok5, Allowlist.basic()));
+        assertFalse(Jsoup.isValid(nok6, Allowlist.basic()));
+        assertFalse(Jsoup.isValid(ok, Allowlist.none()));
+        assertFalse(Jsoup.isValid(nok7, Allowlist.basic()));
     }
 
     @Test public void testIsValidDocument() {
         String ok = "<html><head></head><body><p>Hello</p></body><html>";
         String nok = "<html><head><script>woops</script><title>Hello</title></head><body><p>Hello</p></body><html>";
 
-        Whitelist relaxed = Whitelist.relaxed();
+        Allowlist relaxed = Allowlist.relaxed();
         Cleaner cleaner = new Cleaner(relaxed);
         Document okDoc = Jsoup.parse(ok);
         assertTrue(cleaner.isValid(okDoc));
         assertFalse(cleaner.isValid(Jsoup.parse(nok)));
-        assertFalse(new Cleaner(Whitelist.none()).isValid(okDoc));
+        assertFalse(new Cleaner(Allowlist.none()).isValid(okDoc));
     }
 
     @Test public void resolvesRelativeLinks() {
         String html = "<a href='/foo'>Link</a><img src='/bar'>";
-        String clean = Jsoup.clean(html, "http://example.com/", Whitelist.basicWithImages());
+        String clean = Jsoup.clean(html, "http://example.com/", Allowlist.basicWithImages());
         assertEquals("<a href=\"http://example.com/foo\" rel=\"nofollow\">Link</a>\n<img src=\"http://example.com/bar\">", clean);
     }
 
     @Test public void preservesRelativeLinksIfConfigured() {
         String html = "<a href='/foo'>Link</a><img src='/bar'> <img src='javascript:alert()'>";
-        String clean = Jsoup.clean(html, "http://example.com/", Whitelist.basicWithImages().preserveRelativeLinks(true));
+        String clean = Jsoup.clean(html, "http://example.com/", Allowlist.basicWithImages().preserveRelativeLinks(true));
         assertEquals("<a href=\"/foo\" rel=\"nofollow\">Link</a>\n<img src=\"/bar\"> \n<img>", clean);
     }
 
     @Test public void dropsUnresolvableRelativeLinks() {
         String html = "<a href='/foo'>Link</a>";
-        String clean = Jsoup.clean(html, Whitelist.basic());
+        String clean = Jsoup.clean(html, Allowlist.basic());
         assertEquals("<a rel=\"nofollow\">Link</a>", clean);
     }
 
     @Test public void handlesCustomProtocols() {
         String html = "<img src='cid:12345' /> <img src='data:gzzt' />";
-        String dropped = Jsoup.clean(html, Whitelist.basicWithImages());
+        String dropped = Jsoup.clean(html, Allowlist.basicWithImages());
         assertEquals("<img> \n<img>", dropped);
 
-        String preserved = Jsoup.clean(html, Whitelist.basicWithImages().addProtocols("img", "src", "cid", "data"));
+        String preserved = Jsoup.clean(html, Allowlist.basicWithImages().addProtocols("img", "src", "cid", "data"));
         assertEquals("<img src=\"cid:12345\"> \n<img src=\"data:gzzt\">", preserved);
     }
 
     @Test public void handlesAllPseudoTag() {
         String html = "<p class='foo' src='bar'><a class='qux'>link</a></p>";
-        Whitelist whitelist = new Whitelist()
+        Allowlist allowlist = new Allowlist()
                 .addAttributes(":all", "class")
                 .addAttributes("p", "style")
                 .addTags("p", "a");
 
-        String clean = Jsoup.clean(html, whitelist);
+        String clean = Jsoup.clean(html, allowlist);
         assertEquals("<p class=\"foo\"><a class=\"qux\">link</a></p>", clean);
     }
 
     @Test public void addsTagOnAttributesIfNotSet() {
         String html = "<p class='foo' src='bar'>One</p>";
-        Whitelist whitelist = new Whitelist()
+        Allowlist allowlist = new Allowlist()
             .addAttributes("p", "class");
         // ^^ whitelist does not have explicit tag add for p, inferred from add attributes.
-        String clean = Jsoup.clean(html, whitelist);
+        String clean = Jsoup.clean(html, allowlist);
         assertEquals("<p class=\"foo\">One</p>", clean);
     }
 
@@ -247,8 +247,8 @@ public class CleanerTest {
         os.charset("ascii");
 
         String html = "<div><p>&bernou;</p></div>";
-        String customOut = Jsoup.clean(html, "http://foo.com/", Whitelist.relaxed(), os);
-        String defaultOut = Jsoup.clean(html, "http://foo.com/", Whitelist.relaxed());
+        String customOut = Jsoup.clean(html, "http://foo.com/", Allowlist.relaxed(), os);
+        String defaultOut = Jsoup.clean(html, "http://foo.com/", Allowlist.relaxed());
         assertNotSame(defaultOut, customOut);
 
         assertEquals("<div><p>&Bscr;</p></div>", customOut); // entities now prefers shorted names if aliased
@@ -258,37 +258,37 @@ public class CleanerTest {
 
         os.charset("ASCII");
         os.escapeMode(Entities.EscapeMode.base);
-        String customOut2 = Jsoup.clean(html, "http://foo.com/", Whitelist.relaxed(), os);
+        String customOut2 = Jsoup.clean(html, "http://foo.com/", Allowlist.relaxed(), os);
         assertEquals("<div><p>&#x212c;</p></div>", customOut2);
     }
 
     @Test public void handlesFramesets() {
         String dirty = "<html><head><script></script><noscript></noscript></head><frameset><frame src=\"foo\" /><frame src=\"foo\" /></frameset></html>";
-        String clean = Jsoup.clean(dirty, Whitelist.basic());
+        String clean = Jsoup.clean(dirty, Allowlist.basic());
         assertEquals("", clean); // nothing good can come out of that
 
         Document dirtyDoc = Jsoup.parse(dirty);
-        Document cleanDoc = new Cleaner(Whitelist.basic()).clean(dirtyDoc);
+        Document cleanDoc = new Cleaner(Allowlist.basic()).clean(dirtyDoc);
         assertNotNull(cleanDoc);
         assertEquals(0, cleanDoc.body().childNodeSize());
     }
 
     @Test public void cleansInternationalText() {
-        assertEquals("привет", Jsoup.clean("привет", Whitelist.none()));
+        assertEquals("привет", Jsoup.clean("привет", Allowlist.none()));
     }
 
     @Test
     public void testScriptTagInWhiteList() {
-        Whitelist whitelist = Whitelist.relaxed();
-        whitelist.addTags( "script" );
-        assertTrue( Jsoup.isValid("Hello<script>alert('Doh')</script>World !", whitelist ) );
+        Allowlist allowlist = Allowlist.relaxed();
+        allowlist.addTags( "script" );
+        assertTrue( Jsoup.isValid("Hello<script>alert('Doh')</script>World !", allowlist) );
     }
 
     @Test
     public void bailsIfRemovingProtocolThatsNotSet() {
         assertThrows(IllegalArgumentException.class, () -> {
             // a case that came up on the email list
-            Whitelist w = Whitelist.none();
+            Allowlist w = Allowlist.none();
 
             // note no add tag, and removing protocol without adding first
             w.addAttributes("a", "href");
@@ -298,20 +298,20 @@ public class CleanerTest {
 
     @Test public void handlesControlCharactersAfterTagName() {
         String html = "<a/\06>";
-        String clean = Jsoup.clean(html, Whitelist.basic());
+        String clean = Jsoup.clean(html, Allowlist.basic());
         assertEquals("<a rel=\"nofollow\"></a>", clean);
     }
 
     @Test public void handlesAttributesWithNoValue() {
         // https://github.com/jhy/jsoup/issues/973
-        String clean = Jsoup.clean("<a href>Clean</a>", Whitelist.basic());
+        String clean = Jsoup.clean("<a href>Clean</a>", Allowlist.basic());
 
         assertEquals("<a rel=\"nofollow\">Clean</a>", clean);
     }
 
     @Test public void handlesNoHrefAttribute() {
         String dirty = "<a>One</a> <a href>Two</a>";
-        Whitelist relaxedWithAnchor = Whitelist.relaxed().addProtocols("a", "href", "#");
+        Allowlist relaxedWithAnchor = Allowlist.relaxed().addProtocols("a", "href", "#");
         String clean = Jsoup.clean(dirty, relaxedWithAnchor);
         assertEquals("<a>One</a> <a>Two</a>", clean);
     }
@@ -319,7 +319,7 @@ public class CleanerTest {
     @Test public void handlesNestedQuotesInAttribute() {
         // https://github.com/jhy/jsoup/issues/1243 - no repro
         String orig = "<div style=\"font-family: 'Calibri'\">Will (not) fail</div>";
-        Whitelist allow = Whitelist.relaxed()
+        Allowlist allow = Allowlist.relaxed()
             .addAttributes("div", "style");
 
         String clean = Jsoup.clean(orig, allow);


### PR DESCRIPTION
This PR renames the `Whitelist` class to `Allowlist` to make the language more welcoming and inclusive. This follows the [IETF RFC on "Terminology, Power and Offensive Language"](https://tools.ietf.org/id/draft-knodel-terminology-01.html#rfc.section.1.2).