### PR TITLE
Fix regression from commit a657ae

### DIFF
--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -667,7 +667,7 @@ public class Elements extends ArrayList<Element> {
     private <T extends Node> List<T> nodesOfType(Class<T> tClass) {
         ArrayList<T> nodes = new ArrayList<>();
         for (Element el: this) {
-            if (el.getClass().isInstance(tClass)) { // Handles FormElements
+            if (tClass.isInstance(el)) { // Handles FormElements
                 nodes.add(tClass.cast(el));
             } else if (Node.class.isAssignableFrom(tClass)) { // check if child nodes match
                 for (int i = 0; i < el.childNodeSize(); i++) {

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -293,6 +293,12 @@ public class ElementsTest {
         assertEquals("2", forms.get(1).id());
     }
 
+    @Test public void formsRegression() {
+        Document doc = Jsoup.parse("<form id=1></form>");
+        List<FormElement> forms = doc.select("form").forms();
+        assertEquals(1, forms.size());
+    }
+
     @Test public void comments() {
         Document doc = Jsoup.parse("<!-- comment1 --><p><!-- comment2 --><p class=two><!-- comment3 -->");
         List<Comment> comments = doc.select("p").comments();


### PR DESCRIPTION
The refactoring of the `Elements.forms()` method in [commit a657ae](https://github.com/jhy/jsoup/commit/a657ae0240b875a703a1e4909d56ad59997d362d#diff-4f0778cbabadac4729bae10ebec0c0aaR639) introduced a regression issue:
A `FormElement` in an `Elements` collection is not returned by `forms()` any more.
The `instanceof` operator equivalent [`Class.isInstance`](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#isInstance-java.lang.Object-) is incorrectly used.