### PR TITLE
Remove unused TokenQueue.consumeTagName

### DIFF
--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -341,19 +341,6 @@ public class TokenQueue {
     }
     
     /**
-     * Consume an tag name off the queue (word or :, _, -)
-     * 
-     * @return tag name
-     */
-    public String consumeTagName() {
-        int start = pos;
-        while (!isEmpty() && (matchesWord() || matchesAny(':', '_', '-')))
-            pos++;
-        
-        return queue.substring(start, pos);
-    }
-    
-    /**
      * Consume a CSS element selector (tag name, but | instead of : for namespaces (or *| for wildcard namespace), to not conflict with :pseudo selects).
      * 
      * @return tag name


### PR DESCRIPTION
This method is not used anywhere, and I guess it could easily be mistaken for `consumeElementSelector` so I'd suggest to remove it?