### PR TITLE
Allow backslash-escaping within ElementSelector and CssIdentifier

### DIFF
--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -360,10 +360,10 @@ public class TokenQueue {
      */
     public String consumeElementSelector() {
         int start = pos;
-        while (!isEmpty() && (matchesWord() || matchesAny("*|","|", "_", "-")))
+        while (!isEmpty() && (matchesWord() || matchesAny("*|","|", "_", "-", "\\") || pos>0 && queue.charAt(pos-1)=='\\'))
             pos++;
         
-        return queue.substring(start, pos);
+        return queue.substring(start, pos).replace("\\", "");
     }
 
     /**
@@ -373,10 +373,10 @@ public class TokenQueue {
      */
     public String consumeCssIdentifier() {
         int start = pos;
-        while (!isEmpty() && (matchesWord() || matchesAny('-', '_')))
+        while (!isEmpty() && (matchesWord() || matchesAny('-', '_', '\\') || pos>0 && queue.charAt(pos-1)=='\\'))
             pos++;
 
-        return queue.substring(start, pos);
+        return queue.substring(start, pos).replace("\\", "");
     }
 
     /**

--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -360,10 +360,15 @@ public class TokenQueue {
      */
     public String consumeElementSelector() {
         int start = pos;
-        while (!isEmpty() && (matchesWord() || matchesAny("*|","|", "_", "-", "\\") || pos>0 && queue.charAt(pos-1)=='\\'))
+        boolean hasEscape=false;
+        
+        while (!isEmpty() && (matchesWord() || matchesAny("*|","|", "_", "-", "\\") || pos>0 && queue.charAt(pos-1)=='\\' && (hasEscape=true)))
             pos++;
         
-        return queue.substring(start, pos).replace("\\", "");
+        if (hasEscape) {
+            return TokenQueue.unescape(queue.substring(start, pos));
+        }
+        return queue.substring(start, pos);
     }
 
     /**
@@ -373,10 +378,15 @@ public class TokenQueue {
      */
     public String consumeCssIdentifier() {
         int start = pos;
-        while (!isEmpty() && (matchesWord() || matchesAny('-', '_', '\\') || pos>0 && queue.charAt(pos-1)=='\\'))
+        boolean hasEscape=false;
+        
+        while (!isEmpty() && (matchesWord() || matchesAny('-', '_', '\\') || pos>0 && queue.charAt(pos-1)=='\\' && (hasEscape=true)))
             pos++;
 
-        return queue.substring(start, pos).replace("\\", "");
+        if (hasEscape) {
+        	return TokenQueue.unescape(queue.substring(start, pos));
+        }
+        return queue.substring(start, pos);
     }
 
     /**


### PR DESCRIPTION
There has been previous discussion about element names or CSS tokens that can currently not been selected through JSoup's selector, because they contain JSoup Selector operators (like `#`, `.` , ...).

In #1055 it was suggested to use escape characters within the selector syntax.

This (simple) implementation modifies `TokenQueue` so `consumeElementSelector` and `consumeCSSIdentifier` will continue matching if the preceeding character is a backslash (`\`). Finally, all backslashes are removed from the result.

It is a simple approach, and will not allow escaping backslashes themselves - but there should never be a backslash in an element name or CSS identifier?

Here's a simple test case:
```java
	@Test public void testSelectorEscapes() {
		Document doc = Jsoup.parse("<root><e.dot>e with dot</e.dot><e class=\"dot\">e with class dot</e><f id=\"i.d\">f with i.d</f><x id=\"i\" class=\"d\">id i with class d</x></root>", "", Parser.xmlParser());

		assertEquals("e with class dot", 	doc.select("e.dot").text());
		assertEquals("e with dot", 			doc.select("e\\.dot").text());
		assertEquals("id i with class d", 	doc.select("#i.d").text());
		assertEquals("f with i.d", 			doc.select("#i\\.d").text());

	}
```


This PR would close issue #1441 .