### PR TITLE
Add Selectors :local-name, :name and :namespace-uri

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1620,4 +1620,29 @@ public class Element extends Node {
             && previousSibling() != null
             && !out.outline();
     }
+
+	public String namespacePrefix() {
+		final String tn = this.tagName();
+		final int p = tn.indexOf(':');
+		if (p<0) return null;
+		return tn.substring(0, p);
+	}
+
+	public String namespaceURI() {
+		final String prefix = namespacePrefix();
+		if (prefix==null) return null;
+		
+		return declaredNamespaceURIbyPrefix("xmlns:"+prefix);
+	}
+
+	private String declaredNamespaceURIbyPrefix(String xmlnsAttr) {
+		final String uri = this.attr(xmlnsAttr);
+		if (!uri.isEmpty()) return uri;
+		
+		final Element parent = parent();
+		if (parent!=null) {
+			return parent.declaredNamespaceURIbyPrefix(xmlnsAttr);
+		}
+		return null;
+	}
 }

--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -79,6 +79,53 @@ public abstract class Evaluator {
     }
 
     /**
+     * Evaluator for tag name
+     */
+    public static final class LocalName extends Evaluator {
+        private String tagName;
+
+        public LocalName(String tagName) {
+            this.tagName = tagName;
+        }
+
+        @Override
+        public boolean matches(Element root, Element element) {
+        	final String tn = element.tagName();
+        	final int p = tn.indexOf(':');
+        	if (p>-1) {
+                return (tn.substring(p+1).equals(tagName));
+        	}
+            return (tn.equals(tagName));
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s", tagName);
+        }
+    }
+    
+    /**
+     * Evaluator for tag name
+     */
+    public static final class NamespaceURI extends Evaluator {
+        private String nsUri;
+
+        public NamespaceURI(String nsUri) {
+            this.nsUri = nsUri;
+        }
+
+        @Override
+        public boolean matches(Element root, Element element) {
+            return this.nsUri.equals(element.namespaceURI());
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s", nsUri);
+        }
+    }
+    
+    /**
      * Evaluator for element id
      */
     public static final class Id extends Evaluator {

--- a/src/main/java/org/jsoup/select/QueryParser.java
+++ b/src/main/java/org/jsoup/select/QueryParser.java
@@ -173,6 +173,12 @@ public class QueryParser {
             contains(true);
         else if (tq.matches(":containsData("))
             containsData();
+        else if (tq.matches(":local-name("))
+            byLocalName();
+        else if (tq.matches(":name("))
+            byName();
+        else if (tq.matches(":namespace-uri("))
+            byNamespaceURI();
         else if (tq.matches(":matches("))
             matches(false);
         else if (tq.matches(":matchesOwn("))
@@ -239,6 +245,30 @@ public class QueryParser {
 
             evals.add(new Evaluator.Tag(tagName));
         }
+    }
+
+    private void byLocalName() {
+    	tq.consume(":local-name");
+        String tagName = tq.chompBalanced('(', ')');
+        Validate.notEmpty(tagName);
+
+        evals.add(new Evaluator.LocalName(tagName));
+    }
+
+    private void byName() {
+    	tq.consume(":name");
+        String tagName = tq.chompBalanced('(', ')');
+        Validate.notEmpty(tagName);
+
+        evals.add(new Evaluator.Tag(tagName));
+    }
+
+    private void byNamespaceURI() {
+    	tq.consume(":namespace-URI");
+        String nsUri = tq.chompBalanced('(', ')');
+        Validate.notEmpty(nsUri);
+
+        evals.add(new Evaluator.NamespaceURI(nsUri));
     }
 
     private void byAttribute() {

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -70,6 +70,9 @@ import java.util.IdentityHashMap;
  * <tr><td><code>:only-child</code></td><td>elements that have a parent element and whose parent element have no other element children</td><td></td></tr>
  * <tr><td><code>:only-of-type</code></td><td> an element that has a parent element and whose parent element has no other element children with the same expanded element name</td><td></td></tr>
  * <tr><td><code>:empty</code></td><td>elements that have no children at all</td><td></td></tr>
+ * <tr><td><code>:local-name</code></td><td>elements with a given local-name (without namespace prefix), <b>case sensitive</b></td><td>:local-name(foo)</td></tr>
+ * <tr><td><code>:name</code></td><td>elements with a given Qname (including namespace prefix), <b>case sensitive</b></td><td>:name(bar:foo)</td></tr>
+ * <tr><td><code>:namespace-uri</code></td><td>elements with a given namespace URI, <b>case sensitive</b></td><td>:namespace-uri(http://jsoup.org/)</td></tr>
  * </table>
  *
  * @author Jonathan Hedley, jonathan@hedley.net


### PR DESCRIPTION
Another shot at #1441 by adding XPath-like Selector functions `:local-name()`, `:name()` and `:namespace-uri()`.

Here's a corresponding test case:
```java
	@Test public void testXMLXPathSelectors() {
		Document doc = Jsoup.parse("<root xmlns:xyz=\"https://www.eekhoorn.xyz/demo\" xmlns:abc=\"https://www.eekhoorn.xyz/demo\"><xyz:demo>demo xyz</xyz:demo><abc:demo>demo abc</abc:demo></root>", "", Parser.xmlParser());

		assertEquals("demo xyz demo abc", 	doc.select(":local-name(demo)").text());

		assertEquals("demo xyz", 	 	doc.select(":name(xyz:demo)").text());
		assertEquals("demo xyz demo abc", 	doc.select(":namespace-uri(https://www.eekhoorn.xyz/demo)").text());
	}
```

As it is with XPath, the matchers operate in a case-sensitive way, regardless of the document's ParserSettings.