### PR TITLE
Added Null Check to avoid NPE for shallow Clones

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1616,7 +1616,7 @@ public class Element extends Node {
     private boolean isInlineable(Document.OutputSettings out) {
         return tag().isInline()
             && !tag().isEmpty()
-            && parent().isBlock()
+            && (parent() == null || parent().isBlock())
             && previousSibling() != null
             && !out.outline();
     }


### PR DESCRIPTION
When doing operations on Shallow Node (type-casted to Element) such as toString(), I am getting a NullPointerException. 

While debugging I found Element.isInlineable(Document.OutputSettings) line 1619 calls parent().isBlock(). 
In our case, a shallow clone cannot have a parent. So I have added a Null check.

Note - I found out that this issue has already been raised. Existing issue Link - https://github.com/jhy/jsoup/issues/1410