### PR TITLE
Fix NullpointerException in Element.isInlineable()

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1616,7 +1616,7 @@ public class Element extends Node {
     private boolean isInlineable(Document.OutputSettings out) {
         return tag().isInline()
             && !tag().isEmpty()
-            && parent().isBlock()
+            && (parent()==null || parent().isBlock())
             && previousSibling() != null
             && !out.outline();
     }

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -3,6 +3,7 @@ package org.jsoup.select;
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
 import org.jsoup.nodes.*;
+import org.jsoup.parser.Parser;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -430,5 +431,15 @@ public class ElementsTest {
         assertEquals("http://example.com/foo", absAttrs.get(0));
         assertEquals("http://example.com/bar", absAttrs.get(1));
         assertEquals("http://example.com", absAttrs.get(2));
+    }
+    
+    @Test public void toStringInlineNPE() {
+        Document doc = Jsoup.parse(
+                "<root><jobOffer><id>4711</id></jobOffer></root>",
+                "http://example.com", Parser.xmlParser()
+        );
+
+        Element e = doc.select("jobOffer").first().clone();
+        System.out.println( e.toString() );
     }
 }


### PR DESCRIPTION
Regression, introduced in 3a9bf46eeb36196d841c3fa05597e40a13f51f43 .

`parent()` will be `null` for freshly cloned, created or removed `Element`s.