### PR TITLE
Limit reading CharBuffer.array() to CharBuffer.limit() to avoid additional NULL characters at the end of some inputs

### DIFF
--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -130,7 +130,7 @@ public final class DataUtil {
             try {
                 CharBuffer defaultDecoded = Charset.forName(defaultCharset).decode(firstBytes);
                 if (defaultDecoded.hasArray())
-                    doc = parser.parseInput(new CharArrayReader(defaultDecoded.array(), 0, defaultDecoded.limit()), baseUri);
+                    doc = parser.parseInput(new CharArrayReader(defaultDecoded.array(), defaultDecoded.arrayOffset(), defaultDecoded.limit()), baseUri);
                 else
                     doc = parser.parseInput(defaultDecoded.toString(), baseUri);
             } catch (UncheckedIOException e) {

--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -130,7 +130,7 @@ public final class DataUtil {
             try {
                 CharBuffer defaultDecoded = Charset.forName(defaultCharset).decode(firstBytes);
                 if (defaultDecoded.hasArray())
-                    doc = parser.parseInput(new CharArrayReader(defaultDecoded.array()), baseUri);
+                    doc = parser.parseInput(new CharArrayReader(defaultDecoded.array(), 0, defaultDecoded.limit()), baseUri);
                 else
                     doc = parser.parseInput(defaultDecoded.toString(), baseUri);
             } catch (UncheckedIOException e) {

--- a/src/test/java/org/jsoup/helper/DataUtilTest.java
+++ b/src/test/java/org/jsoup/helper/DataUtilTest.java
@@ -155,17 +155,18 @@ public class DataUtilTest {
     }
 
     @Test
+    public void supportsUTF8BOM() throws IOException {
+        File in = getFile("/bomtests/bom_utf8.html");
+        Document doc = Jsoup.parse(in, null, "http://example.com");
+        assertEquals("OK", doc.head().select("title").text());
+    }
+
+    @Test
     public void noExtraNULLBytes() throws IOException {
     	final byte[] b = "<html><head><meta charset=\"UTF-8\"></head><body><div><u>ü</u>ü</div></body></html>".getBytes("UTF-8");
     	
     	Document doc = Jsoup.parse(new ByteArrayInputStream(b), null, "");
     	assertFalse( doc.outerHtml().contains("\u0000") );
-    }
-
-    @Test
-    public void supportsUTF8BOMNoExtraNULL() throws IOException {
-        File in = getFile("/bomtests/bom_utf8.html");
-        Document doc = Jsoup.parse(in, null, "http://example.com");
     }
 
     @Test

--- a/src/test/java/org/jsoup/helper/DataUtilTest.java
+++ b/src/test/java/org/jsoup/helper/DataUtilTest.java
@@ -166,7 +166,6 @@ public class DataUtilTest {
     public void supportsUTF8BOMNoExtraNULL() throws IOException {
         File in = getFile("/bomtests/bom_utf8.html");
         Document doc = Jsoup.parse(in, null, "http://example.com");
-        assertFalse (doc.toString().contains("\u0000"));
     }
 
     @Test

--- a/src/test/java/org/jsoup/helper/DataUtilTest.java
+++ b/src/test/java/org/jsoup/helper/DataUtilTest.java
@@ -155,10 +155,18 @@ public class DataUtilTest {
     }
 
     @Test
-    public void supportsUTF8BOM() throws IOException {
+    public void noExtraNULLBytes() throws IOException {
+    	final byte[] b = "<html><head><meta charset=\"UTF-8\"></head><body><div><u>ü</u>ü</div></body></html>".getBytes("UTF-8");
+    	
+    	Document doc = Jsoup.parse(new ByteArrayInputStream(b), null, "");
+    	assertFalse( doc.outerHtml().contains("\u0000") );
+    }
+
+    @Test
+    public void supportsUTF8BOMNoExtraNULL() throws IOException {
         File in = getFile("/bomtests/bom_utf8.html");
         Document doc = Jsoup.parse(in, null, "http://example.com");
-        assertEquals("OK", doc.head().select("title").text());
+        assertFalse (doc.toString().contains("\u0000"));
     }
 
     @Test


### PR DESCRIPTION
It is not documented explicitly, but `CharBuffer.array()` "Returns the char array that backs this buffer", so the buffer may have excess space at the end that was not used for the input.

(See also the explanation why https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6442955 is not a bug: 

> The Charset Buffer API is optimized for efficiency, not convenience. Buffer copies are avoided, but this means some buffers have extra elements between their limit and their capacity.

)

In a recent change to DataUtil the `array()` was passed without restricting its use to the length of `limit()`, hence adding NULL characters at the end.

Fixed by passing the value of `limit()` to the `CharArrayReader` that is actually reading from the `array()`.