### PR TITLE
Update japicmp, and enable JDK 16-ea CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         # choosing to run a reduced set of LTS, current, and next, to balance coverage and execution time
-        java: [8, 11, 15]
-        # Temporarily removed 16-ea, as it started failing in the japicmp plugin phase.
-        # Working (with japacmp): https://github.com/jhy/jsoup/runs/1556442000?check_suite_focus=true
-        # Failing: https://github.com/jhy/jsoup/runs/1556669892?check_suite_focus=true
-        # Issue raised: https://github.com/siom79/japicmp/issues/275
+        java: [8, 11, 15, 16-ea]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <!-- API version compat check - https://siom79.github.io/japicmp/ -->
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.14.4</version>
+        <version>0.15.2</version>
         <configuration>
           <!-- hard code previous version; can't detect when running stateless on build server -->
           <oldVersion>


### PR DESCRIPTION
Verified that the GitHub CI Action now succeeds on JDK 16-ea, with the fixes in japacmp 0.15.2.

https://github.com/siom79/japicmp/issues/275
https://github.com/siom79/japicmp/issues/279