### PR TITLE
Adds easy request session-state and corrects cookie domain and path rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,17 +203,19 @@
             <onlyModified>false</onlyModified>
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
             <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
-            <excludes>
-              <!-- 1.14.1 interface adds. rarely implemented outside of jsoup, and can't provide default impl in 7, so flag in changelog -->
-              <exclude>org.jsoup.Connection.cookieStore()</exclude>
-              <exclude>org.jsoup.Connection.cookieStore(java.net.CookieStore)</exclude>
-              <exclude>jsoup.Connection.newRequest()</exclude>
-            </excludes>
+            <overrideCompatibilityChangeParameters>
+              <!-- 1.14.1 interface adds for cookies. rarely implemented outside of jsoup, and can't provide default impl in 7, so flag in changelog -->
+              <overrideCompatibilityChangeParameter>
+                <compatibilityChange>METHOD_ADDED_TO_INTERFACE</compatibilityChange>
+                <binaryCompatible>true</binaryCompatible>
+                <sourceCompatible>true</sourceCompatible>
+              </overrideCompatibilityChangeParameter>
+            </overrideCompatibilityChangeParameters>
           </parameter>
         </configuration>
         <executions>
           <execution>
-            <phase>verify</phase>
+            <phase>package</phase>
             <goals>
               <goal>cmp</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,12 @@
             <onlyModified>false</onlyModified>
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
             <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+            <excludes>
+              <!-- 1.14.1 interface adds. rarely implemented outside of jsoup, and can't provide default impl in 7, so flag in changelog -->
+              <exclude>org.jsoup.Connection.cookieStore()</exclude>
+              <exclude>org.jsoup.Connection.cookieStore(java.net.CookieStore)</exclude>
+              <exclude>jsoup.Connection.newRequest()</exclude>
+            </excludes>
           </parameter>
         </configuration>
         <executions>

--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -8,6 +8,7 @@ import javax.net.ssl.SSLSocketFactory;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.CookieStore;
 import java.net.Proxy;
 import java.net.URL;
 import java.util.Collection;
@@ -15,16 +16,25 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * The Connection interface is a convenient HTTP client to fetch content from the web, and parse them into Documents.
- * <p>
- * To get a new Connection, use {@link org.jsoup.Jsoup#connect(String)}. Connections contain {@link Connection.Request}
- * and {@link Connection.Response} objects. The request objects are reusable as prototype requests.
- * </p>
- * <p>
- * Request configuration can be made using either the shortcut methods in Connection (e.g. {@link #userAgent(String)}),
- * or by methods in the Connection.Request object directly. All request configuration must be made before the request is
- * executed.
- * </p>
+ The Connection interface is a convenient HTTP client and session object to fetch content from the web, and parse them
+ into Documents.
+ <p>To start a new session, use either {@link org.jsoup.Jsoup#newSession()} or {@link org.jsoup.Jsoup#connect(String)}.
+ Connections contain {@link Connection.Request} and {@link Connection.Response} objects (once executed). Configuration
+ settings (URL, timeout, useragent, etc) set on a session will be applied by default to each subsequent request.</p>
+ <p>To start a new request from the session, use {@link #newRequest()}.</p>
+ <p>Cookies are stored in memory for the duration of the session. For that reason, do not use one single session for all
+ requests in a long-lived application, or you are likely to run out of memory, unless care is taken to clean up the
+ cookie store. The cookie store for the session is available via {@link #cookieStore()}. You may provide your own
+ implementation via {@link #cookieStore(java.net.CookieStore)} before making requests.</p>
+ <p>Request configuration can be made using either the shortcut methods in Connection (e.g. {@link #userAgent(String)}),
+ or by methods in the Connection.Request object directly. All request configuration must be made before the request is
+ executed. When used as an ongoing session, initialize all defaults prior to making multi-threaded {@link
+#newRequest()}s.</p>
+ <p>Note that the term "Connection" used here does not mean that a long-lived connection is held against a server for
+ the lifetime of the Connection object. A socket connection is only made at the point of request execution ({@link
+#execute()}, {@link #get()}, or {@link #post()}), and the server's response consumed.</p>
+ <p>For multi-threaded implementations, it is important to use a {@link #newRequest()} for each request. The session may
+ be shared across threads but a given request, not.</p>
  */
 @SuppressWarnings("unused")
 public interface Connection {
@@ -49,6 +59,13 @@ public interface Connection {
             return hasBody;
         }
     }
+
+    /**
+     Creates a new request, using this Connection as the session-state and to initialize the connection settings (which may then be independently on the returned Connection.Request object).
+     @return a new Connection object, with a shared Cookie Store and initialized settings from this Connection and Request
+     @since 1.14.1
+     */
+    Connection newRequest();
 
     /**
      * Set the request URL to fetch. The protocol must be HTTP or HTTPS.
@@ -206,11 +223,15 @@ public interface Connection {
     Connection data(Map<String, String> data);
 
     /**
-     * Add a number of request data parameters. Multiple parameters may be set at once, e.g.: <code>.data("name",
-     * "jsoup", "language", "Java", "language", "English");</code> creates a query string like:
-     * <code>{@literal ?name=jsoup&language=Java&language=English}</code>
-     * @param keyvals a set of key value pairs.
-     * @return this Connection, for chaining
+     Add one or more request {@code key, val} data parameter pairs.<p>Multiple parameters may be set at once, e.g.:
+     <code>.data("name", "jsoup", "language", "Java", "language", "English");</code> creates a query string like:
+     <code>{@literal ?name=jsoup&language=Java&language=English}</code></p>
+     <p>For GET requests, data parameters will be sent on the request query string. For POST (and other methods that
+     contain a body), they will be sent as body form parameters, unless the body is explicitly set by {@link
+    #requestBody(String)}, in which case they will be query string parameters.</p>
+
+     @param keyvals a set of key value pairs.
+     @return this Connection, for chaining
      */
     Connection data(String... keyvals);
 
@@ -264,6 +285,21 @@ public interface Connection {
      * @return this Connection, for chaining
      */
     Connection cookies(Map<String, String> cookies);
+
+    /**
+     Provide a custom or pre-filled CookieStore to be used on requests made by this Connection.
+     @param cookieStore a cookie store to use for subsequent requests
+     @return this Connection, for chaining
+     @since 1.14.1
+     */
+    Connection cookieStore(CookieStore cookieStore);
+
+    /**
+     Get the cookie store used by this Connection.
+     @return the cookie store
+     @since 1.14.1
+     */
+    CookieStore cookieStore();
 
     /**
      * Provide an alternate parser to use when parsing the response to a Document. If not set, defaults to the HTML

--- a/src/main/java/org/jsoup/HttpStatusException.java
+++ b/src/main/java/org/jsoup/HttpStatusException.java
@@ -10,7 +10,7 @@ public class HttpStatusException extends IOException {
     private final String url;
 
     public HttpStatusException(String message, int statusCode, String url) {
-        super(message);
+        super(message + ". Status=" + statusCode + ", URL=[" + url + "]");
         this.statusCode = statusCode;
         this.url = url;
     }
@@ -21,10 +21,5 @@ public class HttpStatusException extends IOException {
 
     public String getUrl() {
         return url;
-    }
-
-    @Override
-    public String toString() {
-        return super.toString() + ". Status=" + statusCode + ", URL=" + url;
     }
 }

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -62,7 +62,7 @@ public class Jsoup {
     }
 
     /**
-     * Creates a new {@link Connection} to a URL. Use to fetch and parse a HTML page.
+     * Creates a new {@link Connection} (session), with the defined request URL. Use to fetch and parse a HTML page.
      * <p>
      * Use examples:
      * <ul>
@@ -71,9 +71,38 @@ public class Jsoup {
      * </ul>
      * @param url URL to connect to. The protocol must be {@code http} or {@code https}.
      * @return the connection. You can add data, cookies, and headers; set the user-agent, referrer, method; and then execute.
+     * @see #newSession()
+     * @see Connection#newRequest()
      */
     public static Connection connect(String url) {
         return HttpConnection.connect(url);
+    }
+
+    /**
+     Creates a new {@link Connection} to use as a session. Connection settings (user-agent, timeouts, URL, etc), and
+     cookies will be maintained for the session. Use examples:
+<pre><code>
+Connection session = Jsoup.newSession()
+     .timeout(20 * 1000)
+     .userAgent("FooBar 2000");
+
+Document doc1 = session.newRequest()
+     .url("https://jsoup.org/").data("ref", "example")
+     .get();
+Document doc2 = session.newRequest()
+     .url("https://en.wikipedia.org/wiki/Main_Page")
+     .get();
+Connection con3 = session.newRequest();
+</code></pre>
+
+     <p>For multi-threaded requests, it is safe to use this session between threads, but take care to call {@link
+    Connection#newRequest()} per request and not share that instance between threads when executing or parsing.</p>
+
+     @return a connection
+     @since 1.14.1
+     */
+    public static Connection newSession() {
+        return new HttpConnection();
     }
 
     /**

--- a/src/main/java/org/jsoup/helper/CookieUtil.java
+++ b/src/main/java/org/jsoup/helper/CookieUtil.java
@@ -1,0 +1,88 @@
+package org.jsoup.helper;
+
+import org.jsoup.Connection;
+import org.jsoup.internal.StringUtil;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ Helper functions to support the Cookie Manager / Cookie Storage in HttpConnection.
+
+ @since 1.14.1 */
+class CookieUtil {
+    // cookie manager get() wants request headers but doesn't use them, so we just pass a dummy object here
+    private static final Map<String, List<String>> EmptyRequestHeaders = Collections.unmodifiableMap(new HashMap<>());
+    private static final String Sep = "; ";
+    private static final String CookieName = "Cookie";
+    private static final String Cookie2Name = "Cookie2";
+
+    /**
+     Pre-request, get any applicable headers out of the Request cookies and the Cookie Store, and add them to the request
+     headers. If the Cookie Store duplicates any Request cookies (same name and value), they will be discarded.
+     */
+    static void applyCookiesToRequest(HttpConnection.Request req, HttpURLConnection con) throws IOException {
+        // Request key/val cookies. LinkedHashSet used to preserve order, as cookie store will return most specific path first
+        Set<String> cookieSet = requestCookieSet(req);
+        Set<String> cookies2 = null;
+
+        // stored:
+        Map<String, List<String>> storedCookies = req.cookieManager().get(asUri(req.url), EmptyRequestHeaders);
+        for (Map.Entry<String, List<String>> entry : storedCookies.entrySet()) {
+            // might be Cookie: name=value; name=value\nCookie2: name=value; name=value
+            List<String> cookies = entry.getValue(); // these will be name=val
+            if (cookies == null || cookies.size() == 0) // the cookie store often returns just an empty "Cookie" key, no val
+                continue;
+
+            String key = entry.getKey(); // Cookie or Cookie2
+            Set<String> set;
+            if (CookieName.equals(key))
+                set = cookieSet;
+            else if (Cookie2Name.equals(key)) {
+                set = new HashSet<>();
+                cookies2 = set;
+            } else {
+                continue; // unexpected header key
+            }
+            set.addAll(cookies);
+        }
+
+        if (cookieSet.size() > 0)
+            con.addRequestProperty(CookieName, StringUtil.join(cookieSet, Sep));
+        if (cookies2 != null && cookies2.size() > 0)
+            con.addRequestProperty(Cookie2Name, StringUtil.join(cookies2, Sep));
+    }
+
+    private static LinkedHashSet<String> requestCookieSet(Connection.Request req) {
+        LinkedHashSet<String> set = new LinkedHashSet<>();
+        // req cookies are the wildcard key/val cookies (no domain, path, etc)
+        for (Map.Entry<String, String> cookie : req.cookies().entrySet()) {
+            set.add(cookie.getKey() + "=" + cookie.getValue());
+        }
+        return set;
+    }
+
+    static URI asUri(URL url) throws IOException {
+        try {
+            return url.toURI();
+        } catch (URISyntaxException e) {
+            throw new MalformedURLException(e.getMessage()); // this would be a WTF because we construct the URL
+        }
+    }
+
+    static void storeCookies(HttpConnection.Request req, URL url, Map<String, List<String>> resHeaders) throws IOException {
+        req.cookieManager().put(CookieUtil.asUri(url), resHeaders); // stores cookies for session
+
+    }
+}

--- a/src/main/java/org/jsoup/helper/CookieUtil.java
+++ b/src/main/java/org/jsoup/helper/CookieUtil.java
@@ -76,8 +76,10 @@ class CookieUtil {
     static URI asUri(URL url) throws IOException {
         try {
             return url.toURI();
-        } catch (URISyntaxException e) {
-            throw new MalformedURLException(e.getMessage()); // this would be a WTF because we construct the URL
+        } catch (URISyntaxException e) {  // this would be a WTF because we construct the URL
+            MalformedURLException ue = new MalformedURLException(e.getMessage());
+            ue.initCause(e);
+            throw ue;
         }
     }
 

--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -36,6 +36,7 @@ import java.util.zip.GZIPInputStream;
  * Internal static utilities for handling data.
  *
  */
+@SuppressWarnings("CharsetObjectCanBeUsed")
 public final class DataUtil {
     private static final Pattern charsetPattern = Pattern.compile("(?i)\\bcharset=\\s*(?:[\"'])?([^\\s,;\"']*)");
     public static final Charset UTF_8 = Charset.forName("UTF-8"); // Don't use StandardCharsets, as those only appear in Android API 19, and we target 10.
@@ -59,7 +60,7 @@ public final class DataUtil {
      * @return Document
      * @throws IOException on IO error
      */
-    public static Document load(File in, String charsetName, String baseUri) throws IOException {
+    public static Document load(File in, @Nullable String charsetName, String baseUri) throws IOException {
         InputStream stream = new FileInputStream(in);
         String name = Normalizer.lowerCase(in.getName());
         if (name.endsWith(".gz") || name.endsWith(".z")) {
@@ -264,7 +265,7 @@ public final class DataUtil {
     }
 
     private static @Nullable BomCharset detectCharsetFromBom(final ByteBuffer byteData) {
-        final Buffer buffer = byteData; // .mark and rewind used to return Buffer, now ByteBuffer, so cast for backward compat
+        @SuppressWarnings("UnnecessaryLocalVariable") final Buffer buffer = byteData; // .mark and rewind used to return Buffer, now ByteBuffer, so cast for backward compat
         buffer.mark();
         byte[] bom = new byte[4];
         if (byteData.remaining() >= bom.length) {

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -1,5 +1,7 @@
 package org.jsoup.nodes;
 
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
 import org.jsoup.helper.DataUtil;
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.StringUtil;
@@ -20,10 +22,11 @@ import java.util.List;
 
  @author Jonathan Hedley, jonathan@hedley.net */
 public class Document extends Element {
+    private @Nullable Connection connection; // the connection this doc was fetched from, if any
     private OutputSettings outputSettings = new OutputSettings();
     private Parser parser; // the parser used to parse this document
     private QuirksMode quirksMode = QuirksMode.noQuirks;
-    private String location;
+    private final String location;
     private boolean updateMetaCharset = false;
 
     /**
@@ -58,10 +61,24 @@ public class Document extends Element {
     /**
      * Get the URL this Document was parsed from. If the starting URL is a redirect,
      * this will return the final URL from which the document was served from.
+     * <p>Will return an empty string if the location is unknown (e.g. if parsed from a String).
      * @return location
      */
     public String location() {
-     return location;
+        return location;
+    }
+
+    /**
+     Returns the Connection (Request/Response) object that was used to fetch this document, if any; otherwise, a new
+     default Connection object. This can be used to continue a session, preserving settings and cookies, etc.
+     @return the Connection (session) associated with this Document, or an empty one otherwise.
+     @see Connection#newRequest()
+     */
+    public Connection connection() {
+        if (connection == null)
+            return Jsoup.newSession();
+        else
+            return connection;
     }
 
     /**
@@ -606,6 +623,21 @@ public class Document extends Element {
      */
     public Document parser(Parser parser) {
         this.parser = parser;
+        return this;
+    }
+
+    /**
+     Set the Connection used to fetch this document. This Connection is used as a session object when further requests are
+     made (e.g. when a form is submitted).
+
+     @param connection to set
+     @return this document, for chaining
+     @see Connection#newRequest()
+     @since 1.14.1
+     */
+    public Document connection(Connection connection) {
+        Validate.notNull(connection);
+        this.connection = connection;
         return this;
     }
 }

--- a/src/main/java/org/jsoup/nodes/FormElement.java
+++ b/src/main/java/org/jsoup/nodes/FormElement.java
@@ -53,11 +53,14 @@ public class FormElement extends Element {
     }
 
     /**
-     * Prepare to submit this form. A Connection object is created with the request set up from the form values. You
-     * can then set up other options (like user-agent, timeout, cookies), then execute it.
-     * @return a connection prepared from the values of this form.
-     * @throws IllegalArgumentException if the form's absolute action URL cannot be determined. Make sure you pass the
-     * document's base URI when parsing.
+     Prepare to submit this form. A Connection object is created with the request set up from the form values. This
+     Connection will inherit the settings and the cookies (etc) of the connection/session used to request this Document
+     (if any), as available in {@link Document#connection()}
+     <p>You can then set up other options (like user-agent, timeout, cookies), then execute it.</p>
+
+     @return a connection prepared from the values of this form, in the same session as the one used to request it
+     @throws IllegalArgumentException if the form's absolute action URL cannot be determined. Make sure you pass the
+     document's base URI when parsing.
      */
     public Connection submit() {
         String action = hasAttr("action") ? absUrl("action") : baseUri();
@@ -65,7 +68,9 @@ public class FormElement extends Element {
         Connection.Method method = attr("method").equalsIgnoreCase("POST") ?
                 Connection.Method.POST : Connection.Method.GET;
 
-        return Jsoup.connect(action)
+        Document owner = ownerDocument();
+        Connection connection = owner != null? owner.connection().newRequest() : Jsoup.newSession();
+        return connection.url(action)
                 .data(formData())
                 .method(method);
     }

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -62,6 +62,11 @@ public class HtmlTreeBuilder extends TreeBuilder {
         return ParseSettings.htmlDefault;
     }
 
+    @Override
+    HtmlTreeBuilder newInstance() {
+        return new HtmlTreeBuilder();
+    }
+
     @Override @ParametersAreNonnullByDefault
     protected void initialiseParse(Reader input, String baseUri, Parser parser) {
         super.initialiseParse(input, baseUri, parser);

--- a/src/main/java/org/jsoup/parser/ParseErrorList.java
+++ b/src/main/java/org/jsoup/parser/ParseErrorList.java
@@ -9,11 +9,21 @@ import java.util.ArrayList;
  */
 public class ParseErrorList extends ArrayList<ParseError>{
     private static final int INITIAL_CAPACITY = 16;
+    private final int initialCapacity;
     private final int maxSize;
     
     ParseErrorList(int initialCapacity, int maxSize) {
         super(initialCapacity);
+        this.initialCapacity = initialCapacity;
         this.maxSize = maxSize;
+    }
+
+    /**
+     Create a new ParseErrorList with the same settings, but no errors in the list
+     @param copy initial and max size details to copy
+     */
+    ParseErrorList(ParseErrorList copy) {
+        this(copy.initialCapacity, copy.maxSize);
     }
     
     boolean canAddError() {

--- a/src/main/java/org/jsoup/parser/ParseSettings.java
+++ b/src/main/java/org/jsoup/parser/ParseSettings.java
@@ -49,6 +49,10 @@ public class ParseSettings {
         preserveAttributeCase = attribute;
     }
 
+    ParseSettings(ParseSettings copy) {
+        this(copy.preserveTagCase, copy.preserveAttributeCase);
+    }
+
     /**
      * Normalizes a tag name according to the case preservation setting.
      */

--- a/src/main/java/org/jsoup/parser/Parser.java
+++ b/src/main/java/org/jsoup/parser/Parser.java
@@ -26,6 +26,20 @@ public class Parser {
         settings = treeBuilder.defaultSettings();
         errors = ParseErrorList.noTracking();
     }
+
+    /**
+     Creates a new Parser as a deep copy of this; including initializing a new TreeBuilder. Allows independent (multi-threaded) use.
+     @return a copied parser
+     */
+    public Parser newInstance() {
+        return new Parser(this);
+    }
+
+    private Parser(Parser copy) {
+        treeBuilder = copy.treeBuilder.newInstance(); // because extended
+        errors = new ParseErrorList(copy.errors); // only copies size, not contents
+        settings = new ParseSettings(copy.settings);
+    }
     
     public Document parseInput(String html, String baseUri) {
         return treeBuilder.parse(new StringReader(html), baseUri, this);

--- a/src/main/java/org/jsoup/parser/TreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilder.java
@@ -59,6 +59,12 @@ abstract class TreeBuilder {
         return doc;
     }
 
+    /**
+     Create a new copy of this TreeBuilder
+     @return copy, ready for a new parse
+     */
+    abstract TreeBuilder newInstance();
+
     abstract List<Node> parseFragment(String inputFragment, Element context, String baseUri, Parser parser);
 
     protected void runParser() {

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -45,6 +45,11 @@ public class XmlTreeBuilder extends TreeBuilder {
     }
 
     @Override
+    XmlTreeBuilder newInstance() {
+        return new XmlTreeBuilder();
+    }
+
+    @Override
     protected boolean process(Token token) {
         // start tag, end tag, doctype, comment, character, eof
         switch (token.type) {

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -261,7 +261,7 @@ public class HttpConnectionTest {
             con.execute();
         } catch (IllegalArgumentException e) {
             threw = true;
-            assertEquals("URL not yet set", e.getMessage());
+            assertEquals("URL not set. Make sure to call #url(...) before executing the request.", e.getMessage());
         }
         assertTrue(threw);
     }

--- a/src/test/java/org/jsoup/integration/SessionIT.java
+++ b/src/test/java/org/jsoup/integration/SessionIT.java
@@ -1,0 +1,116 @@
+package org.jsoup.integration;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.UncheckedIOException;
+import org.jsoup.integration.servlets.FileServlet;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Integration tests to test longer running Connection */
+public class SessionIT {
+    @Test
+    public void multiThread() throws InterruptedException {
+        int numThreads = 20;
+        int numThreadLoops = 5;
+        String[] urls = {
+            FileServlet.urlTo("/htmltests/smh-biz-article-1.html.gz"),
+            FileServlet.urlTo("/htmltests/news-com-au-home.html.gz"),
+            FileServlet.urlTo("/htmltests/google-ipod.html.gz"),
+            FileServlet.urlTo("/htmltests/large.html"),
+        };
+        String[] titles = {
+            "The board’s next fear: the female quota",
+            "News.com.au | News from Australia and around the world online | NewsComAu",
+            "ipod - Google Search",
+            "Large HTML"
+        };
+        ThreadCatcher catcher = new ThreadCatcher();
+
+        Connection session = Jsoup.newSession();
+
+        Thread[] threads = new Thread[numThreads];
+        for (int threadNum = 0; threadNum < numThreads; threadNum++) {
+            Thread thread = new Thread(() -> {
+                for (int loop = 0; loop < numThreadLoops; loop++) {
+                    for (int i = 0; i < urls.length; i++) {
+                        try {
+                            Document doc = session.newRequest().url(urls[i]).get();
+                            assertEquals(titles[i], doc.title());
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }
+                }
+            });
+            thread.setName("Runner-" + threadNum);
+            thread.start();
+            thread.setUncaughtExceptionHandler(catcher);
+            threads[threadNum] = thread;
+        }
+
+        // now join them all
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertEquals(0, catcher.exceptionCount.get());
+    }
+
+    // test that we throw a nice clear exception if you try to multi-thread by forget .newRequest()
+    @Test
+    public void multiThreadWithoutNewRequestBlowsUp() throws InterruptedException {
+        int numThreads = 20;
+        String url = FileServlet.urlTo("/htmltests/large.html");
+        String title = "Large HTML";
+
+        ThreadCatcher catcher = new ThreadCatcher();
+        Connection session = Jsoup.newSession();
+
+        Thread[] threads = new Thread[numThreads];
+        for (int threadNum = 0; threadNum < numThreads; threadNum++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    Document doc = session.url(url).get();
+                    assertEquals(title, doc.title());
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            thread.setName("Runner-" + threadNum);
+            thread.start();
+            thread.setUncaughtExceptionHandler(catcher);
+            threads[threadNum] = thread;
+        }
+
+        // now join them all
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // only one should have passed, rest should have blown up (assuming the started whilst other was running)
+        assertEquals(numThreads - 1, catcher.multiThreadExceptions.get());
+        assertEquals(numThreads - 1, catcher.exceptionCount.get());
+    }
+
+
+    static class ThreadCatcher implements Thread.UncaughtExceptionHandler {
+        AtomicInteger exceptionCount = new AtomicInteger();
+        AtomicInteger multiThreadExceptions = new AtomicInteger();
+
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+            if (e instanceof IllegalArgumentException && e.getMessage().contains("Multiple threads"))
+                multiThreadExceptions.incrementAndGet();
+            else
+                e.printStackTrace();
+            exceptionCount.incrementAndGet();
+        }
+    }
+
+}

--- a/src/test/java/org/jsoup/integration/SessionIT.java
+++ b/src/test/java/org/jsoup/integration/SessionIT.java
@@ -5,6 +5,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.UncheckedIOException;
 import org.jsoup.integration.servlets.EchoServlet;
 import org.jsoup.integration.servlets.FileServlet;
+import org.jsoup.integration.servlets.SlowRider;
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -79,8 +80,8 @@ public class SessionIT {
     @Test
     public void multiThreadWithoutNewRequestBlowsUp() throws InterruptedException {
         int numThreads = 20;
-        String url = FileServlet.urlTo("/htmltests/large.html");
-        String title = "Large HTML";
+        String url = SlowRider.Url + "?" + SlowRider.MaxTimeParam + "=10000"; // this makes sure that the first req is still executing whilst the others run
+        String title = "Slow Rider";
 
         ThreadCatcher catcher = new ThreadCatcher();
         Connection session = Jsoup.newSession();

--- a/src/test/java/org/jsoup/integration/SessionIT.java
+++ b/src/test/java/org/jsoup/integration/SessionIT.java
@@ -3,8 +3,11 @@ package org.jsoup.integration;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.UncheckedIOException;
+import org.jsoup.integration.servlets.EchoServlet;
 import org.jsoup.integration.servlets.FileServlet;
 import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -14,6 +17,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Integration tests to test longer running Connection */
 public class SessionIT {
+    @BeforeAll
+    public static void setUp() {
+        TestServer.start();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        TestServer.stop();
+    }
+
     @Test
     public void multiThread() throws InterruptedException {
         int numThreads = 20;

--- a/src/test/java/org/jsoup/integration/SessionTest.java
+++ b/src/test/java/org/jsoup/integration/SessionTest.java
@@ -8,6 +8,8 @@ import org.jsoup.integration.servlets.FileServlet;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -17,6 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SessionTest {
+    @BeforeAll
+    public static void setUp() {
+        TestServer.start();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        TestServer.stop();
+    }
 
     private static Elements keyEls(String key, Document doc) {
         return doc.select("th:contains(" + key + ") + td");

--- a/src/test/java/org/jsoup/integration/SessionTest.java
+++ b/src/test/java/org/jsoup/integration/SessionTest.java
@@ -1,0 +1,129 @@
+package org.jsoup.integration;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.integration.servlets.CookieServlet;
+import org.jsoup.integration.servlets.EchoServlet;
+import org.jsoup.integration.servlets.FileServlet;
+import org.jsoup.nodes.Document;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SessionTest {
+
+    private static Elements keyEls(String key, Document doc) {
+        return doc.select("th:contains(" + key + ") + td");
+    }
+
+    private static String keyText(String key, Document doc) {
+        return doc.selectFirst("th:contains(" + key + ") + td").text();
+    }
+
+    @Test
+    public void testPathScopedCookies() throws IOException {
+        final Connection session = Jsoup.newSession();
+        final String userAgent = "Jsoup Testalot v0.1";
+
+        session.userAgent(userAgent);
+        session.url(CookieServlet.Url);
+
+        // should have no cookies:
+        Connection con1 = session.newRequest();
+        Document doc1 = con1.get();
+        assertEquals(0, doc1.select("table tr").size()); // none sent to servlet
+
+        // set the cookies
+        Connection con2 = session.newRequest().data(CookieServlet.SetCookiesParam, "1");
+        Document doc2 = con2.get();
+        assertEquals(0, doc2.select("table tr").size());  // none sent to servlet - we just got them!
+        Map<String, String> cookies = con2.response().cookies(); // simple cookie response, all named "One", so should be first sent
+        assertEquals(1, cookies.size());
+        assertEquals("Root", cookies.get("One"));
+
+        // todo - interrogate cookie-store
+
+        // check that they are sent and filtered to the right path
+        Connection con3 = session.newRequest();
+        Document doc3 = con3.get();
+        assertCookieServlet(doc3);
+
+        Document echo = session.newRequest().url(EchoServlet.Url).get();
+        assertEchoServlet(echo);
+        assertEquals(userAgent, keyText("User-Agent", echo)); // check that customer user agent sent on session arrived
+
+        // check that cookies aren't set out of the session
+        Document doc4 = Jsoup.newSession().url(CookieServlet.Url).get();
+        assertEquals(0, doc4.select("table tr").size()); // none sent to servlet
+
+        // check can add local ones also
+        Document doc5 = session.newRequest().cookie("Bar", "Qux").get();
+        Elements doc5Bar = keyEls("Bar", doc5);
+        assertEquals("Qux", doc5Bar.first().text());
+    }
+
+    // validate that only cookies set by cookie servlet get to the cookie servlet path
+    private void assertCookieServlet(Document doc) {
+        assertEquals(2, doc.select("table tr").size());  // two of three sent to servlet (/ and /CookieServlet)
+        Elements doc3Els = keyEls("One", doc);
+        assertEquals(2, doc3Els.size());
+        assertEquals("CookieServlet", doc3Els.get(0).text()); // ordered by most specific path
+        assertEquals("Root", doc3Els.get(1).text()); // ordered by most specific path
+    }
+
+    // validate that only for echo servlet
+    private void assertEchoServlet(Document doc) {
+        Elements echoEls = keyEls("Cookie: One", doc);  // two of three sent to servlet (/ and /EchoServlet)
+        assertEquals(2, echoEls.size());
+        assertEquals("EchoServlet", echoEls.get(0).text()); // ordered by most specific path - /Echo
+        assertEquals("Root", echoEls.get(1).text()); // ordered by most specific path - /
+    }
+
+    @Test
+    public void testPathScopedCookiesOnRedirect() throws IOException {
+        Connection session = Jsoup.newSession();
+
+        Document doc1 = session.newRequest()
+            .url(CookieServlet.Url)
+            .data(CookieServlet.LocationParam, EchoServlet.Url)
+            .data(CookieServlet.SetCookiesParam, "1")
+            .get();
+
+        // we should be redirected to the echo servlet with cookies
+        assertEquals(EchoServlet.Url, doc1.location());
+        assertEchoServlet(doc1); // checks we only have /echo cookies
+
+        Document doc2 = session.newRequest()
+            .url(EchoServlet.Url)
+            .get();
+        assertEchoServlet(doc2); // test retained in session
+
+        Document doc3 = session.newRequest()
+            .url(CookieServlet.Url)
+            .get();
+        assertCookieServlet(doc3); // and so were the /cookie cookies
+    }
+
+    @Test
+    public void testCanChangeParsers() throws IOException {
+        Connection session = Jsoup.newSession().parser(Parser.xmlParser());
+
+        String xmlUrl = FileServlet.urlTo("/htmltests/xml-test.xml");
+        String xmlVal = "<doc><val>One<val>Two</val>Three</val></doc>\n";
+
+        Document doc1 = session.newRequest().url(xmlUrl).get();
+        assertEquals(xmlVal, doc1.html()); // not HTML normed, used XML parser
+
+        Document doc2 = session.newRequest().parser(Parser.htmlParser()).url(xmlUrl).get();
+        assertTrue(doc2.html().startsWith("<html>"));
+
+        Document doc3 = session.newRequest().url(xmlUrl).get();
+        assertEquals(xmlVal, doc3.html()); // did not blow away xml default
+    }
+}

--- a/src/test/java/org/jsoup/integration/TestServer.java
+++ b/src/test/java/org/jsoup/integration/TestServer.java
@@ -34,7 +34,7 @@ public class TestServer {
 
     public static void stop() {
         synchronized (jetty) {
-            int count = latch.decrementAndGet();
+            int count = latch.getAndDecrement();
             if (count == 0) {
                 try {
                     jetty.stop();

--- a/src/test/java/org/jsoup/integration/servlets/CookieServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/CookieServlet.java
@@ -1,0 +1,76 @@
+package org.jsoup.integration.servlets;
+
+import org.jsoup.integration.TestServer;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class CookieServlet extends BaseServlet{
+    public static final String Url = TestServer.map(CookieServlet.class);
+    public static final String SetCookiesParam = "setCookies";
+    public static final String LocationParam = "loc";
+
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        doIt(req, res);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        doIt(req, res);
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        doIt(req, res);
+    }
+
+    private void doIt(HttpServletRequest req, HttpServletResponse res) throws IOException {
+        // Do we want to set cookies?
+        if (req.getParameter(SetCookiesParam) != null)
+            setCookies(res);
+
+        // Do we want to redirect elsewhere?
+        String loc = req.getParameter(LocationParam);
+        if (loc != null) {
+            res.sendRedirect(loc);
+            return;
+        }
+
+        // print out the cookies that were received
+        res.setContentType(TextHtml);
+        res.setStatus(200);
+
+        PrintWriter w = res.getWriter();
+        w.println("<table>");
+        final Cookie[] cookies = req.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                EchoServlet.write(w, cookie.getName(), cookie.getValue());
+            }
+        }
+        w.println("</table>");
+    }
+
+    private void setCookies(HttpServletResponse res) {
+        Cookie one = new Cookie("One", "Root");
+        one.setPath("/");
+        res.addCookie(one);
+
+        Cookie two = new Cookie("One", "CookieServlet");
+        two.setPath("/CookieServlet");
+        two.setHttpOnly(true);
+        two.setComment("Quite nice");
+        res.addCookie(two);
+
+        Cookie three = new Cookie("One", "EchoServlet");
+        three.setPath("/EchoServlet");
+        res.addCookie(three);
+    }
+
+}

--- a/src/test/java/org/jsoup/integration/servlets/EchoServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/EchoServlet.java
@@ -7,6 +7,7 @@ import org.jsoup.integration.TestServer;
 
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
@@ -78,6 +79,14 @@ public class EchoServlet extends BaseServlet {
             }
         }
 
+        // cookies
+        final Cookie[] cookies = req.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                EchoServlet.write(w, "Cookie: " + cookie.getName(), cookie.getValue());
+            }
+        }
+
         // the request params
         Enumeration<String> parameterNames = req.getParameterNames();
         while (parameterNames.hasMoreElements()) {
@@ -111,7 +120,7 @@ public class EchoServlet extends BaseServlet {
         w.println("</table>");
     }
 
-    private static void write(PrintWriter w, String key, String val) {
+    static void write(PrintWriter w, String key, String val) {
         w.println("<tr><th>" + escape(key) + "</th><td>" + escape(val) + "</td></tr>");
     }
 

--- a/src/test/java/org/jsoup/integration/servlets/FileServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/FileServlet.java
@@ -25,6 +25,8 @@ public class FileServlet extends BaseServlet {
         File file = ParseTest.getFile(location);
         if (file.exists()) {
             res.setContentType(contentType);
+            if (file.getName().endsWith("gz"))
+                res.addHeader("Content-Encoding", "gzip");
             res.setStatus(HttpServletResponse.SC_OK);
 
             ServletOutputStream out = res.getOutputStream();

--- a/src/test/java/org/jsoup/integration/servlets/SlowRider.java
+++ b/src/test/java/org/jsoup/integration/servlets/SlowRider.java
@@ -29,6 +29,7 @@ public class SlowRider extends BaseServlet {
         }
 
         long startTime = System.currentTimeMillis();
+        w.println("<title>Slow Rider</title>");
         while (true) {
             w.println("<p>Are you still there?");
             boolean err = w.checkError(); // flush, and check still ok

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -140,6 +140,11 @@ public class DocumentTest {
         assertEquals("http://www.nytimes.com/2010/07/26/business/global/26bp.html?hp",baseUri);
     }
 
+    @Test public void testLocationFromString() {
+        Document doc = Jsoup.parse("<p>Hello");
+        assertEquals("", doc.location());
+    }
+
     @Test public void testHtmlAndXmlSyntax() {
         String h = "<!DOCTYPE html><body><img async checked='checked' src='&<>\"'>&lt;&gt;&amp;&quot;<foo />bar";
         Document doc = Jsoup.parse(h);

--- a/src/test/java/org/jsoup/nodes/FormElementTest.java
+++ b/src/test/java/org/jsoup/nodes/FormElementTest.java
@@ -2,8 +2,13 @@ package org.jsoup.nodes;
 
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
+import org.jsoup.integration.servlets.CookieServlet;
+import org.jsoup.integration.servlets.EchoServlet;
+import org.jsoup.integration.servlets.FileServlet;
+import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -174,5 +179,28 @@ public class FormElementTest {
         assertEquals("user", data.get(0).key());
         assertEquals("login", data.get(1).key());
         assertNull(doc.selectFirst("input[name=pass]"));
+    }
+
+    @Test public void formSubmissionCarriesCookiesFromSession() throws IOException {
+        String echoUrl = EchoServlet.Url; // this is a dirty hack to initialize the EchoServlet(!)
+        Document cookieDoc = Jsoup.connect(CookieServlet.Url)
+            .data(CookieServlet.SetCookiesParam, "1")
+            .get();
+        Document formDoc = cookieDoc.connection().newRequest() // carries cookies from above set
+            .url(FileServlet.urlTo("/htmltests/upload-form.html"))
+            .get();
+        FormElement form = formDoc.select("form").forms().get(0);
+        Document echo = form.submit().post();
+
+        assertEquals(echoUrl, echo.location());
+        Elements els = echo.select("th:contains(Cookie: One)");
+        // ensure that the cookies are there and in path-specific order (two with same name)
+        assertEquals("EchoServlet", els.get(0).nextElementSibling().text());
+        assertEquals("Root", els.get(1).nextElementSibling().text());
+
+        // make sure that the session following kept unique requests
+        assertTrue(cookieDoc.connection().response().url().toExternalForm().contains("CookieServlet"));
+        assertTrue(formDoc.connection().response().url().toExternalForm().contains("upload-form"));
+        assertTrue(echo.connection().response().url().toExternalForm().contains("EchoServlet"));
     }
 }

--- a/src/test/java/org/jsoup/nodes/FormElementTest.java
+++ b/src/test/java/org/jsoup/nodes/FormElementTest.java
@@ -2,10 +2,13 @@ package org.jsoup.nodes;
 
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
+import org.jsoup.integration.TestServer;
 import org.jsoup.integration.servlets.CookieServlet;
 import org.jsoup.integration.servlets.EchoServlet;
 import org.jsoup.integration.servlets.FileServlet;
 import org.jsoup.select.Elements;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -19,6 +22,16 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Jonathan Hedley
  */
 public class FormElementTest {
+    @BeforeAll
+    public static void setUp() {
+        TestServer.start();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        TestServer.stop();
+    }
+
     @Test public void hasAssociatedControls() {
         //"button", "fieldset", "input", "keygen", "object", "output", "select", "textarea"
         String html = "<form id=1><button id=1><fieldset id=2 /><input id=3><keygen id=4><object id=5><output id=6>" +


### PR DESCRIPTION
This extends the Connection implementation to support (optional) sessions, which allow request defaults (timeout, proxy, etc) to be set once and then applied to all requests within that session. 

Cookies are re-implemented to correctly support path and domain filtering when used within a session. A default in-memory cookie store is used for the session, or a custom implementation (perhaps disk-persistent, or pre-set) can be used instead.

Forms submitted using the `FormElement#submit()` use the same session that was used to fetch the document and so pass cookies and other defaults appropriately.

The session is multi-thread safe and can execute multiple requests concurrently. If the user accidently tries to execute the same request object across multiple threads (vs calling `Connection#newRequest()`), that is detected cleanly and a clear exception is thrown (vs weird blowups in input stream reading, or forcing everything throw a synchronized bottleneck.

Examples:
```java
Connection session = Jsoup.newSession()
     .timeout(20 * 1000)
     .userAgent("FooBar 2000");

Document doc1 = session.newRequest()
     .url("https://jsoup.org/").data("ref", "example")
     .get();
Document doc2 = session.newRequest()
     .url("https://en.wikipedia.org/wiki/Main_Page")
     .get();
Connection con3 = session.newRequest();
```