### PR TITLE
Implement static method Element.of(html)

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1628,9 +1628,11 @@ public class Element extends Node {
      * @see #html(String)
      */
     static Element of(final String html){
-        String head = html.trim().substring(1,5);
-        if (head.equals("html") || head.equals("head"))
-            throw new IllegalArgumentException("Element syntax error: Outer tag can not be <html> or <head>.");
+        if(html.trim().length() > 5) {
+            String head = html.trim().substring(1, 5);
+            if (head.equals("html") || head.equals("head"))
+                throw new IllegalArgumentException("Element syntax error: Outer tag can not be <html> or <head>.");
+        }
         Element e = new Element("div").html(html);
         if (e.childNodeSize() > 1){
             throw new IllegalArgumentException("Element syntax error: Number of outer element must be one.");

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1621,6 +1621,22 @@ public class Element extends Node {
         return this;
     }
 
+    /**
+     * Create an element with HTML.
+     * @param html HTML to parse, there should be only one outer tag which become the return element.
+     * @return the element create by the outer tag
+     * @see #html(String)
+     */
+    static Element of(final String html){
+        Element e = new Element("div").html(html);
+        if (e.childNodeSize() > 1){
+            throw new IllegalArgumentException("Element syntax error: Number of outer element must be one.");
+        }else if (e.childNodeSize() == 0){
+            throw new IllegalArgumentException("Element syntax error: No legal element detected.");
+        }
+        return e.child(0);
+    }
+
     @Override
     public Element clone() {
         return (Element) super.clone();

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1628,6 +1628,9 @@ public class Element extends Node {
      * @see #html(String)
      */
     static Element of(final String html){
+        String head = html.trim().substring(1,5);
+        if (head.equals("html") || head.equals("head"))
+            throw new IllegalArgumentException("Element syntax error: Outer tag can not be <html> or <head>.");
         Element e = new Element("div").html(html);
         if (e.childNodeSize() > 1){
             throw new IllegalArgumentException("Element syntax error: Number of outer element must be one.");

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -2060,4 +2060,11 @@ public class ElementTest {
             Element e = Element.of("");
         });
     }
+
+    @Test
+    public void elementOf04() {
+        assertThrows(IllegalArgumentException.class,()->{
+            Element e = Element.of("<html><head></head><body></body><html>");
+        });
+    }
 }

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -2039,4 +2039,25 @@ public class ElementTest {
         els.add(new Element("a"));
         assertEquals(1, els.size());
     }
+
+    @Test
+    public void elementOf01() {
+        assertThrows(IllegalArgumentException.class,()->{
+            Element e = Element.of("<span>Some stuff</span><span>Second part</span>");
+        });
+    }
+
+    @Test
+    public void elementOf02() {
+        Element e = Element.of("<div id=\"test\"><span>Some stuff</span><span>Second part</span></div>");
+        assertEquals("div",e.tag().getName());
+        assertEquals("test",e.attributes().get("id"));
+    }
+
+    @Test
+    public void elementOf03() {
+        assertThrows(IllegalArgumentException.class,()->{
+            Element e = Element.of("");
+        });
+    }
 }


### PR DESCRIPTION
I implement `Element.of(html)` mentioned in #1411 by using method `element.html()`, while using a `<div>` to be the top element can succeed in most situation, but can not hold cases like input tag `<html>`. I will glad to work more on this and welcome your code reviews.