### PR TITLE
Fix #1492:Attributes equals now is order sensitive

### DIFF
--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -386,9 +386,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
 
         Attributes that = (Attributes) o;
 
-        if (size != that.size) return false;
-        if (!Arrays.equals(keys, that.keys)) return false;
-        return Arrays.equals(vals, that.vals);
+        return dataset().equals(that.dataset());
     }
 
     /**

--- a/src/test/java/org/jsoup/headTest.java
+++ b/src/test/java/org/jsoup/headTest.java
@@ -1,0 +1,30 @@
+package org.jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class headTest {
+    String html = "<div someattribute=\"somevalue\"=\"\"></div>";
+    String url = "https://www2.deloitte.com/us/en/insights/industry/power-and-utilities/future-of-energy-us-energy-transition.html";
+
+    @Test
+    public void testXml() {
+        Document xml = Jsoup.parse(html, "", Parser.xmlParser());
+        String xmlResult = xml.toString();
+        assertEquals(xmlResult, "<div someattribute=\"somevalue\" =\"\"></div>");
+    }
+
+    @Test
+    public void testHtml() throws IOException {
+        //Document doc = Jsoup.connect(url).get();
+        Document doc1 = Jsoup.parse(url);
+        Document doc2 = Jsoup.connect(url).get();
+        assertEquals(doc2.head(), doc1.head());
+    }
+}
+

--- a/src/test/java/org/jsoup/nodes/AttributesTest.java
+++ b/src/test/java/org/jsoup/nodes/AttributesTest.java
@@ -1,7 +1,9 @@
 package org.jsoup.nodes;
 
+import org.jsoup.Jsoup;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -226,5 +228,21 @@ public class AttributesTest {
         a.put(Attributes.internalKey("baseUri"), "example.com");
         a.put(Attributes.internalKey("another"), "example.com");
         assertEquals(2, a.size());
+    }
+
+    @Test
+    public void testOrder1() throws IOException {
+
+        final Attributes attributesBarFoo = Jsoup.parseBodyFragment("<a style=\"bar\" class=\"foo\">").select("a").first().attributes();
+        final Attributes attributesFooBar = Jsoup.parseBodyFragment("<a class=\"foo\" style=\"bar\">").select("a").first().attributes();
+        assertEquals(attributesBarFoo, attributesFooBar);
+    }
+
+    @Test
+    public void testOrder2() throws IOException {
+
+        final Attributes attributesBarFoo = Jsoup.parseBodyFragment("<base href=\"http://www.runoob.com/images/\" target=\"_blank\">").select("base").first().attributes();
+        final Attributes attributesFooBar = Jsoup.parseBodyFragment("<base target=\"_blank\" href=\"http://www.runoob.com/images/\">").select("base").first().attributes();
+        assertEquals(attributesBarFoo, attributesFooBar);
     }
 }

--- a/src/test/java/org/jsoup/orderTest.java
+++ b/src/test/java/org/jsoup/orderTest.java
@@ -1,0 +1,27 @@
+package org.jsoup;
+import org.jsoup.nodes.Attributes;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+
+public class orderTest {
+
+    @Test
+    public void testInput() throws IOException {
+
+        final Attributes attributesBarFoo = Jsoup.parseBodyFragment("<a style=\"bar\" class=\"foo\">").select("a").first().attributes();
+        final Attributes attributesFooBar = Jsoup.parseBodyFragment("<a class=\"foo\" style=\"bar\">").select("a").first().attributes();
+        assertEquals(attributesBarFoo, attributesFooBar);
+    }
+
+    @Test
+    public void anotherTest() throws IOException {
+
+        final Attributes attributesBarFoo = Jsoup.parseBodyFragment("<base href=\"http://www.runoob.com/images/\" target=\"_blank\">").select("base").first().attributes();
+        final Attributes attributesFooBar = Jsoup.parseBodyFragment("<base target=\"_blank\" href=\"http://www.runoob.com/images/\">").select("base").first().attributes();
+        assertEquals(attributesBarFoo, attributesFooBar);
+    }
+}
+


### PR DESCRIPTION
Since Attributes are implemented by map, so the comparison can be realized by calling `equals()` for map in the function `equals()` in `Attributes.java`