### PR TITLE
Change how empty attribute names are handled

### DIFF
--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -104,17 +104,15 @@ abstract class Token {
             if (pendingAttributeName != null) {
                 // the tokeniser has skipped whitespace control chars, but trimming could collapse to empty for other control codes, so verify here
                 pendingAttributeName = pendingAttributeName.trim();
-                if (pendingAttributeName.length() > 0) {
-                    String value;
-                    if (hasPendingAttributeValue)
-                        value = pendingAttributeValue.length() > 0 ? pendingAttributeValue.toString() : pendingAttributeValueS;
-                    else if (hasEmptyAttributeValue)
-                        value = "";
-                    else
-                        value = null;
-                    // note that we add, not put. So that the first is kept, and rest are deduped, once in a context where case sensitivity is known (the appropriate tree builder).
-                    attributes.add(pendingAttributeName, value);
-                }
+                String value;
+                if (hasPendingAttributeValue)
+                    value = pendingAttributeValue.length() > 0 ? pendingAttributeValue.toString() : pendingAttributeValueS;
+                else if (hasEmptyAttributeValue)
+                    value = "";
+                else
+                    value = null;
+                // note that we add, not put. So that the first is kept, and rest are deduped, once in a context where case sensitivity is known (the appropriate tree builder).
+                attributes.add(pendingAttributeName, value);
             }
             pendingAttributeName = null;
             hasEmptyAttributeValue = false;

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -596,8 +596,8 @@ enum TokeniserState {
                 case '=':
                     t.error(this);
                     t.tagPending.newAttribute();
-                    t.tagPending.appendAttributeName(c);
-                    t.transition(AttributeName);
+                    t.tagPending.appendAttributeName("");
+                    t.transition(BeforeAttributeValue);
                     break;
                 default: // A-Z, anything else
                     t.tagPending.newAttribute();

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -87,6 +87,7 @@ public class XmlTreeBuilder extends TreeBuilder {
             startTag.attributes.deduplicate(settings);
 
         Element el = new Element(tag, null, settings.normalizeAttributes(startTag.attributes));
+        el.attributes().remove("");
         insertNode(el);
         if (startTag.isSelfClosing()) {
             if (!tag.isKnownTag()) // unknown tag, remember this is self closing for output. see above.

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1415,6 +1415,18 @@ public class HtmlParserTest {
         assertFalse(didAddElements(full));
     }
 
+    @Test public void attributesWithNoKeyAndNoVal(){
+        String html = "<div =\"\"></div>";
+        org.jsoup.nodes.Document doc = Jsoup.parse(html);
+        String html_parse = doc.toString();
+        assertEquals("<html>\n" +
+                " <head></head>\n" +
+                " <body>\n" +
+                "  <div =\"\"></div>\n" +
+                " </body>\n" +
+                "</html>",html_parse);
+    }
+
     private boolean didAddElements(String input) {
         // two passes, one as XML and one as HTML. XML does not vivify missing/optional tags
         Document html = Jsoup.parse(input);

--- a/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
@@ -255,6 +255,13 @@ public class XmlTreeBuilderTest {
         assertEquals("<p One=\"One\" ONE=\"Two\" one=\"Three\" two=\"Six\" Two=\"Eight\">Text</p>", doc.selectFirst("p").outerHtml());
     }
 
+    @Test public void attributesWithNoKeyAndNoVal(){
+        String html = "<div =\"\"></div>";
+        org.jsoup.nodes.Document xml = Jsoup.parse(html, "", Parser.xmlParser());
+        String xmlResult = xml.toString();
+        assertEquals("<div></div>", xmlResult);
+    }
+
     @Test public void readerClosedAfterParse() {
         Document doc = Jsoup.parse("Hello", "", Parser.xmlParser());
         TreeBuilder treeBuilder = doc.parser().getTreeBuilder();


### PR DESCRIPTION
When parsing <div ="">, the parser no longer treats " ="" " whole as the key of the attribute, but "","" as the key and val.
" ="" " will be retained if we use HTML, but not if we use XML