### PR TITLE
fix issue#1490

### DIFF
--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -58,7 +58,6 @@ public class Jsoup {
      call for url.
 
      @param html HTML to parse
-     @return sane HTML
      @return sane HTML if input correct, sane HTML if input is url,
      empty HTML if encountered IOException.
 

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -66,7 +66,7 @@ public class Jsoup {
             URL url = new URL(html);
             url.toURI();
             return parse(url, 3000);
-        }catch (URISyntaxException | MalformedURLException e) {
+        } catch (URISyntaxException | MalformedURLException e) {
             return Parser.parse(html, "");
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -59,7 +59,8 @@ public class Jsoup {
 
      @param html HTML to parse
      @return sane HTML
-     @return sane HTML if input correct, sane HTML if input is url, empty HTML if encountered IOException.
+     @return sane HTML if input correct, sane HTML if input is url,
+     empty HTML if encountered IOException.
 
      @see #parse(String, String)
      */

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -12,6 +12,8 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 /**
@@ -51,6 +53,8 @@ public class Jsoup {
     /**
      Parse HTML into a Document. As no base URI is specified, absolute URL detection relies on the HTML including a
      {@code <base href>} tag.
+     MonteCrystal#1490: Check if passed string is a url while it should be an html. If is url, then invoke the parse
+     call for url.
 
      @param html HTML to parse
      @return sane HTML
@@ -58,7 +62,16 @@ public class Jsoup {
      @see #parse(String, String)
      */
     public static Document parse(String html) {
-        return Parser.parse(html, "");
+        try {
+            URL url = new URL(html);
+            url.toURI();
+            return parse(url, 3000);
+        }catch (URISyntaxException | MalformedURLException e) {
+            return Parser.parse(html, "");
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -22,6 +22,7 @@ import java.net.URL;
  @author Jonathan Hedley */
 
 public class Jsoup {
+    static final int TIMEOUT = 3000;
     private Jsoup() {}
 
     /**
@@ -61,15 +62,14 @@ public class Jsoup {
 
      @see #parse(String, String)
      */
-    public static Document parse(String html) {
+    public static Document parse(final String html) {
         try {
             URL url = new URL(html);
             url.toURI();
-            return parse(url, 3000);
+            return parse(url, TIMEOUT);
         } catch (URISyntaxException | MalformedURLException e) {
             return Parser.parse(html, "");
         } catch (IOException e) {
-            e.printStackTrace();
             return null;
         }
     }

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -70,7 +70,7 @@ public class Jsoup {
         } catch (URISyntaxException | MalformedURLException e) {
             return Parser.parse(html, "");
         } catch (IOException e) {
-            return null;
+            return Parser.parse("", "");
         }
     }
 

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -59,6 +59,7 @@ public class Jsoup {
 
      @param html HTML to parse
      @return sane HTML
+     @return sane HTML if input correct, sane HTML if input is url, empty HTML if encountered IOException.
 
      @see #parse(String, String)
      */

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1429,7 +1429,7 @@ public class HtmlParserTest {
     void testParseUrl() throws IOException {
         String url = "https://www2.deloitte.com/us/en/insights/industry/power-and-utilities/future-of-energy-us-energy-transition.html";
         Document doc1 = Jsoup.parse(url);
-        assertNotEquals("<head><\\head>",doc1.head());
+        assertNotEquals("<head></head>",doc1.head().toString());
     }
 
 

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1432,7 +1432,6 @@ public class HtmlParserTest {
         assertNotEquals("<head></head>",doc1.head().toString());
     }
 
-
     @Test
     void testParseHead(){
         String html = "<!DOCTYPE html>\n" +

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1424,4 +1424,22 @@ public class HtmlParserTest {
         int xmlElementCount = xml.getAllElements().size();
         return htmlElementCount > xmlElementCount;
     }
+
+    @Test
+    void testParseUrl() throws IOException {
+        String url = "https://www2.deloitte.com/us/en/insights/industry/power-and-utilities/future-of-energy-us-energy-transition.html";
+        Document doc1 = Jsoup.parse(url);
+        assertNotEquals("<head><\\head>",doc1.head());
+    }
+
+
+    @Test
+    void testParseHead(){
+        String html = "<!DOCTYPE html>\n" +
+                "<html><head><style type=\"text/css\"></style></head><body>\n" +
+                "<div class=\"c1\"><token type=\"underline\" color=\"any\">\n" +
+                "</body></html>";
+        assertEquals("<head>\n <style type=\"text/css\"></style>\n</head>", Jsoup.parse(html).head().toString());
+    }
+
 }


### PR DESCRIPTION
Issue#1490 was because a url is passed while Jsoup.parse(String html) only accepts html. Created a check for wrongly passing url into jsoup.parse() where an html should be passed. If it is detected as url then handle it as url. Increased robustness.