### PR TITLE
implement method replaceAll, instead of hiding non supported operations

### DIFF
--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -16,6 +16,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.ConcurrentModificationException;
+import java.util.function.UnaryOperator;
 
 /**
  A list of {@link Element}s, with methods that act on every element in the list.
@@ -681,6 +684,28 @@ public class Elements extends ArrayList<Element> {
             }
         }
         return nodes;
+    }
+    
+    /**
+     * Implement a method to replace tag. The idea comes from Arraylist.replaceAll()
+     * @param operator a lambda to do the replacement
+     * @see ArrayList#replaceAll(UnaryOperator) 
+     */
+    public void replaceAll(UnaryOperator<Element> operator) {
+        Objects.requireNonNull(operator);
+        final int expectedModCount = modCount;
+        final int size = this.size();
+
+        for(int i = 0; this.modCount == expectedModCount && i < size; i++)
+        {
+            Element element = this.get(i);
+            Element replacer = operator.apply(element);
+            element.replaceWith(replacer);
+        }
+        if (modCount != expectedModCount) {
+            throw new ConcurrentModificationException();
+        }
+        modCount++;
     }
 
 }

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -14,6 +14,116 @@ import static org.junit.jupiter.api.Assertions.*;
 
  @author Jonathan Hedley, jonathan@hedley.net */
 public class ElementsTest {
+
+    @Test public void replaceAlltest01() {
+        String html =
+                "<html>" +
+                        "<head>" +
+                        "<meta content=\"text/html\">" +
+                        "<meta name=\"theme-color\">" +
+                        "</head>" +
+                        "<body>" +
+                        "<h1>a head</h1>" +
+                        "<p>a paragraph。</p>" +
+                        "</body>" +
+                        "</html>";
+        Document document = Jsoup.parse(html);
+        document.select("meta").replaceAll(element ->
+        {
+            return new Element("miao");
+        });
+        String expected =
+                "<html>\n" +
+                        " <head>\n" +
+                        "  <miao></miao><miao></miao>\n" +
+                        " </head>\n" +
+                        " <body>\n" +
+                        "  <h1>a head</h1>\n" +
+                        "  <p>a paragraph。</p>\n" +
+                        " </body>\n" +
+                        "</html>";
+        String given = document.toString();
+        assertEquals(expected, given);
+
+    }
+
+    @Test public void replaceAlltest02() {
+        String html =
+                "<html>" +
+                        "<head>" +
+                        "<meta content=\"text/html\">" +
+                        "<meta name=\"theme-color\">" +
+                        "</head>" +
+                        "<body>" +
+                        "<h1>a head</h1>" +
+                        "<p>a paragraph。</p>" +
+                        "</body>" +
+                        "</html>";
+        Document document = Jsoup.parse(html);
+        document.select("head").replaceAll(element ->
+        {
+            return new Element("miao");
+        });
+        String expected =
+                "<html>\n" +
+                        " <miao></miao>\n" +
+                        " <body>\n" +
+                        "  <h1>a head</h1>\n" +
+                        "  <p>a paragraph。</p>\n" +
+                        " </body>\n" +
+                        "</html>";
+        String given = document.toString();
+        assertEquals(expected, given);
+    }
+
+    @Test public void replaceAlltest03() {
+        String html =
+                "<html>" +
+                        "<head>" +
+                        "<meta content=\"text/html\">" +
+                        "<meta name=\"theme-color\">" +
+                        "</head>" +
+                        "<body>" +
+                        "<h1>a head</h1>" +
+                        "<p>a paragraph。</p>" +
+                        "</body>" +
+                        "</html>";
+        Document document = Jsoup.parse(html);
+        document.select("body").replaceAll(element ->
+        {
+            return new Element("miao");
+        });
+        String expected =
+                "<html>\n" +
+                        " <head>\n" +
+                        "  <meta content=\"text/html\">\n" +
+                        "  <meta name=\"theme-color\">\n" +
+                        " </head><miao></miao>\n" +
+                        "</html>";
+        String given = document.toString();
+        assertEquals(expected, given);
+    }
+
+    @Test public void replaceAlltest04() {
+        String html =
+                "<html>" +
+                        "<head>" +
+                        "<meta content=\"text/html\">" +
+                        "<meta name=\"theme-color\">" +
+                        "</head>" +
+                        "<body>" +
+                        "<h1>a head</h1>" +
+                        "<p>a paragraph。</p>" +
+                        "</body>" +
+                        "</html>";
+        Document document = Jsoup.parse(html);
+        document.select("html").replaceAll(element ->
+        {
+            return new Element("miao");
+        });
+        String expected = "<miao></miao>";
+        assertEquals(expected, document.toString());
+    }
     @Test public void filter() {
         String h = "<p>Excl</p><div class=headline><p>Hello</p><p>There</p></div><div class=headline><h1>Headline</h1></div>";
         Document doc = Jsoup.parse(h);

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -18,15 +18,15 @@ public class ElementsTest {
     @Test public void replaceAlltest01() {
         String html =
                 "<html>" +
-                        "<head>" +
-                        "<meta content=\"text/html\">" +
-                        "<meta name=\"theme-color\">" +
-                        "</head>" +
-                        "<body>" +
-                        "<h1>a head</h1>" +
-                        "<p>a paragraph。</p>" +
-                        "</body>" +
-                        "</html>";
+                "<head>" +
+                "<meta content=\"text/html\">" +
+                "<meta name=\"theme-color\">" +
+                "</head>" +
+                "<body>" +
+                "<h1>a head</h1>" +
+                "<p>a paragraph。</p>" +
+                "</body>" +
+                "</html>";
         Document document = Jsoup.parse(html);
         document.select("meta").replaceAll(element ->
         {
@@ -34,14 +34,14 @@ public class ElementsTest {
         });
         String expected =
                 "<html>\n" +
-                        " <head>\n" +
-                        "  <miao></miao><miao></miao>\n" +
-                        " </head>\n" +
-                        " <body>\n" +
-                        "  <h1>a head</h1>\n" +
-                        "  <p>a paragraph。</p>\n" +
-                        " </body>\n" +
-                        "</html>";
+                " <head>\n" +
+                "  <miao></miao><miao></miao>\n" +
+                " </head>\n" +
+                " <body>\n" +
+                "  <h1>a head</h1>\n" +
+                "  <p>a paragraph。</p>\n" +
+                " </body>\n" +
+                "</html>";
         String given = document.toString();
         assertEquals(expected, given);
 
@@ -50,15 +50,15 @@ public class ElementsTest {
     @Test public void replaceAlltest02() {
         String html =
                 "<html>" +
-                        "<head>" +
-                        "<meta content=\"text/html\">" +
-                        "<meta name=\"theme-color\">" +
-                        "</head>" +
-                        "<body>" +
-                        "<h1>a head</h1>" +
-                        "<p>a paragraph。</p>" +
-                        "</body>" +
-                        "</html>";
+                "<head>" +
+                "<meta content=\"text/html\">" +
+                "<meta name=\"theme-color\">" +
+                "</head>" +
+                "<body>" +
+                "<h1>a head</h1>" +
+                "<p>a paragraph。</p>" +
+                "</body>" +
+                "</html>";
         Document document = Jsoup.parse(html);
         document.select("head").replaceAll(element ->
         {
@@ -66,12 +66,12 @@ public class ElementsTest {
         });
         String expected =
                 "<html>\n" +
-                        " <miao></miao>\n" +
-                        " <body>\n" +
-                        "  <h1>a head</h1>\n" +
-                        "  <p>a paragraph。</p>\n" +
-                        " </body>\n" +
-                        "</html>";
+                " <miao></miao>\n" +
+                " <body>\n" +
+                "  <h1>a head</h1>\n" +
+                "  <p>a paragraph。</p>\n" +
+                " </body>\n" +
+                "</html>";
         String given = document.toString();
         assertEquals(expected, given);
     }
@@ -79,15 +79,15 @@ public class ElementsTest {
     @Test public void replaceAlltest03() {
         String html =
                 "<html>" +
-                        "<head>" +
-                        "<meta content=\"text/html\">" +
-                        "<meta name=\"theme-color\">" +
-                        "</head>" +
-                        "<body>" +
-                        "<h1>a head</h1>" +
-                        "<p>a paragraph。</p>" +
-                        "</body>" +
-                        "</html>";
+                "<head>" +
+                "<meta content=\"text/html\">" +
+                "<meta name=\"theme-color\">" +
+                "</head>" +
+                "<body>" +
+                "<h1>a head</h1>" +
+                "<p>a paragraph。</p>" +
+                "</body>" +
+                "</html>";
         Document document = Jsoup.parse(html);
         document.select("body").replaceAll(element ->
         {
@@ -95,11 +95,11 @@ public class ElementsTest {
         });
         String expected =
                 "<html>\n" +
-                        " <head>\n" +
-                        "  <meta content=\"text/html\">\n" +
-                        "  <meta name=\"theme-color\">\n" +
-                        " </head><miao></miao>\n" +
-                        "</html>";
+                " <head>\n" +
+                "  <meta content=\"text/html\">\n" +
+                "  <meta name=\"theme-color\">\n" +
+                " </head><miao></miao>\n" +
+                "</html>";
         String given = document.toString();
         assertEquals(expected, given);
     }
@@ -107,15 +107,15 @@ public class ElementsTest {
     @Test public void replaceAlltest04() {
         String html =
                 "<html>" +
-                        "<head>" +
-                        "<meta content=\"text/html\">" +
-                        "<meta name=\"theme-color\">" +
-                        "</head>" +
-                        "<body>" +
-                        "<h1>a head</h1>" +
-                        "<p>a paragraph。</p>" +
-                        "</body>" +
-                        "</html>";
+                "<head>" +
+                "<meta content=\"text/html\">" +
+                "<meta name=\"theme-color\">" +
+                "</head>" +
+                "<body>" +
+                "<h1>a head</h1>" +
+                "<p>a paragraph。</p>" +
+                "</body>" +
+                "</html>";
         Document document = Jsoup.parse(html);
         document.select("html").replaceAll(element ->
         {

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -3,6 +3,7 @@ package org.jsoup.select;
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
 import org.jsoup.nodes.*;
+import org.jsoup.parser.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -14,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
  @author Jonathan Hedley, jonathan@hedley.net */
 public class ElementsTest {
-
     @Test public void replaceAlltest01() {
         String html =
                 "<html>" +
@@ -30,20 +30,19 @@ public class ElementsTest {
         Document document = Jsoup.parse(html);
         document.select("meta").replaceAll(element ->
         {
-            return new Element("miao");
+            return new Element("foo");
         });
         String expected =
                 "<html>\n" +
                 " <head>\n" +
-                "  <miao></miao><miao></miao>\n" +
+                "  <foo></foo><foo></foo>\n" +
                 " </head>\n" +
                 " <body>\n" +
                 "  <h1>a head</h1>\n" +
                 "  <p>a paragraph。</p>\n" +
                 " </body>\n" +
                 "</html>";
-        String given = document.toString();
-        assertEquals(expected, given);
+        assertEquals(expected, document.toString());
 
     }
 
@@ -62,18 +61,17 @@ public class ElementsTest {
         Document document = Jsoup.parse(html);
         document.select("head").replaceAll(element ->
         {
-            return new Element("miao");
+            return new Element("foo");
         });
         String expected =
                 "<html>\n" +
-                " <miao></miao>\n" +
+                " <foo></foo>\n" +
                 " <body>\n" +
                 "  <h1>a head</h1>\n" +
                 "  <p>a paragraph。</p>\n" +
                 " </body>\n" +
                 "</html>";
-        String given = document.toString();
-        assertEquals(expected, given);
+        assertEquals(expected, document.toString());
     }
 
     @Test public void replaceAlltest03() {
@@ -91,17 +89,16 @@ public class ElementsTest {
         Document document = Jsoup.parse(html);
         document.select("body").replaceAll(element ->
         {
-            return new Element("miao");
+            return new Element("foo");
         });
         String expected =
                 "<html>\n" +
                 " <head>\n" +
                 "  <meta content=\"text/html\">\n" +
                 "  <meta name=\"theme-color\">\n" +
-                " </head><miao></miao>\n" +
+                " </head><foo></foo>\n" +
                 "</html>";
-        String given = document.toString();
-        assertEquals(expected, given);
+        assertEquals(expected, document.toString());
     }
 
     @Test public void replaceAlltest04() {
@@ -119,11 +116,36 @@ public class ElementsTest {
         Document document = Jsoup.parse(html);
         document.select("html").replaceAll(element ->
         {
-            return new Element("miao");
+            return new Element("foo");
         });
-        String expected = "<miao></miao>";
+        String expected = "<foo></foo>";
         assertEquals(expected, document.toString());
     }
+
+    @Test public void replaceAlltest05() {
+        String html =
+            "<html>" +
+            "<head>" +
+            "<meta content=\"text/html\">" +
+            "<meta name=\"theme-color\">" +
+            "</head>" +
+            "<body>" +
+            "<h1>a head</h1>" +
+            "<p>a paragraph。</p>" +
+            "</body>" +
+            "</html>";
+        Document document = Jsoup.parse(html);
+        document.select("html").replaceAll(element ->
+        {
+            Attributes miao = new Attributes();
+            miao.add("attribute","value");
+            return new Element(Tag.valueOf("foo"), "", miao);
+        });
+        String expected = "<foo attribute=\"value\"></foo>";
+        System.out.println(document.toString());
+        assertEquals(expected, document.toString());
+    }
+
     @Test public void filter() {
         String h = "<p>Excl</p><div class=headline><p>Hello</p><p>There</p></div><div class=headline><h1>Headline</h1></div>";
         Document doc = Jsoup.parse(h);


### PR DESCRIPTION
  #1514 When users want to replace all tags with other tags, they may use replaceAll(). But this will not work at all because the original method replaceAll() is inherited from `ArrayList` on `Elements`. To solve this issue, both implementing the method replaceAll() and hiding non-supported operations work. By using for loop and lambda, replaceAll() is implemented. 