### PR TITLE
Fix issue#1446

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -410,7 +410,7 @@ public class Element extends Node {
      * </ul>
      * <p>See the query syntax documentation in {@link org.jsoup.select.Selector}.</p>
      * <p>Also known as {@code querySelectorAll()} in the Web DOM.</p>
-     * 
+     *
      * @param cssQuery a {@link Selector} CSS-like query
      * @return an {@link Elements} list containing elements that match the query (empty if none match)
      * @see Selector selector query syntax
@@ -418,7 +418,30 @@ public class Element extends Node {
      * @throws Selector.SelectorParseException (unchecked) on an invalid CSS query.
      */
     public Elements select(String cssQuery) {
-        return Selector.select(cssQuery, this);
+        return select(cssQuery, false);
+    }
+
+    /**
+     * Find elements that match the {@link Selector} CSS query, with this element as the starting context. Matched elements
+     * may include this element, or any of its children.
+     * <p>This method is generally more powerful to use than the DOM-type {@code getElementBy*} methods, because
+     * multiple filters can be combined, e.g.:</p>
+     * <ul>
+     * <li>{@code el.select("a[href]")} - finds links ({@code a} tags with {@code href} attributes)
+     * <li>{@code el.select("a[href*=example.com]")} - finds links pointing to example.com (loosely)
+     * </ul>
+     * <p>See the query syntax documentation in {@link org.jsoup.select.Selector}.</p>
+     * <p>Also known as {@code querySelectorAll()} in the Web DOM.</p>
+     *
+     * @param cssQuery a {@link Selector} CSS-like query
+     * @param caseSensitiveFlag select case-sensitively if true
+     * @return an {@link Elements} list containing elements that match the query (empty if none match)
+     * @see Selector selector query syntax
+     * @see QueryParser#parse(String)
+     * @throws Selector.SelectorParseException (unchecked) on an invalid CSS query.
+     */
+    public Elements select(String cssQuery, boolean caseSensitiveFlag) {
+        return Selector.select(cssQuery, this, caseSensitiveFlag);
     }
 
     /**
@@ -1436,6 +1459,17 @@ public class Element extends Node {
      */
     // performance sensitive
     public boolean hasClass(String className) {
+        return hasClass(className, false);
+    }
+
+    /**
+     * Tests if this element has a class. Case insensitive.
+     * @param className name of class to check for
+     * @param caseSensitiveFlag select case-sensitively if true
+     * @return true if it does, false if not
+     */
+    // performance sensitive
+    public boolean hasClass(String className, boolean caseSensitiveFlag) {
         if (attributes == null)
             return false;
 
@@ -1449,6 +1483,9 @@ public class Element extends Node {
 
         // if both lengths are equal, only need compare the className with the attribute
         if (len == wantLen) {
+            if (caseSensitiveFlag) {
+                return className.equals(classAttr);
+            }
             return className.equalsIgnoreCase(classAttr);
         }
 

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -410,7 +410,7 @@ public class Element extends Node {
      * </ul>
      * <p>See the query syntax documentation in {@link org.jsoup.select.Selector}.</p>
      * <p>Also known as {@code querySelectorAll()} in the Web DOM.</p>
-     *
+     * 
      * @param cssQuery a {@link Selector} CSS-like query
      * @return an {@link Elements} list containing elements that match the query (empty if none match)
      * @see Selector selector query syntax

--- a/src/main/java/org/jsoup/select/Evaluator.java
+++ b/src/main/java/org/jsoup/select/Evaluator.java
@@ -105,14 +105,20 @@ public abstract class Evaluator {
      */
     public static final class Class extends Evaluator {
         private final String className;
+        private boolean caseSensitiveFlag;
 
         public Class(String className) {
             this.className = className;
         }
 
+        public Class(String className, boolean caseSensitive) {
+            this(className);
+            this.caseSensitiveFlag = caseSensitive;
+        }
+
         @Override
         public boolean matches(Element root, Element element) {
-            return (element.hasClass(className));
+            return (element.hasClass(className, caseSensitiveFlag));
         }
 
         @Override

--- a/src/main/java/org/jsoup/select/QueryParser.java
+++ b/src/main/java/org/jsoup/select/QueryParser.java
@@ -18,6 +18,7 @@ public class QueryParser {
     private final static String[] combinators = {",", ">", "+", "~", " "};
     private static final String[] AttributeEvals = new String[]{"=", "!=", "^=", "$=", "*=", "~="};
 
+    private boolean caseSensitiveFlag;
     private final TokenQueue tq;
     private final String query;
     private final List<Evaluator> evals = new ArrayList<>();
@@ -34,14 +35,35 @@ public class QueryParser {
     }
 
     /**
+     * Create a new QueryParser.
+     * @param query CSS query
+     * @param caseSensitiveFlag select case-sensitively if true
+     */
+    private QueryParser(String query, boolean caseSensitiveFlag) {
+        this(query);
+        this.caseSensitiveFlag = caseSensitiveFlag;
+    }
+
+    /**
      * Parse a CSS query into an Evaluator.
      * @param query CSS query
      * @return Evaluator
      * @see Selector selector query syntax
      */
     public static Evaluator parse(String query) {
+        return parse(query, false);
+    }
+
+    /**
+     * Parse a CSS query into an Evaluator.
+     * @param query CSS query
+     * @param caseSensitiveFlag select case-sensitively if true
+     * @return Evaluator
+     * @see Selector selector query syntax
+     */
+    public static Evaluator parse(String query, boolean caseSensitiveFlag) {
         try {
-            QueryParser p = new QueryParser(query);
+            QueryParser p = new QueryParser(query, caseSensitiveFlag);
             return p.parse();
         } catch (IllegalArgumentException e) {
             throw new Selector.SelectorParseException(e.getMessage());
@@ -225,7 +247,7 @@ public class QueryParser {
     private void byClass() {
         String className = tq.consumeCssIdentifier();
         Validate.notEmpty(className);
-        evals.add(new Evaluator.Class(className.trim()));
+        evals.add(new Evaluator.Class(className.trim(), this.caseSensitiveFlag));
     }
 
     private void byTag() {

--- a/src/main/java/org/jsoup/select/QueryParser.java
+++ b/src/main/java/org/jsoup/select/QueryParser.java
@@ -169,7 +169,10 @@ public class QueryParser {
             else if (tq.matches("["))
                 sq.append("[").append(tq.chompBalanced('[', ']')).append("]");
             else if (tq.matchesAny(combinators))
-                break;
+                if (sq.length() > 0)
+                    break;
+                else
+                    tq.consume();
             else
                 sq.append(tq.consume());
         }

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -89,8 +89,21 @@ public class Selector {
      * @throws Selector.SelectorParseException (unchecked) on an invalid CSS query.
      */
     public static Elements select(String query, Element root) {
+        return select(query, root, false);
+    }
+
+    /**
+     * Find elements matching selector.
+     *
+     * @param query CSS selector
+     * @param root  root element to descend into
+     * @param caseSensitiveFlag select case-sensitively if true
+     * @return matching elements, empty if none
+     * @throws Selector.SelectorParseException (unchecked) on an invalid CSS query.
+     */
+    public static Elements select(String query, Element root, boolean caseSensitiveFlag) {
         Validate.notEmpty(query);
-        return select(QueryParser.parse(query), root);
+        return select(QueryParser.parse(query, caseSensitiveFlag), root);
     }
 
     /**

--- a/src/test/java/org/jsoup/select/CssTest.java
+++ b/src/test/java/org/jsoup/select/CssTest.java
@@ -19,6 +19,13 @@ public class CssTest {
 	public static void initClass() {
 		StringBuilder sb = new StringBuilder("<html><head></head><body>");
 
+		sb.append("<div class=\"c1\">" +
+				"Some text\n" +
+				"</div>\n" +
+				"<div class=\"C1\">\n" +
+				"Some other text\n" +
+				"</div>");
+
 		sb.append("<div id='pseudo'>");
 		for (int i = 1; i <= 10; i++) {
 			sb.append(String.format("<p>%d</p>",i));
@@ -48,6 +55,16 @@ public class CssTest {
 	@BeforeEach
 	public void init() {
 		html  = Jsoup.parse(htmlString);
+	}
+
+	@Test
+	public void caseSensitive() {
+		assertEquals("Some text" , Jsoup.parse(htmlString).select(".c1", true).text());
+	}
+
+	@Test
+	public void caseInsensitive(){
+		assertEquals("Some text Some other text", Jsoup.parse(htmlString).select(".c1").text());
 	}
 
 	@Test

--- a/src/test/java/org/jsoup/select/CssTest.java
+++ b/src/test/java/org/jsoup/select/CssTest.java
@@ -59,12 +59,12 @@ public class CssTest {
 
 	@Test
 	public void caseSensitive() {
-		assertEquals("Some text" , Jsoup.parse(htmlString).select(".c1", true).text());
+		assertEquals("Some text" , html.select(".c1", true).text());
 	}
 
 	@Test
 	public void caseInsensitive(){
-		assertEquals("Some text Some other text", Jsoup.parse(htmlString).select(".c1").text());
+		assertEquals("Some text Some other text", html.select(".c1").text());
 	}
 
 	@Test

--- a/src/test/java/org/jsoup/select/QueryParserTest.java
+++ b/src/test/java/org/jsoup/select/QueryParserTest.java
@@ -1,5 +1,7 @@
 package org.jsoup.select;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -10,6 +12,19 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Jonathan Hedley
  */
 public class QueryParserTest {
+
+    @Test public void testConsumeSubQuery() {
+        Document doc = Jsoup.parse("<html><head>h</head><body>" +
+                "<li><strong>l1</strong></li>" +
+                "<a><li><strong>l2</strong></li></a>" +
+                "<p><strong>yes</strong></p>" +
+                "</body></html>");
+        assertEquals("l1 l2 yes", doc.body().select(">p>strong,>*>li>strong").text());
+        assertEquals("l2 yes", doc.select("body>p>strong,body>*>li>strong").text());
+        assertEquals("yes", doc.select(">body>*>li>strong,>body>p>strong").text());
+        assertEquals("l2", doc.select(">body>p>strong,>body>*>li>strong").text());
+    }
+
     @Test public void testOrGetsCorrectPrecedence() {
         // tests that a selector "a b, c d, e f" evals to (a AND b) OR (c AND d) OR (e AND f)"
         // top level or, three child ands


### PR DESCRIPTION
Fix issue#1446. HTML class names are case-sensitive, while our CSS selectors are case-insensitive. So I added a boolean variable to make the selection for Class can be customized by the user whether caseSensitive. This function is currently only for Class objects, if needed I can also add this option for other objects. I am a student taking a software engineering course and trying to fix Jsoup issues is part of my homework. My code may not be well written, thank you for your understanding, and welcome for any suggestions.