### PR TITLE
Empty attribute name produces invalid XML output with using xmlParser

### DIFF
--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -596,6 +596,7 @@ enum TokeniserState {
                 case '=':
                     t.error(this);
                     t.tagPending.newAttribute();
+                    t.tagPending.setIllegalAttributeName();
                     t.tagPending.appendAttributeName(c);
                     t.transition(AttributeName);
                     break;

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -85,7 +85,9 @@ public class XmlTreeBuilder extends TreeBuilder {
         // todo: wonder if for xml parsing, should treat all tags as unknown? because it's not html.
         if (startTag.hasAttributes())
             startTag.attributes.deduplicate(settings);
-
+        if (!startTag.checkValid()) {
+            startTag.attributes.remove(startTag.getIllegalPendingAttributeName());
+        }
         Element el = new Element(tag, null, settings.normalizeAttributes(startTag.attributes));
         insertNode(el);
         if (startTag.isSelfClosing()) {
@@ -128,6 +130,12 @@ public class XmlTreeBuilder extends TreeBuilder {
      * @param endTag tag to close
      */
     private void popStackToClose(Token.EndTag endTag) {
+
+        //Judge whether the attribute people are legal
+        if (!endTag.checkValid()) {
+            endTag.attributes.remove(endTag.getIllegalPendingAttributeName());
+        }
+
         String elName = settings.normalizeTag(endTag.tagName);
         Element firstFound = null;
 

--- a/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
@@ -261,5 +261,18 @@ public class XmlTreeBuilderTest {
         assertNull(treeBuilder.reader);
         assertNull(treeBuilder.tokeniser);
     }
-
+    @Test
+    public void beforeAttributeNameIllegalValue(){
+        String html = "<div =\"\">";
+        Document doc = Jsoup.parse(html,"",Parser.xmlParser());
+        String xml = doc.toString();
+        assertEquals("<div></div>", xml);
+    }
+    @Test
+    public void secondAttributeNameIllegalValue(){
+        String ht = "<div someattribute=\"somevalue\"=\"\"></div>";
+        Document doc = Jsoup.parse(ht,"",Parser.xmlParser());
+        String xml = doc.toString();
+        assertEquals("<div someattribute=\"somevalue\"></div>", xml);
+    }
 }


### PR DESCRIPTION
Fix issue #1474
In my opinion, since the value of attribute name is empty, this result of parsing seem more reasonable

```
     <div></div>
```
Added two new variables hasIllegalAttributeName and illegalPendingAttributeName used to record the current key values are reasonable and while building the XML dom tree the illegal key value will change to empty