### PR TITLE
Support for match with quoted pattern

### DIFF
--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -264,6 +264,7 @@ public class TokenQueue {
         char last = 0;
         boolean inSingleQuote = false;
         boolean inDoubleQuote = false;
+        boolean inEQ = false;
 
         do {
             if (isEmpty()) break;
@@ -273,8 +274,10 @@ public class TokenQueue {
                     inSingleQuote = !inSingleQuote;
                 else if (c == '"' && c != open && !inSingleQuote)
                     inDoubleQuote = !inDoubleQuote;
-                if (inSingleQuote || inDoubleQuote)
+                if (inSingleQuote || inDoubleQuote || inEQ){
+                    last = c;
                     continue;
+                }
 
                 if (c == open) {
                     depth++;
@@ -283,6 +286,10 @@ public class TokenQueue {
                 }
                 else if (c == close)
                     depth--;
+            } else if (c == 'Q') {
+                inEQ = true;
+            } else if (c == 'E') {
+                inEQ = false;
             }
 
             if (depth > 0 && last != 0)

--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -264,7 +264,7 @@ public class TokenQueue {
         char last = 0;
         boolean inSingleQuote = false;
         boolean inDoubleQuote = false;
-        boolean inEQ = false;
+        boolean inRegexQE = false; // regex \Q .. \E escapes from Pattern.quote()
 
         do {
             if (isEmpty()) break;
@@ -274,7 +274,7 @@ public class TokenQueue {
                     inSingleQuote = !inSingleQuote;
                 else if (c == '"' && c != open && !inSingleQuote)
                     inDoubleQuote = !inDoubleQuote;
-                if (inSingleQuote || inDoubleQuote || inEQ){
+                if (inSingleQuote || inDoubleQuote || inRegexQE){
                     last = c;
                     continue;
                 }
@@ -287,9 +287,9 @@ public class TokenQueue {
                 else if (c == close)
                     depth--;
             } else if (c == 'Q') {
-                inEQ = true;
+                inRegexQE = true;
             } else if (c == 'E') {
-                inEQ = false;
+                inRegexQE = false;
             }
 
             if (depth > 0 && last != 0)

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -73,6 +73,8 @@ import java.util.IdentityHashMap;
  * <tr><td><code>:empty</code></td><td>elements that have no children at all</td><td></td></tr>
  * </table>
  *
+ * <p>A word on using regular expressions in these selectors: depending on the content of the regex, you will need to quote the pattern using <b><code>Pattern.quote("regex")</code></b> for it to parse correclty through both the selector parser and the regex parser. E.g. <code>String query = "div:matches(" + Pattern.quote(regex) + ");"</code>.</p>
+ *
  * @author Jonathan Hedley, jonathan@hedley.net
  * @see Element#select(String)
  */

--- a/src/test/java/org/jsoup/parser/TokenQueueTest.java
+++ b/src/test/java/org/jsoup/parser/TokenQueueTest.java
@@ -1,7 +1,10 @@
 package org.jsoup.parser;
 
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -94,5 +97,13 @@ public class TokenQueueTest {
         } catch (IllegalArgumentException expected) {
             assertEquals("Did not find balanced marker at 'something(or another)) else'", expected.getMessage());
         }
+    }
+
+    @Test
+    public void testQuotedPattern() {
+        final Document doc = Jsoup.parse("<div>\\) foo1</div><div>( foo2</div><div>1) foo3</div>");
+        assertEquals("\n\\) foo1",doc.select("div:matches(" + Pattern.quote("\\)") + ")").get(0).childNode(0).toString());
+        assertEquals("\n( foo2",doc.select("div:matches(" + Pattern.quote("(") + ")").get(0).childNode(0).toString());
+        assertEquals("\n1) foo3",doc.select("div:matches(" + Pattern.quote("1)") + ")").get(0).childNode(0).toString());
     }
 }


### PR DESCRIPTION
For `Pattern.quote()`, it turns a regex into a raw value, which if matched directly as an argument to `:match()` could cause an error like the one below mentioned in #986 due to lack of deliberate escaping.
```java
final Document doc = Jsoup.parse("<div>1) foo</div>");
System.out.println(doc.select("div:matches(" + Pattern.quote("1)") + ")"));
```
Therefore supports detection of the `\Q` and `\E` that  `Pattern.quote()` generates when parsing.