### PR TITLE
modify Element.clone() for issue #763

### DIFF
--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -393,6 +393,17 @@ public class Document extends Element {
             }
         }
     }
+
+    /**
+     * Set the document's output settings.
+     * This is used to override the function in Element, to avoid misuse.
+     * @param out new output settings.
+     */
+    @Override
+    public void setOutputSettings(Document.OutputSettings out)
+    {
+        this.outputSettings(out);
+    }
     
 
     /**

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -399,6 +399,7 @@ public class Document extends Element {
      * This is used to override the function in Element, to avoid misuse.
      * @param out new output settings.
      */
+    //CS304 Issue link: https://github.com/jhy/jsoup/issues/763
     @Override
     public void setOutputSettings(Document.OutputSettings out)
     {

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -48,6 +48,27 @@ public class Element extends Node {
     private @Nullable WeakReference<List<Element>> shadowChildrenRef; // points to child elements shadowed from node children
     List<Node> childNodes;
     private @Nullable Attributes attributes; // field is nullable but all methods for attributes are non null
+    private @Nullable Document.OutputSettings outputSettings = null;
+
+    /**
+     * Setup the output setting for this element.
+     * By default, it uses the default output setting.
+     * @param out the output setting this element will use
+     */
+    public void setOutputSettings(Document.OutputSettings out)
+    {
+        Validate.notNull(out);
+        this.outputSettings = out;
+    }
+
+    /**
+     * Return the current output setting of this element.
+     * @return the output setting of this element
+     */
+    Document.OutputSettings getOutputSettings()
+    {
+        return this.outputSettings;
+    }
 
     /**
      * Create a new, standalone element.
@@ -1623,7 +1644,13 @@ public class Element extends Node {
 
     @Override
     public Element clone() {
-        return (Element) super.clone();
+        Element clone = (Element)super.clone();
+        Document owner = this.ownerDocument();
+        if (owner != null)
+        {
+            clone.setOutputSettings(owner.outputSettings());
+        }
+        return clone;
     }
 
     @Override

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -55,6 +55,7 @@ public class Element extends Node {
      * By default, it uses the default output setting.
      * @param out the output setting this element will use
      */
+    //CS304 Issue link: https://github.com/jhy/jsoup/issues/763
     public void setOutputSettings(Document.OutputSettings out)
     {
         Validate.notNull(out);
@@ -65,6 +66,7 @@ public class Element extends Node {
      * Return the current output setting of this element.
      * @return the output setting of this element
      */
+    //CS304 Issue link: https://github.com/jhy/jsoup/issues/763
     Document.OutputSettings getOutputSettings()
     {
         return this.outputSettings;
@@ -1642,6 +1644,11 @@ public class Element extends Node {
         return this;
     }
 
+    /**
+     * After cloning, copy the document's output setting to the element
+     * @return the cloned Element
+     */
+    //CS304 Issue link: https://github.com/jhy/jsoup/issues/763
     @Override
     public Element clone() {
         Element clone = (Element)super.clone();

--- a/src/main/java/org/jsoup/nodes/NodeUtils.java
+++ b/src/main/java/org/jsoup/nodes/NodeUtils.java
@@ -3,6 +3,8 @@ package org.jsoup.nodes;
 import org.jsoup.parser.HtmlTreeBuilder;
 import org.jsoup.parser.Parser;
 
+import javax.print.Doc;
+
 /**
  * Internal helpers for Nodes, to keep the actual node APIs relatively clean. A jsoup internal class, so don't use it as
  * there is no contract API).
@@ -10,11 +12,19 @@ import org.jsoup.parser.Parser;
 final class NodeUtils {
     /**
      * Get the output setting for this node,  or if this node has no document (or parent), retrieve the default output
-     * settings
+     * settings, or if this node is an instance of Element, check if there is a designated output setting
      */
     static Document.OutputSettings outputSettings(Node node) {
         Document owner = node.ownerDocument();
-        return owner != null ? owner.outputSettings() : (new Document("")).outputSettings();
+        if (owner == null && node instanceof Element)
+        {
+            Document.OutputSettings out = ((Element) node).getOutputSettings();
+            return out != null ? out : (new Document("")).outputSettings();
+        }
+        else
+        {
+            return owner != null ? owner.outputSettings() : (new Document("")).outputSettings();
+        }
     }
 
     /**

--- a/src/main/java/org/jsoup/nodes/NodeUtils.java
+++ b/src/main/java/org/jsoup/nodes/NodeUtils.java
@@ -14,6 +14,7 @@ final class NodeUtils {
      * Get the output setting for this node,  or if this node has no document (or parent), retrieve the default output
      * settings, or if this node is an instance of Element, check if there is a designated output setting
      */
+    //CS304 Issue link: https://github.com/jhy/jsoup/issues/763
     static Document.OutputSettings outputSettings(Node node) {
         Document owner = node.ownerDocument();
         if (owner == null && node instanceof Element)

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -2039,4 +2039,31 @@ public class ElementTest {
         els.add(new Element("a"));
         assertEquals(1, els.size());
     }
+
+    @Test void singleElementShouldHaveStandardOutputSetting()
+    {
+        Element li = new Element("li");
+        li.setOutputSettings(new Document.OutputSettings().prettyPrint(true));
+        assertEquals("<li></li>", li.outerHtml());
+    }
+
+    @Test void elementFromDocumentShouldHaveSameOutputSetting()
+    {
+        Document document = Jsoup.parse("<div> </div>");
+        document.outputSettings(new Document.OutputSettings().prettyPrint(false));
+        Element element = document.body();
+        Element clone = element.clone();
+        assertEquals(element.outerHtml(), clone.outerHtml());
+    }
+
+    @Test void elementWithParentsFromDocumentShouldHaveSameOutputSetting()
+    {
+        Document document = Jsoup.parse("<div> <div> </div> </div>" +
+                "<br> </br>");
+        document.outputSettings(new Document.OutputSettings().prettyPrint(false));
+        Element element = document.body();
+        Element clone = element.clone();
+        assertEquals(element.outerHtml(), clone.outerHtml());
+    }
+
 }

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -2040,6 +2040,8 @@ public class ElementTest {
         assertEquals(1, els.size());
     }
 
+    // CS304 (manually written) Issue link:
+    // CS304 Issue link: https://github.com/jhy/jsoup/issues/763
     @Test void singleElementShouldHaveStandardOutputSetting()
     {
         Element li = new Element("li");
@@ -2047,6 +2049,8 @@ public class ElementTest {
         assertEquals("<li></li>", li.outerHtml());
     }
 
+    // CS304 (manually written) Issue link:
+    // CS304 Issue link: https://github.com/jhy/jsoup/issues/763
     @Test void elementFromDocumentShouldHaveSameOutputSetting()
     {
         Document document = Jsoup.parse("<div> </div>");
@@ -2056,6 +2060,8 @@ public class ElementTest {
         assertEquals(element.outerHtml(), clone.outerHtml());
     }
 
+    // CS304 (manually written) Issue link:
+    // CS304 Issue link: https://github.com/jhy/jsoup/issues/763
     @Test void elementWithParentsFromDocumentShouldHaveSameOutputSetting()
     {
         Document document = Jsoup.parse("<div> <div> </div> </div>" +


### PR DESCRIPTION
**Summary**
I add a private instance <code>Document.OutputSettings</code> to record what output setting this element itself should follow. Also, I modify <code>NodeUtils.outputSettings</code>, which obtains the output setting of the node. It checks whether the node is element or not. If it is element, than check if it has an ownerDocument. If it does not have an ownerDocument, it will use the element's output setting. Or it will still follow the ownerDocument's output setting.