### PR TITLE
Support different whitespace characters

### DIFF
--- a/src/main/java/org/jsoup/parser/CharacterReader.java
+++ b/src/main/java/org/jsoup/parser/CharacterReader.java
@@ -377,6 +377,8 @@ public final class CharacterReader {
                 case '/':
                 case '>':
                 case '<':
+                case '\u00A0':
+                case '\u3000':
                 case TokeniserState.nullChar:
                     break OUTER;
             }

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -150,6 +150,8 @@ enum TokeniserState {
 
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -223,6 +225,8 @@ enum TokeniserState {
 
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -564,6 +568,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -614,6 +620,8 @@ enum TokeniserState {
 
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -654,6 +662,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -699,6 +709,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -818,6 +830,8 @@ enum TokeniserState {
 
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -863,6 +877,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1109,6 +1125,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1141,6 +1159,8 @@ enum TokeniserState {
             }
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1180,6 +1200,8 @@ enum TokeniserState {
                     t.emitDoctypePending();
                     t.transition(Data);
                     break;
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1234,6 +1256,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1274,6 +1298,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1367,6 +1393,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1405,6 +1433,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1442,6 +1472,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1482,6 +1514,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1575,6 +1609,8 @@ enum TokeniserState {
         void read(Tokeniser t, CharacterReader r) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1655,6 +1691,8 @@ enum TokeniserState {
         if (t.isAppropriateEndTagToken() && !r.isEmpty()) {
             char c = r.consume();
             switch (c) {
+                case '\u00A0':
+                case '\u3000':
                 case '\t':
                 case '\n':
                 case '\r':
@@ -1733,6 +1771,8 @@ enum TokeniserState {
 
         char c = r.consume();
         switch (c) {
+            case '\u00A0':
+            case '\u3000':
             case '\t':
             case '\n':
             case '\r':

--- a/src/test/java/org/jsoup/parser/CharacterReaderTest.java
+++ b/src/test/java/org/jsoup/parser/CharacterReaderTest.java
@@ -1,5 +1,7 @@
 package org.jsoup.parser;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -336,4 +338,24 @@ public class CharacterReaderTest {
         assertTrue(r.isEmpty());
     }
 
+    @Test
+    public void spaceType1(){
+        String html = "<a\u00A0href=\"http://example.com/test\">test</a>";
+        Document doc = Jsoup.parse(html);
+        assertEquals("<a href=\"http://example.com/test\">test</a>", doc.childNode(0).childNode(1).childNode(0).toString());
+    }
+
+    @Test
+    public void spaceType2(){
+        String html = "<a\u0020href=\"http://example.com/test\">test</a>";
+        Document doc = Jsoup.parse(html);
+        assertEquals("<a href=\"http://example.com/test\">test</a>", doc.childNode(0).childNode(1).childNode(0).toString());
+    }
+
+    @Test
+    public void spaceType3(){
+        String html = "<a\u3000href=\"http://example.com/test\">test</a>";
+        Document doc = Jsoup.parse(html);
+        assertEquals("<a href=\"http://example.com/test\">test</a>", doc.childNode(0).childNode(1).childNode(0).toString());
+    }
 }


### PR DESCRIPTION
#1550 Improve the parser. It can detect three kinds of types of space in Unicode (i.e., \u00A0, \u0020, \u3000) now.