### PR TITLE
merging HEAD into BODY while use white list

### DIFF
--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -227,7 +227,7 @@ Connection con3 = session.newRequest();
      @see Cleaner#clean(Document)
      */
     public static String clean(String bodyHtml, String baseUri, Safelist safelist) {
-        Document dirty = parseBodyFragment(bodyHtml, baseUri);
+        Document dirty = parse(bodyHtml, baseUri);
         Cleaner cleaner = new Cleaner(safelist);
         Document clean = cleaner.clean(dirty);
         return clean.body().html();

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -65,7 +65,15 @@ public class Cleaner {
         Validate.notNull(dirtyDocument);
 
         Document clean = Document.createShell(dirtyDocument.baseUri());
-        copySafeNodes(dirtyDocument.body(), clean.body());
+        Element head,body;
+        if(dirtyDocument.head().childNodeSize() > 0){
+            head = dirtyDocument.head();
+            copySafeNodes(head, clean.body());
+        }
+        if(dirtyDocument.body().childNodeSize() > 0){
+            body = dirtyDocument.body();
+            copySafeNodes(body, clean.body());
+        }
         clean.outputSettings(dirtyDocument.outputSettings().clone());
 
         return clean;

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -339,4 +339,17 @@ public class CleanerTest {
         assertEquals(Document.OutputSettings.Syntax.xml, result.outputSettings().syntax());
         assertEquals("<p>test<br /></p>", result.body().html());
     }
+    @Test public void NoHeadCleanerTest(){
+        Safelist whitelist = Safelist.relaxed()
+                .addTags("!DOCTYPE html", "html","body","head","meta", "style")
+                .addAttributes("meta", "charset");
+        String value = "<html><head><style>.some {color: red}</style></head><body>3<script>alert('pwned')</script>4</body></html>";
+        String doc = Jsoup.clean(value, whitelist);
+        assertEquals("<head>\n" +
+                " <style>.some {color: red}</style>\n" +
+                "</head>\n" +
+                "<body>\n" +
+                " 34\n" +
+                "</body>",doc);
+    }
 }


### PR DESCRIPTION
replace
```
Document dirty = parseBodyFragment(bodyHtml, baseUri);
```
to
```
Document dirty = parse(bodyHtml, baseUri);
```
Because that's what causes the head and body to blend together.
Then consider whether the head and body are in the white list respectively.