### PR TITLE
[fixes #1616] Make the imports of javax.annotation(.meta) optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
           <instructions>
             <Bundle-DocURL>https://jsoup.org/</Bundle-DocURL>
             <Export-Package>org.jsoup.*</Export-Package>
-            <Import-Package>javax.annotation;version=!,javax.annotation.meta;version=!,*</Import-Package>
+            <Import-Package>javax.annotation;version=!;resolution:=optional,javax.annotation.meta;version=!;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
This actually fixes the resolution fully - the javax.annotation and javax.annotation.meta should not be required as they are only used at build time. 