### PR TITLE
[fixes #1535] Changing CombiningEvaluator to public.  

### DIFF
--- a/src/main/java/org/jsoup/select/CombiningEvaluator.java
+++ b/src/main/java/org/jsoup/select/CombiningEvaluator.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 /**
  * Base combining (and, or) evaluator.
  */
-abstract class CombiningEvaluator extends Evaluator {
+public abstract class CombiningEvaluator extends Evaluator {
     final ArrayList<Evaluator> evaluators;
     int num = 0;
 
@@ -39,7 +39,7 @@ abstract class CombiningEvaluator extends Evaluator {
         num = evaluators.size();
     }
 
-    static final class And extends CombiningEvaluator {
+    public static final class And extends CombiningEvaluator {
         And(Collection<Evaluator> evaluators) {
             super(evaluators);
         }
@@ -64,7 +64,7 @@ abstract class CombiningEvaluator extends Evaluator {
         }
     }
 
-    static final class Or extends CombiningEvaluator {
+    public static final class Or extends CombiningEvaluator {
         /**
          * Create a new Or evaluator. The initial evaluators are ANDed together and used as the first clause of the OR.
          * @param evaluators initial OR clause (these are wrapped into an AND evaluator).


### PR DESCRIPTION
Evaluator class is very powerful mechanism when complex select query is not required or writing a custom predicate.
CombiningEvaluator is not public so it can't be used by clients.
Making CombiningEvaluator class and CombiningEvaluator.Or and CombiningEvaluator.And public

https://github.com/jhy/jsoup/issues/1535
