### PR TITLE
Remove the javax.annotation* OSGi package imports to finally fix #1616

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
           <instructions>
             <Bundle-DocURL>https://jsoup.org/</Bundle-DocURL>
             <Export-Package>org.jsoup.*</Export-Package>
-            <Import-Package>javax.annotation;version=!,javax.annotation.meta;version=!,*</Import-Package>
+            <Import-Package>!javax.annotation,!javax.annotation.meta,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
@jhy This PR removes both javax.annotation and javax.annotation.meta from the OSGi MANIFEST.MF Import-Packages.

This is probably a more correct fix than my first PR (and it applies on top of the current master, which includes that PR).

I've tried this in karaf now and the jsoup OSGi loads without needing the findbugs/jsr305 bundle, and is working as before for my application.

I think the only failure would be if some code tries to access the annotations at runtime (I don't know what that would be, but the annotations have retention policy runtime, after all).