### PR TITLE
Added full parser support for template tags

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@ jsoup changelog
   * Improvement: added native XPath support in Element#selectXpath(String)
     <https://github.com/jhy/jsoup/pull/1629>
 
+  * Improvement: added full support for the <template> tag to the HTML5 parser spec.
+    <https://github.com/jhy/jsoup/issues/1634>
+
   * Improvement: added support in CharacterReader to track newlines, so that parse errors can be reported more
     intuitively.
     <https://github.com/jhy/jsoup/pull/1624>

--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -237,7 +237,7 @@ public class Tag implements Cloneable {
             "ul", "ol", "pre", "div", "blockquote", "hr", "address", "figure", "figcaption", "form", "fieldset", "ins",
             "del", "dl", "dt", "dd", "li", "table", "caption", "thead", "tfoot", "tbody", "colgroup", "col", "tr", "th",
             "td", "video", "audio", "canvas", "details", "menu", "plaintext", "template", "article", "main",
-            "svg", "math", "center"
+            "svg", "math", "center", "template"
     };
     private static final String[] inlineTags = {
             "object", "base", "font", "tt", "i", "b", "u", "big", "small", "em", "strong", "dfn", "code", "samp", "kbd",

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1499,4 +1499,90 @@ public class HtmlParserTest {
         String out = doc.body().outerHtml();
         assertEquals("<body style=\"color: red\" name>\n <div></div>\n</body>", out);
     }
+
+    @Test void templateInHead() {
+        // https://try.jsoup.org/~EGp3UZxQe503TJDHQEQEzm8IeUc
+        String html = "<head><template id=1><meta name=tmpl></template><title>Test</title><style>One</style></head><body><p>Two</p>";
+        Document doc = Jsoup.parse(html);
+
+        String want = "<html><head><template id=\"1\"><meta name=\"tmpl\"></template><title>Test</title><style>One</style></head><body><p>Two</p></body></html>";
+        assertEquals(want, TextUtil.stripNewlines(doc.html()));
+
+        Elements template = doc.select("template#1");
+        template.select("meta").attr("content", "Yes");
+        template.unwrap();
+
+        want = "<html><head><meta name=\"tmpl\" content=\"Yes\"><title>Test</title><style>One</style></head><body><p>Two</p></body></html>";
+        assertEquals(want, TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test void nestedTemplateInBody() {
+        String html = "<body><template id=1><table><tr><template id=2><td>One</td><td>Two</td></template></tr></template></body>";
+        Document doc = Jsoup.parse(html);
+
+        String want = "<html><head></head><body><template id=\"1\"><table><tbody><tr><template id=\"2\"><td>One</td><td>Two</td></template></tr></tbody></table></template></body></html>";
+        assertEquals(want, TextUtil.stripNewlines(doc.html()));
+
+        // todo - will be nice to add some simpler template element handling like clone children etc?
+        Element tmplTbl = doc.selectFirst("template#1");
+        Element tmplRow = doc.selectFirst("template#2");
+        assertNotNull(tmplRow);
+        assertNotNull(tmplTbl);
+        tmplRow.appendChild(tmplRow.clone());
+        doc.select("template").unwrap();
+
+        want = "<html><head></head><body><table><tbody><tr><td>One</td><td>Two</td><td>One</td><td>Two</td></tr></tbody></table></body></html>";
+        assertEquals(want, TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test void canSelectIntoTemplate() {
+        String html = "<body><div><template><p>Hello</p>";
+        Document doc = Jsoup.parse(html);
+        String want = "<html><head></head><body><div><template><p>Hello</p></template></div></body></html>";
+        assertEquals(want, TextUtil.stripNewlines(doc.html()));
+
+        Element p = doc.selectFirst("div p");
+        Element p1 = doc.selectFirst("template :containsOwn(Hello)");
+        assertEquals("p", p.normalName());
+        assertEquals(p, p1);
+    }
+
+    @Test void tableRowFragment() {
+        Document doc = Jsoup.parse("<body><table></table></body");
+        String html = "<tr><td><img></td></tr>";
+        Element table = doc.selectFirst("table");
+        table.html(html); // invokes the fragment parser with table as context
+        String want = "<tbody><tr><td><img></td></tr></tbody>";
+        assertEquals(want, TextUtil.stripNewlines(table.html()));
+        want = "<table><tbody><tr><td><img></td></tr></tbody></table>";
+        assertEquals(want, TextUtil.stripNewlines(doc.body().html()));
+    }
+
+    @Test void templateTableRowFragment() {
+        // https://github.com/jhy/jsoup/issues/1409 (per the fragment <tr> use case)
+        Document doc = Jsoup.parse("<body><table><template></template></table></body");
+        String html = "<tr><td><img></td></tr>";
+        Element tmpl = doc.selectFirst("template");
+        tmpl.html(html); // invokes the fragment parser with template as context
+        String want = "<tr><td><img></td></tr>";
+        assertEquals(want, TextUtil.stripNewlines(tmpl.html()));
+        tmpl.unwrap();
+
+        want = "<html><head></head><body><table><tr><td><img></td></tr></table></body></html>";
+        assertEquals(want, TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test void templateNotInTableRowFragment() {
+        // https://github.com/jhy/jsoup/issues/1409 (per the fragment <tr> use case)
+        Document doc = Jsoup.parse("<body><template></template></body");
+        String html = "<tr><td><img></td></tr>";
+        Element tmpl = doc.selectFirst("template");
+        tmpl.html(html); // invokes the fragment parser with template as context
+        String want = "<tr><td><img></td></tr>";
+        assertEquals(want, TextUtil.stripNewlines(tmpl.html()));
+        tmpl.unwrap();
+
+        want = "<html><head></head><body><tr><td><img></td></tr></body></html>";
+        assertEquals(want, TextUtil.stripNewlines(doc.html()));
+    }
 }

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1585,4 +1585,12 @@ public class HtmlParserTest {
         want = "<html><head></head><body><tr><td><img></td></tr></body></html>";
         assertEquals(want, TextUtil.stripNewlines(doc.html()));
     }
+
+    @Test void templateFragment() {
+        // https://github.com/jhy/jsoup/issues/1315
+        String html = "<template id=\"lorem-ipsum\"><tr><td>Lorem</td><td>Ipsum</td></tr></template>";
+        Document frag = Jsoup.parseBodyFragment(html);
+        String want = "<template id=\"lorem-ipsum\"><tr><td>Lorem</td><td>Ipsum</td></tr></template>";
+        assertEquals(want, TextUtil.stripNewlines(frag.body().html()));
+    }
 }

--- a/src/test/java/org/jsoup/parser/HtmlTreeBuilderStateTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlTreeBuilderStateTest.java
@@ -44,7 +44,7 @@ public class HtmlTreeBuilderStateTest {
     public void ensureArraysAreSorted() {
         List<Object[]> constants = findConstantArrays(Constants.class);
         ensureSorted(constants);
-        assertEquals(38, constants.size());
+        assertEquals(40, constants.size());
     }
 
 

--- a/src/test/java/org/jsoup/parser/HtmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlTreeBuilderTest.java
@@ -18,7 +18,7 @@ public class HtmlTreeBuilderTest {
     public void ensureSearchArraysAreSorted() {
         List<Object[]> constants = HtmlTreeBuilderStateTest.findConstantArrays(HtmlTreeBuilder.class);
         HtmlTreeBuilderStateTest.ensureSorted(constants);
-        assertEquals(7, constants.size());
+        assertEquals(8, constants.size());
     }
 
     @Test


### PR DESCRIPTION
This implements the HTML5 parser spec for `<template>` tags.

Note that as jsoup is a parser and does not run scripts, and for unsurprising selector support, it does not wrap the contents of the template children in a Document fragment object. Per #1634

We could choose to add a TemplateElement class with extra functionality around cloning the children etc. Very open to suggestions here!

Fixes #1634
Fixes #1630
Fixes #1409
Fixes #1315 