### PR TITLE
Allow attributes valid in html when converting

### DIFF
--- a/src/main/java/org/jsoup/helper/W3CDom.java
+++ b/src/main/java/org/jsoup/helper/W3CDom.java
@@ -38,10 +38,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Stack;
-import java.util.regex.Pattern;
+import java.util.Locale;
 
 import static javax.xml.transform.OutputKeys.METHOD;
+import static org.jsoup.nodes.Document.OutputSettings.Syntax.html;
 import static org.jsoup.nodes.Document.OutputSettings.Syntax.xml;
+import static org.jsoup.nodes.Document.OutputSettings.Syntax;
 
 /**
  * Helper class to transform a {@link org.jsoup.nodes.Document} to a {@link org.w3c.dom.Document org.w3c.dom.Document},
@@ -342,8 +344,15 @@ public class W3CDom {
         }
 
         private void copyAttributes(org.jsoup.nodes.Node source, Element el) {
+            final Syntax syntax;
+            if (this.doc.getDoctype() != null &&
+                    this.doc.getDoctype().getName().toLowerCase(Locale.ROOT).equals("html")) {
+                syntax = html;
+            } else {
+                syntax = xml;
+            }
             for (Attribute attribute : source.attributes()) {
-                String key = Attribute.getValidKey(attribute.getKey(), xml);
+                String key = Attribute.getValidKey(attribute.getKey(), syntax);
                 if (key != null) { // null if couldn't be coerced to validity
                     el.setAttribute(key, attribute.getValue());
                 }

--- a/src/test/java/org/jsoup/helper/W3CDomTest.java
+++ b/src/test/java/org/jsoup/helper/W3CDomTest.java
@@ -191,6 +191,20 @@ public class W3CDomTest {
     }
 
     @Test
+    public void handlesAccentedCharsAttributeNames() {
+        String html = "<!DOCTYPE html><html><head></head><body style=\"color: red\" \" name\"><p hành=\"1\" hình=\"2\">unicode attr names</p></body></html>";
+        org.jsoup.nodes.Document jsoupDoc;
+        jsoupDoc = Jsoup.parse(html);
+        Element body = jsoupDoc.select("body").first();
+        assertTrue(body.hasAttr("\"")); // actually an attribute with key '"'. Correct per HTML5 spec, but w3c xml dom doesn't dig it
+        assertTrue(body.hasAttr("name\""));
+
+        Document w3Doc = W3CDom.convert(jsoupDoc);
+        String out = W3CDom.asString(w3Doc, W3CDom.OutputHtml());
+        assertEquals("<!DOCTYPE html SYSTEM \"about:legacy-compat\">\n<html><head><META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body name=\"\" style=\"color: red\"><p hành=\"1\" hình=\"2\">unicode attr names</p></body></html>", out);
+    }
+
+    @Test
     public void handlesInvalidTagAsText() {
         org.jsoup.nodes.Document jsoup = Jsoup.parse("<インセンティブで高収入！>Text <p>More</p>");
 


### PR DESCRIPTION
When parsing and converting an html document, the "syntax" was hard-coded to xml. This PR checks the document type of the output document and uses that to determine which attributes are valid.

Changes for https://github.com/jhy/jsoup/issues/1647