### PR TITLE
[alignment] Fix alignment issues so repeated processing works properly

### DIFF
--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -696,6 +696,10 @@ public abstract class Node implements Cloneable {
         return outerHtml();
     }
 
+    protected void indent(Appendable accum, int depth, Document.OutputSettings out, int lessSpace) throws IOException {
+        accum.append('\n').append(StringUtil.padding((depth * out.indentAmount()) - lessSpace, out.maxPaddingWidth()));
+    }
+
     protected void indent(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         accum.append('\n').append(StringUtil.padding(depth * out.indentAmount(), out.maxPaddingWidth()));
     }

--- a/src/main/java/org/jsoup/nodes/TextNode.java
+++ b/src/main/java/org/jsoup/nodes/TextNode.java
@@ -89,8 +89,15 @@ public class TextNode extends LeafNode {
         if (parentIndent && StringUtil.startsWithNewline(coreValue()) && blank) // we are skippable whitespace
             return;
 
-        if (prettyPrint && ((siblingIndex == 0 && parent != null && parent.tag().formatAsBlock() && !blank) || (out.outline() && siblingNodes().size()>0 && !blank) ))
-            indent(accum, depth, out);
+        if (prettyPrint && ((siblingIndex() == 0 && parent != null && parent.tag().formatAsBlock() && !blank) || (out.outline() && !siblingNodes().isEmpty() && !blank) )) {
+            String normalized = StringUtil.normaliseWhitespace(coreValue());
+            boolean startsWithSpace = normalized.startsWith(" ");
+            if (startsWithSpace) {
+                indent(accum, depth, out, 1);
+            } else {
+                indent(accum, depth, out);
+            }
+        }
 
         final boolean normaliseWhite = prettyPrint && !Element.preserveWhitespace(parentNode);
         final boolean stripWhite = prettyPrint && parentNode instanceof Document;

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -499,7 +499,7 @@ public class ElementTest {
         Document document = Jsoup.parse(html);
         document.outputSettings().outline(true);
 
-        assertEquals("<div>\n <span>1:15</span>\n –\n <span>2:15</span>\n &nbsp;p.m.\n</div>", document.body().html());
+        assertEquals("<div>\n <span>1:15</span>\n –\n <span>2:15</span>\n&nbsp;p.m.\n</div>", document.body().html());
     }
 
     @Test


### PR DESCRIPTION
Context: formatter-maven-plugin formats source code for html using jsoup with mixed results.

During first pass on formatting a file with pretty printing, if tags such as ```<div>``` with content on second line show up, jsoup currently forces that +1 in the padding which is incorrect.  If the div is inline, jsoup will correctly align it with line breaks properly on that first pass.  A secondary pass of now formatted file will result in the same behaviour with +1.  This seems to affect many elements based on file we have [here](https://github.com/revelc/formatter-maven-plugin/blob/main/src/test/resources/someFile.html)

I tried various ways to address and don't know jsoup enough to know the right way.  What seemed to work best without messing anything else up was to use the normalize on the string already present in jsoup when doing pretty printing and if that ends up with space before content as it does in this case (one at start and one at end), then do the padding with 1 less character.  Under testing this seemed to then work on the first round and every subsequent pretty print of same worked out the same way.

I even tried your website to drop the file I have above.  It does behave in same way there so this seems right but may not be the most appropriate way to resolve.  Please take a look here and let me know what you think.

One test seemed inherently wrong here too where it had a non breaking space but was being prefixed with an extra space.  To me that means it got 2 when it didn't need the extra.  While look and feel is better with that space, I wasn't quite sure how to make that look better and technically one space is all that needed so I adapted that test to match the change.