### PR TITLE
[header] Support header comments so line breaks properly

### DIFF
--- a/src/main/java/org/jsoup/nodes/Comment.java
+++ b/src/main/java/org/jsoup/nodes/Comment.java
@@ -37,12 +37,23 @@ public class Comment extends LeafNode {
     }
 
 	void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
-        if (out.prettyPrint() && ((siblingIndex() == 0 && parentNode instanceof Element && ((Element) parentNode).tag().formatAsBlock()) || (out.outline() )))
+        if (out.prettyPrint() && ((siblingIndex() == 0 && parentNode instanceof Element && ((Element) parentNode).tag().formatAsBlock()) || (out.outline() ))) {
             indent(accum, depth, out);
-        accum
+        }
+
+        // Handle Header License Comment Properly under Pretty Print
+        if (out.prettyPrint() && accum.toString().isEmpty()) {
+            accum
+                .append("<!--")
+                .append(getData())
+                .append("-->")
+                .append("\n");
+        } else {
+            accum
                 .append("<!--")
                 .append(getData())
                 .append("-->");
+        }
     }
 
 	void outerHtmlTail(Appendable accum, int depth, Document.OutputSettings out) {}

--- a/src/test/java/org/jsoup/nodes/CommentTest.java
+++ b/src/test/java/org/jsoup/nodes/CommentTest.java
@@ -21,7 +21,8 @@ public class CommentTest {
 
     @Test
     public void testToString() {
-        assertEquals("<!-- This is one heck of a comment! -->", comment.toString());
+        // Tests under toString are pretty printed with first being simulated license header (no content), respect new line
+        assertEquals("<!-- This is one heck of a comment! -->\n", comment.toString());
 
         Document doc = Jsoup.parse("<div><!-- comment--></div>");
         assertEquals("<div>\n <!-- comment-->\n</div>", doc.body().html());


### PR DESCRIPTION
context: formatter-maven-plugin

Issue: Many files come with copyright headers in the files.  The html parser for pretty printing with jsoup treats this header comment incorrectly and ends up adding the html tag at end of --> on same line.  I'm not sure the fix I have here is appropriate but it did solve the issue.

As with before you can see this with this file [here](https://github.com/revelc/formatter-maven-plugin/blob/main/src/test/resources/someFile.html).