### PR TITLE
added junit-5 extension to handle network flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,14 @@
       <version>3.0.2</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <!-- junit5 extension to sanitise tests that are flaky due to network issues. -->
+      <groupId>io.github.jensdietrich.saflate</groupId>
+      <artifactId>saflate-network-junit5</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
Intercepts network related exceptions to skip tests that can be flaky due to network errors. The extension can be applied to all tests by adding the runtime parameter `-Djunit.jupiter.extensions.autodetection.enabled=true`