### PR TITLE
Use moditect for multi-release module-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.jsoup</groupId>
   <artifactId>jsoup</artifactId>
-  <version>1.14.3</version><!-- remember to update previous version below for japicmp -->
+  <version>1.14.3-module</version><!-- remember to update previous version below for japicmp -->
   <description>jsoup is a Java library for working with real-world HTML. It provides a very convenient API for fetching URLs and extracting and manipulating data, using the best of HTML5 DOM methods and CSS selectors. jsoup implements the WHATWG HTML5 specification, and parses HTML to the same DOM as modern browsers do.</description>
   <url>https://jsoup.org/</url>
   <inceptionYear>2009</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -249,15 +249,13 @@
                     <artifactId>${project.artifactId}</artifactId>
                     <version>${project.version}</version>
                   </artifact>
-                  <moduleInfoSource>
-                    module org.jsoup {
-                      requires java.xml;
-                      exports org.jsoup;
-                    }
-                  </moduleInfoSource>
+                  <moduleInfoFile>
+                    ${project.build.sourceDirectory}/../moditect/module-info.java
+                  </moduleInfoFile>
                 </module>
               </modules>
               <jdepsExtraArgs>
+                <!-- Ignore jsr305 -->
                 <arg>--ignore-missing-deps</arg>
               </jdepsExtraArgs>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <integration.test.arguments>
+      --add-exports org.jsoup/org.jsoup.integration=ALL-UNNAMED
+      --add-exports org.jsoup/org.jsoup.integration.servlets=ALL-UNNAMED
+      --add-opens org.jsoup/org.jsoup.integration=ALL-UNNAMED
+    </integration.test.arguments>
   </properties>
 
   <build>
@@ -181,6 +186,9 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+            <configuration>
+              <argLine>${integration.test.arguments}</argLine>
+            </configuration>
           </execution>
         </executions>
         <configuration>
@@ -216,6 +224,43 @@
             <goals>
               <goal>cmp</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <version>1.0.0.RC1</version>
+        <executions>
+          <execution>
+            <id>add-module-info</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <overwriteExistingFiles>true</overwriteExistingFiles>
+              <outputDirectory>${project.build.directory}</outputDirectory>
+              <jvmVersion>9</jvmVersion>
+              <modules>
+                <module>
+                  <artifact>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>${project.artifactId}</artifactId>
+                    <version>${project.version}</version>
+                  </artifact>
+                  <moduleInfo>
+                    <name>jsoup</name>
+                    <requires>
+                      !jsr305;
+                    </requires>
+                    <exports>
+                      org.jsoup;
+                    </exports>
+                  </moduleInfo>
+                </module>
+              </modules>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -287,6 +332,9 @@
                   <goal>integration-test</goal>
                   <goal>verify</goal>
                 </goals>
+                <configuration>
+                  <argLine>${integration.test.arguments}</argLine>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <integration.test.arguments>
+      <!-- compatibility with jdk 8 -->
+      -XX:+IgnoreUnrecognizedVMOptions
       <!-- junit use reflection to run tests -->
-      --add-exports jsoup/org.jsoup.integration=ALL-UNNAMED
-      --add-exports jsoup/org.jsoup.integration.servlets=ALL-UNNAMED
-      --add-opens jsoup/org.jsoup.integration=ALL-UNNAMED
+      --add-exports=org.jsoup/org.jsoup.integration=ALL-UNNAMED
+      --add-exports=org.jsoup/org.jsoup.integration.servlets=ALL-UNNAMED
+      --add-opens=org.jsoup/org.jsoup.integration=ALL-UNNAMED
     </integration.test.arguments>
   </properties>
 
@@ -247,15 +249,12 @@
                     <artifactId>${project.artifactId}</artifactId>
                     <version>${project.version}</version>
                   </artifact>
-                  <moduleInfo>
-                    <name>jsoup</name>
-                    <requires>
-                      !jsr305;
-                    </requires>
-                    <exports>
-                      org.jsoup;
-                    </exports>
-                  </moduleInfo>
+                  <moduleInfoSource>
+                    module org.jsoup {
+                      requires java.xml;
+                      exports org.jsoup;
+                    }
+                  </moduleInfoSource>
                 </module>
               </modules>
               <jdepsExtraArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <integration.test.arguments>
-      --add-exports org.jsoup/org.jsoup.integration=ALL-UNNAMED
-      --add-exports org.jsoup/org.jsoup.integration.servlets=ALL-UNNAMED
-      --add-opens org.jsoup/org.jsoup.integration=ALL-UNNAMED
+      <!-- junit use reflection to run tests -->
+      --add-exports jsoup/org.jsoup.integration=ALL-UNNAMED
+      --add-exports jsoup/org.jsoup.integration.servlets=ALL-UNNAMED
+      --add-opens jsoup/org.jsoup.integration=ALL-UNNAMED
     </integration.test.arguments>
   </properties>
 
@@ -128,9 +129,6 @@
         <version>3.2.0</version>
         <configuration>
           <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>org.jsoup</Automatic-Module-Name>
-            </manifestEntries>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
           <excludes>
@@ -260,6 +258,9 @@
                   </moduleInfo>
                 </module>
               </modules>
+              <jdepsExtraArgs>
+                <arg>--ignore-missing-deps</arg>
+              </jdepsExtraArgs>
             </configuration>
           </execution>
         </executions>

--- a/src/main/moditect/module-info.java
+++ b/src/main/moditect/module-info.java
@@ -1,0 +1,4 @@
+module org.jsoup {
+    requires java.xml;
+    exports org.jsoup;
+}

--- a/src/main/moditect/module-info.java
+++ b/src/main/moditect/module-info.java
@@ -1,4 +1,9 @@
 module org.jsoup {
-    requires java.xml;
+    requires static java.xml;
+
     exports org.jsoup;
+    exports org.jsoup.nodes;
+    exports org.jsoup.parser;
+    exports org.jsoup.safety;
+    exports org.jsoup.select;
 }


### PR DESCRIPTION
Jackson was using [moditect](https://github.com/moditect/moditect) to generate multi-release module. 
I've tested on release 1.14.3.