### PR TITLE
Make constructors public for CombiningEvaluator.And and CombiningEvaluator.Or

### DIFF
--- a/src/main/java/org/jsoup/select/CombiningEvaluator.java
+++ b/src/main/java/org/jsoup/select/CombiningEvaluator.java
@@ -40,11 +40,11 @@ public abstract class CombiningEvaluator extends Evaluator {
     }
 
     public static final class And extends CombiningEvaluator {
-        And(Collection<Evaluator> evaluators) {
+        public And(Collection<Evaluator> evaluators) {
             super(evaluators);
         }
 
-        And(Evaluator... evaluators) {
+        public And(Evaluator... evaluators) {
             this(Arrays.asList(evaluators));
         }
 
@@ -69,7 +69,7 @@ public abstract class CombiningEvaluator extends Evaluator {
          * Create a new Or evaluator. The initial evaluators are ANDed together and used as the first clause of the OR.
          * @param evaluators initial OR clause (these are wrapped into an AND evaluator).
          */
-        Or(Collection<Evaluator> evaluators) {
+        public Or(Collection<Evaluator> evaluators) {
             super();
             if (num > 1)
                 this.evaluators.add(new And(evaluators));
@@ -78,9 +78,9 @@ public abstract class CombiningEvaluator extends Evaluator {
             updateNumEvaluators();
         }
 
-        Or(Evaluator... evaluators) { this(Arrays.asList(evaluators)); }
+        public Or(Evaluator... evaluators) { this(Arrays.asList(evaluators)); }
 
-        Or() {
+        public Or() {
             super();
         }
 


### PR DESCRIPTION
Hi, I've been using this project for some time now, but I recently noticed that CombiningEvaluator.And and CombiningEvaluator.Or can't be used because their constructors are package-private. So, please review these changes. Thanks!