### PR TITLE
Proposed fix : Disallow replacing nodes with themselves

### DIFF
--- a/src/main/java/org/jsoup/helper/Validate.java
+++ b/src/main/java/org/jsoup/helper/Validate.java
@@ -10,6 +10,18 @@ public final class Validate {
     private Validate() {}
 
     /**
+     * Validates that the two objects are not the same.
+     * @param a First object
+     * @param b Second object
+     * @param message Error message to use if the objects are the same
+     * @throws IllegalArgumentException if the objects are the same
+     */
+    public static void notStrictlyEqual(Object a, Object b, String message) {
+        if (a == b)
+            throw new ValidationException(message);
+    }
+
+    /**
      * Validates that the object is not null
      * @param obj object to test
      * @throws ValidationException if the object is null

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -457,6 +457,7 @@ public abstract class Node implements Cloneable {
     public void replaceWith(Node in) {
         Validate.notNull(in);
         Validate.notNull(parentNode);
+        Validate.notStrictlyEqual(this, in, "Cannot replace a node with itself");
         parentNode.replaceChild(this, in);
     }
 

--- a/src/test/java/org/jsoup/nodes/NodeTest.java
+++ b/src/test/java/org/jsoup/nodes/NodeTest.java
@@ -2,6 +2,7 @@ package org.jsoup.nodes;
 
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
+import org.jsoup.helper.ValidationException;
 import org.jsoup.parser.Tag;
 import org.jsoup.select.NodeVisitor;
 import org.junit.jupiter.api.Test;
@@ -401,5 +402,26 @@ public class NodeTest {
 
         assertNull(firstEl.firstElementChild());
         assertNull(firstEl.lastElementChild());
+    }
+
+    @Test
+    void replaceWithSelf() {
+        // Issue 1843
+
+        Document doc = new Document("");
+        Element h1 = doc.body().appendElement("h1");
+        Element div = doc.body().appendElement("div");
+
+        assertDoesNotThrow(doc::toString);
+
+        assertThrowsExactly(ValidationException.class, () -> h1.replaceWith(h1));
+
+        assertTrue(doc.body().children().contains(h1));
+        assertTrue(doc.body().children().contains(div));
+        assertNotNull(h1.parent());
+        assertNotNull(div.parent());
+        assertDoesNotThrow(doc::toString);
+
+
     }
 }


### PR DESCRIPTION
fixes #1843 : `Node.replaceWith` deletes siblings and creates an invalid state if a node is replaced with itself.

Proposed changes :
 * Equality validation, throw a `ValidationException` just as any other invalid parameter would.
 * Unit test for edge case