### PR TITLE
Use Java 8's Consumer interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ jsoup is designed to deal with all varieties of HTML found in the wild; from pri
 
 See [**jsoup.org**](https://jsoup.org/) for downloads and the full [API documentation](https://jsoup.org/apidocs/).
 
-**Note:** For use in Android projects with a `minSdk` below 24, [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) is required if the `forEach` methods are being used.
-
 [![Build Status](https://github.com/jhy/jsoup/workflows/Build/badge.svg)](https://github.com/jhy/jsoup/actions?query=workflow%3ABuild)
 
 ## Example
@@ -39,6 +37,9 @@ jsoup is an open source project distributed under the liberal [MIT license](http
 1. [Download](https://jsoup.org/download) the latest jsoup jar (or add it to your Maven/Gradle build)
 2. Read the [cookbook](https://jsoup.org/cookbook/)
 3. Enjoy!
+
+### Android support
+When used in Android projects, [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) should be enabled to support Java 8+ features.
 
 ## Development and support
 If you have any questions on how to use jsoup, or have ideas for future development, please get in touch via the [mailing list](https://jsoup.org/discussion).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ jsoup is designed to deal with all varieties of HTML found in the wild; from pri
 
 See [**jsoup.org**](https://jsoup.org/) for downloads and the full [API documentation](https://jsoup.org/apidocs/).
 
+**Note:** For use in Android projects with a `minSdk` below 24, [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) is required if the `forEach` methods are being used.
+
 [![Build Status](https://github.com/jhy/jsoup/workflows/Build/badge.svg)](https://github.com/jhy/jsoup/actions?query=workflow%3ABuild)
 
 ## Example

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
                 <version>2.3.3_r2</version>
               </signature>
               <ignores>java.util.function.Consumer</ignores>
+              <!-- ^ Provided by https://developer.android.com/studio/write/java8-support#library-desugaring
+               Possibly OK to remove androidscents; keep for now to validate other additions are supported. -->
             </configuration>
           </execution>
         </executions>
@@ -203,7 +205,7 @@
             <dependency>
               <groupId>org.jsoup</groupId>
               <artifactId>jsoup</artifactId>
-              <version>1.15.1</version>
+              <version>1.15.3</version>
               <type>jar</type>
             </dependency>
           </oldVersion>
@@ -212,9 +214,11 @@
             <onlyModified>false</onlyModified>
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
             <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
-            <!-- <excludes>
-              <exclude>@java.lang.Deprecated</exclude>
-            </excludes> -->
+            <excludes>
+              <!-- <exclude>@java.lang.Deprecated</exclude> -->
+              <exclude>org.jsoup.nodes.Element#forEachNode(org.jsoup.helper.Consumer)</exclude>
+            </excludes>
+            <!-- japicmp is tripping on a non-removed method when changed ancestor of Consumer in Element - have manually ensure binary and source compat for Consumer changes -->
             <overrideCompatibilityChangeParameters>
               <!-- allows new default and move to default methods. compatible as long as existing binaries aren't making calls via reflection. if so, they need to catch errors anyway. -->
               <overrideCompatibilityChangeParameter>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
                 <artifactId>android-api-level-10</artifactId>
                 <version>2.3.3_r2</version>
               </signature>
+              <ignores>java.util.function.Consumer</ignores>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/org/jsoup/helper/Consumer.java
+++ b/src/main/java/org/jsoup/helper/Consumer.java
@@ -3,14 +3,17 @@ package org.jsoup.helper;
 /**
  A functional interface (ala Java's {@link java.util.function.Consumer} interface, implemented here for cross compatibility with Android.
  @param <T> the input type
- */
-@FunctionalInterface
-public interface Consumer<T> {
 
+ @deprecated This will be removed in favor of using {@link java.util.function.Consumer} instead in the next release.
+ */
+@Deprecated
+@FunctionalInterface
+public interface Consumer<T> extends java.util.function.Consumer<T> {
     /**
      * Execute this operation on the supplied argument. It is expected to have side effects.
      *
      * @param t the input argument
      */
+    @Override
     void accept(T t);
 }

--- a/src/main/java/org/jsoup/helper/Consumer.java
+++ b/src/main/java/org/jsoup/helper/Consumer.java
@@ -1,11 +1,12 @@
 package org.jsoup.helper;
 
 /**
- A functional interface (ala Java's {@link java.util.function.Consumer} interface, implemented here for cross compatibility with Android.
+ A functional interface (ala Java's {@link java.util.function.Consumer} interface, previously implemented here for cross
+ compatibility with Android before desugaring support was introduced.
  @param <T> the input type
-
- @deprecated This will be removed in favor of using {@link java.util.function.Consumer} instead in the next release.
- */
+ @deprecated Use {@link java.util.function.Consumer} instead. This interface will be removed in the next release. If you
+ are targeting Android, see how to enable
+ <a href="https://developer.android.com/studio/write/java8-support#library-desugaring">desugaring</a>. */
 @Deprecated
 @FunctionalInterface
 public interface Consumer<T> extends java.util.function.Consumer<T> {

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1,7 +1,6 @@
 package org.jsoup.nodes;
 
 import org.jsoup.helper.ChangeNotifyingArrayList;
-import org.jsoup.helper.Consumer;
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.NonnullByDefault;
 import org.jsoup.internal.StringUtil;
@@ -27,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -859,7 +859,7 @@ public class Element extends Node {
             selector.append(String.format(
                 ":nth-child(%d)", elementSiblingIndex() + 1));
 
-        return parent().cssSelector() + selector.toString();
+        return parent().cssSelector() + selector;
     }
 
     /**
@@ -1819,6 +1819,18 @@ public class Element extends Node {
      @see Node#forEachNode(Consumer)
      */
     public Element forEach(Consumer<? super Element> action) {
+        Validate.notNull(action);
+        NodeTraversor.traverse((node, depth) -> {
+            if (node instanceof Element)
+                action.accept((Element) node);
+        }, this);
+        return this;
+    }
+
+    /**
+     @deprecated Use {@link #forEach(Consumer)} instead.
+     */
+    public Element forEach(org.jsoup.helper.Consumer<? super Element> action) {
         Validate.notNull(action);
         NodeTraversor.traverse((node, depth) -> {
             if (node instanceof Element)

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -1,7 +1,6 @@
 package org.jsoup.nodes;
 
 import org.jsoup.SerializationException;
-import org.jsoup.helper.Consumer;
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.select.NodeFilter;
@@ -16,6 +15,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  The base, abstract Node model. Elements, Documents, Comments etc are all Node instances.
@@ -661,6 +661,15 @@ public abstract class Node implements Cloneable {
      @see Element#forEach(Consumer)
      */
     public Node forEachNode(Consumer<? super Node> action) {
+        Validate.notNull(action);
+        NodeTraversor.traverse((node, depth) -> action.accept(node), this);
+        return this;
+    }
+
+    /**
+     @deprecated Use {@link #forEachNode(Consumer)} instead.
+     */
+    public Node forEachNode(org.jsoup.helper.Consumer<? super Node> action) {
         Validate.notNull(action);
         NodeTraversor.traverse((node, depth) -> action.accept(node), this);
         return this;

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -3,7 +3,6 @@ package org.jsoup.nodes;
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
 import org.jsoup.helper.ValidationException;
-import org.jsoup.internal.StringUtil;
 import org.jsoup.parser.ParseSettings;
 import org.jsoup.parser.Parser;
 import org.jsoup.parser.Tag;
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;


### PR DESCRIPTION
* Use the `Consumer` interface introduced in Java 8, as it can be backported for older versions of Android via [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).