### PR TITLE
Use StandardCharsets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ jsoup is designed to deal with all varieties of HTML found in the wild; from pri
 
 See [**jsoup.org**](https://jsoup.org/) for downloads and the full [API documentation](https://jsoup.org/apidocs/).
 
+**Note:** For use in Android projects with a `minSdk` below 19, [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) with the `desugar_jdk_libs_nio` artifact is required, which requires Android Gradle Plugin 7.4.0.
+
 [![Build Status](https://github.com/jhy/jsoup/workflows/Build/badge.svg)](https://github.com/jhy/jsoup/actions?query=workflow%3ABuild)
 
 ## Example

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -35,6 +35,7 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,7 +54,6 @@ import static org.jsoup.internal.Normalizer.lowerCase;
  * Implementation of {@link Connection}.
  * @see org.jsoup.Jsoup#connect(String)
  */
-@SuppressWarnings("CharsetObjectCanBeUsed")
 public class HttpConnection implements Connection {
     public static final String CONTENT_ENCODING = "Content-Encoding";
     /**
@@ -68,8 +68,6 @@ public class HttpConnection implements Connection {
     public static final String FORM_URL_ENCODED = "application/x-www-form-urlencoded";
     private static final int HTTP_TEMP_REDIR = 307; // http/1.1 temporary redirect, not in Java's set.
     private static final String DefaultUploadType = "application/octet-stream";
-    private static final Charset UTF_8 = Charset.forName("UTF-8"); // Don't use StandardCharsets, not in Android API 10.
-    private static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
 
     /**
      Create a new Connection, with the request URL specified.
@@ -481,10 +479,10 @@ public class HttpConnection implements Connection {
         }
 
         private static String fixHeaderEncoding(String val) {
-            byte[] bytes = val.getBytes(ISO_8859_1);
+            byte[] bytes = val.getBytes(StandardCharsets.ISO_8859_1);
             if (!looksLikeUtf8(bytes))
                 return val;
-            return new String(bytes, UTF_8);
+            return new String(bytes, StandardCharsets.UTF_8);
         }
 
         private static boolean looksLikeUtf8(byte[] input) {
@@ -643,7 +641,7 @@ public class HttpConnection implements Connection {
         private boolean ignoreContentType = false;
         private Parser parser;
         private boolean parserDefined = false; // called parser(...) vs initialized in ctor
-        private String postDataCharset = DataUtil.defaultCharsetName;
+        private String postDataCharset = StandardCharsets.UTF_8.name();
         private @Nullable SSLSocketFactory sslSocketFactory;
         private CookieManager cookieManager;
         private volatile boolean executing = false;
@@ -986,7 +984,7 @@ public class HttpConnection implements Connection {
             prepareByteData();
             Validate.notNull(byteData);
             // charset gets set from header on execute, and from meta-equiv on parse. parse may not have happened yet
-            String body = (charset == null ? DataUtil.UTF_8 : Charset.forName(charset))
+            String body = (charset == null ? StandardCharsets.UTF_8 : Charset.forName(charset))
                 .decode(byteData).toString();
             ((Buffer)byteData).rewind(); // cast to avoid covariant return type change in jdk9
             return body;
@@ -1241,9 +1239,9 @@ public class HttpConnection implements Connection {
                 else
                     first = false;
                 url
-                    .append(URLEncoder.encode(keyVal.key(), DataUtil.defaultCharsetName))
+                    .append(URLEncoder.encode(keyVal.key(), StandardCharsets.UTF_8.name()))
                     .append('=')
-                    .append(URLEncoder.encode(keyVal.value(), DataUtil.defaultCharsetName));
+                    .append(URLEncoder.encode(keyVal.value(), StandardCharsets.UTF_8.name()));
             }
             req.url(new URL(StringUtil.releaseBuilder(url)));
             req.data().clear(); // moved into url as get params

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -2,7 +2,6 @@ package org.jsoup.nodes;
 
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
-import org.jsoup.helper.DataUtil;
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.parser.ParseSettings;
@@ -14,6 +13,7 @@ import org.jsoup.select.Evaluator;
 import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -414,7 +414,7 @@ public class Document extends Element {
         public enum Syntax {html, xml}
 
         private Entities.EscapeMode escapeMode = Entities.EscapeMode.base;
-        private Charset charset = DataUtil.UTF_8;
+        private Charset charset = StandardCharsets.UTF_8;
         private final ThreadLocal<CharsetEncoder> encoderThreadLocal = new ThreadLocal<>(); // initialized by start of OuterHtmlVisitor
         @Nullable Entities.CoreCharset coreCharset; // fast encoders for ascii and utf8
 

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -8,11 +8,9 @@ import org.jsoup.nodes.Document.OutputSettings.Syntax;
 import org.jsoup.parser.ParseSettings;
 import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,10 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
  @author Jonathan Hedley, jonathan@hedley.net */
 public class DocumentTest {
-    private static final String charsetUtf8 = "UTF-8";
-    private static final String charsetIso8859 = "ISO-8859-1";
-
-
     @Test public void setTextPreservesDocumentStructure() {
         Document doc = Jsoup.parse("<p>Hello</p>");
         doc.text("Replaced");
@@ -230,19 +224,19 @@ public class DocumentTest {
     public void testMetaCharsetUpdateUtf8() {
         final Document doc = createHtmlDocument("changeThis");
         doc.updateMetaCharsetElement(true);
-        doc.charset(Charset.forName(charsetUtf8));
+        doc.charset(StandardCharsets.UTF_8);
 
         final String htmlCharsetUTF8 = "<html>\n" +
                                         " <head>\n" +
-                                        "  <meta charset=\"" + charsetUtf8 + "\">\n" +
+                                        "  <meta charset=\"" + "UTF-8" + "\">\n" +
                                         " </head>\n" +
                                         " <body></body>\n" +
                                         "</html>";
         assertEquals(htmlCharsetUTF8, doc.toString());
 
         Element selectedElement = doc.select("meta[charset]").first();
-        assertEquals(charsetUtf8, doc.charset().name());
-        assertEquals(charsetUtf8, selectedElement.attr("charset"));
+        assertEquals("UTF-8", doc.charset().name());
+        assertEquals("UTF-8", selectedElement.attr("charset"));
         assertEquals(doc.charset(), doc.outputSettings().charset());
     }
 
@@ -250,19 +244,19 @@ public class DocumentTest {
     public void testMetaCharsetUpdateIso8859() {
         final Document doc = createHtmlDocument("changeThis");
         doc.updateMetaCharsetElement(true);
-        doc.charset(Charset.forName(charsetIso8859));
+        doc.charset(StandardCharsets.ISO_8859_1);
 
         final String htmlCharsetISO = "<html>\n" +
                                         " <head>\n" +
-                                        "  <meta charset=\"" + charsetIso8859 + "\">\n" +
+                                        "  <meta charset=\"" + "ISO-8859-1" + "\">\n" +
                                         " </head>\n" +
                                         " <body></body>\n" +
                                         "</html>";
         assertEquals(htmlCharsetISO, doc.toString());
 
         Element selectedElement = doc.select("meta[charset]").first();
-        assertEquals(charsetIso8859, doc.charset().name());
-        assertEquals(charsetIso8859, selectedElement.attr("charset"));
+        assertEquals("ISO-8859-1", doc.charset().name());
+        assertEquals("ISO-8859-1", selectedElement.attr("charset"));
         assertEquals(doc.charset(), doc.outputSettings().charset());
     }
 
@@ -270,13 +264,13 @@ public class DocumentTest {
     public void testMetaCharsetUpdateNoCharset() {
         final Document docNoCharset = Document.createShell("");
         docNoCharset.updateMetaCharsetElement(true);
-        docNoCharset.charset(Charset.forName(charsetUtf8));
+        docNoCharset.charset(StandardCharsets.UTF_8);
 
-        assertEquals(charsetUtf8, docNoCharset.select("meta[charset]").first().attr("charset"));
+        assertEquals("UTF-8", docNoCharset.select("meta[charset]").first().attr("charset"));
 
         final String htmlCharsetUTF8 = "<html>\n" +
                                         " <head>\n" +
-                                        "  <meta charset=\"" + charsetUtf8 + "\">\n" +
+                                        "  <meta charset=\"" + "UTF-8" + "\">\n" +
                                         " </head>\n" +
                                         " <body></body>\n" +
                                         "</html>";
@@ -320,10 +314,10 @@ public class DocumentTest {
     @Test
     public void testMetaCharsetUpdateEnabledAfterCharsetChange() {
         final Document doc = createHtmlDocument("dontTouch");
-        doc.charset(Charset.forName(charsetUtf8));
+        doc.charset(StandardCharsets.UTF_8);
 
         Element selectedElement = doc.select("meta[charset]").first();
-        assertEquals(charsetUtf8, selectedElement.attr("charset"));
+        assertEquals("UTF-8", selectedElement.attr("charset"));
         assertTrue(doc.select("meta[name=charset]").isEmpty());
     }
 
@@ -331,11 +325,11 @@ public class DocumentTest {
     public void testMetaCharsetUpdateCleanup() {
         final Document doc = createHtmlDocument("dontTouch");
         doc.updateMetaCharsetElement(true);
-        doc.charset(Charset.forName(charsetUtf8));
+        doc.charset(StandardCharsets.UTF_8);
 
         final String htmlCharsetUTF8 = "<html>\n" +
                                         " <head>\n" +
-                                        "  <meta charset=\"" + charsetUtf8 + "\">\n" +
+                                        "  <meta charset=\"" + "UTF-8" + "\">\n" +
                                         " </head>\n" +
                                         " <body></body>\n" +
                                         "</html>";
@@ -347,17 +341,17 @@ public class DocumentTest {
     public void testMetaCharsetUpdateXmlUtf8() {
         final Document doc = createXmlDocument("1.0", "changeThis", true);
         doc.updateMetaCharsetElement(true);
-        doc.charset(Charset.forName(charsetUtf8));
+        doc.charset(StandardCharsets.UTF_8);
 
-        final String xmlCharsetUTF8 = "<?xml version=\"1.0\" encoding=\"" + charsetUtf8 + "\"?>\n" +
+        final String xmlCharsetUTF8 = "<?xml version=\"1.0\" encoding=\"" + "UTF-8" + "\"?>\n" +
                                         "<root>\n" +
                                         " node\n" +
                                         "</root>";
         assertEquals(xmlCharsetUTF8, doc.toString());
 
         XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
-        assertEquals(charsetUtf8, doc.charset().name());
-        assertEquals(charsetUtf8, selectedNode.attr("encoding"));
+        assertEquals("UTF-8", doc.charset().name());
+        assertEquals("UTF-8", selectedNode.attr("encoding"));
         assertEquals(doc.charset(), doc.outputSettings().charset());
     }
 
@@ -365,17 +359,17 @@ public class DocumentTest {
     public void testMetaCharsetUpdateXmlIso8859() {
         final Document doc = createXmlDocument("1.0", "changeThis", true);
         doc.updateMetaCharsetElement(true);
-        doc.charset(Charset.forName(charsetIso8859));
+        doc.charset(StandardCharsets.ISO_8859_1);
 
-        final String xmlCharsetISO = "<?xml version=\"1.0\" encoding=\"" + charsetIso8859 + "\"?>\n" +
+        final String xmlCharsetISO = "<?xml version=\"1.0\" encoding=\"" + "ISO-8859-1" + "\"?>\n" +
                                         "<root>\n" +
                                         " node\n" +
                                         "</root>";
         assertEquals(xmlCharsetISO, doc.toString());
 
         XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
-        assertEquals(charsetIso8859, doc.charset().name());
-        assertEquals(charsetIso8859, selectedNode.attr("encoding"));
+        assertEquals("ISO-8859-1", doc.charset().name());
+        assertEquals("ISO-8859-1", selectedNode.attr("encoding"));
         assertEquals(doc.charset(), doc.outputSettings().charset());
     }
 
@@ -383,16 +377,16 @@ public class DocumentTest {
     public void testMetaCharsetUpdateXmlNoCharset() {
         final Document doc = createXmlDocument("1.0", "none", false);
         doc.updateMetaCharsetElement(true);
-        doc.charset(Charset.forName(charsetUtf8));
+        doc.charset(StandardCharsets.UTF_8);
 
-        final String xmlCharsetUTF8 = "<?xml version=\"1.0\" encoding=\"" + charsetUtf8 + "\"?>\n" +
+        final String xmlCharsetUTF8 = "<?xml version=\"1.0\" encoding=\"" + "UTF-8" + "\"?>\n" +
                                         "<root>\n" +
                                         " node\n" +
                                         "</root>";
         assertEquals(xmlCharsetUTF8, doc.toString());
 
         XmlDeclaration selectedNode = (XmlDeclaration) doc.childNode(0);
-        assertEquals(charsetUtf8, selectedNode.attr("encoding"));
+        assertEquals("UTF-8", selectedNode.attr("encoding"));
     }
 
     @Test


### PR DESCRIPTION
Use the `StandardCharsets` class, as it is backported for Android API levels below 19 with [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) starting with [`desugar_jdk_libs`](https://github.com/google/desugar_jdk_libs/blob/master/CHANGELOG.md) 2.0.0.