### PR TITLE
fix little missunderstanding

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -1240,9 +1240,9 @@ public class HttpConnection implements Connection {
                 else
                     first = false;
                 url
-                    .append(URLEncoder.encode(keyVal.key(), DataUtil.defaultCharsetName))
+                    .append(URLEncoder.encode(keyVal.key(), req.postDataCharset()))
                     .append('=')
-                    .append(URLEncoder.encode(keyVal.value(), DataUtil.defaultCharsetName));
+                    .append(URLEncoder.encode(keyVal.value(), req.postDataCharset()));
             }
             req.url(new URL(StringUtil.releaseBuilder(url)));
             req.data().clear(); // moved into url as get params


### PR DESCRIPTION
The documentation of [Document.postDataCharset(String charset)](https://jsoup.org/apidocs/org/jsoup/Connection.html#postDataCharset(java.lang.String)) says: "Sets the default post data character set for x-www-form-urlencoded post data." 

At first I thought, it was not about the POST request but about the x-www-form-urlencoded data. Which means, that if I used this method sending a charset B as argument, even if I do a GET request the x-www-form-urlencoded data in it would've been converted into chartset B.

What is actually happening is that it's all about POST request and somehow it feels a bit weird. What is happening is that when it's a POST request Jsoup uses the charSet specified by postDataCharSet to transform the  x-www-form-urlencoded  data but for everything else it just uses a default charSet. The most funny thing is that the variable that postDataCharSet affects is initialized with this default charset.

I think that it would be better if Jsoup just used this value (specified using postDataCharSet) to transform x-www-form-urlencoded data, no matter the method used (as long as the method allows such kind of data).

I just changed two lines of code to make that happen.

I hope you reconsider this, it would make some people life easiser.