### PR TITLE
Remove unnecessary override.

### DIFF
--- a/src/main/java/org/jsoup/select/Collector.java
+++ b/src/main/java/org/jsoup/select/Collector.java
@@ -74,11 +74,5 @@ public class Collector {
             }
             return CONTINUE;
         }
-
-        @Override
-        public FilterResult tail(Node node, int depth) {
-            return CONTINUE;
-        }
     }
-
 }


### PR DESCRIPTION
Remove unnecessary override in `FirstFinder`.