### PR TITLE
Removed unnecessary constructor

### DIFF
--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -36,10 +36,6 @@ public class Elements extends ArrayList<Element> {
         super(elements);
     }
     
-    public Elements(List<Element> elements) {
-        super(elements);
-    }
-    
     public Elements(Element... elements) {
     	super(Arrays.asList(elements));
     }


### PR DESCRIPTION
List<Elements> extends Collection<Elements> 
this means that in that case they are literally the same