### PR TITLE
Add method to rename an Element's Tag without resetting the tag's properties

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -178,6 +178,20 @@ public class Element extends Node {
     }
 
     /**
+     * Change (rename) the tag of this element. For example, convert a {@code <span>} to a {@code <div>} with
+     * {@code el.tagName("div");}.
+     *
+     * @param tagName new tag name for this element
+     * @return this element, for chaining
+     * @see Elements#tagName(String)
+     */
+    public Element renameTagPreserveProperties(String tagName) {
+        Validate.notEmptyParam(tagName, "tagName");
+        tag = Tag.convertTag(tag, tagName); // maintains the case option of the original parse
+        return this;
+    }
+
+    /**
      * Get the Tag for this element.
      *
      * @return the tag object

--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -79,6 +79,26 @@ public class Tag implements Cloneable {
     }
 
     /**
+     * Create a new tag with a new name, copying the same characteristics as the old one.
+     *
+     * @param tagName Name of tag, e.g. "p". Case insensitive.
+     * @return The tag, either defined or new generic.
+     */
+    public static Tag convertTag(Tag oldTag, String tagName) {
+        Validate.notNull(tagName);
+        Tag tag = new Tag(tagName);
+        tag.empty = oldTag.empty;
+        tag.formList = oldTag.formList;
+        tag.formSubmit = oldTag.formSubmit;
+        tag.formatAsBlock = oldTag.formatAsBlock;
+        tag.isBlock = oldTag.isBlock;
+        tag.preserveWhitespace = oldTag.preserveWhitespace;
+        tag.selfClosing = oldTag.selfClosing;
+
+        return tag;
+    }
+
+    /**
      * Get a Tag by name. If not previously defined (unknown), returns a new generic tag, that can do anything.
      * <p>
      * Pre-defined tags (P, DIV etc) will be ==, but unknown tags are not registered and will only .equals().

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -1017,6 +1017,39 @@ public class ElementTest {
     }
 
     @Test
+    public void tagNameChangeResetsProperties() {
+        Document doc = Jsoup.parse("<img src='foo.png'>");
+        Element img = doc.select("img").first();
+
+        assertTrue(img.tag().isInline());
+        assertTrue(img.tag().isSelfClosing());
+        assertFalse(img.isBlock());
+
+        // When we rename a tag to a new, unregistered name, confirm that its properties are reset, just as if
+        // we had created one from scratch.
+
+        Tag testTag = Tag.valueOf("jspControl:image", NodeUtils.parser(doc).settings());
+        img.tagName("jspControl:image");
+        assertEquals(testTag, img.tag());
+    }
+
+    @Test
+    public void testRenameTagPreserveProperties() {
+        Document doc = Jsoup.parse("<img src='foo.png'>");
+        Element img = doc.select("img").first();
+        assertTrue(img.tag().isInline());
+        assertTrue(img.tag().isSelfClosing());
+        assertFalse(img.isBlock());
+
+        // When we rename to an unrecognized tag, but tell the element to keep its tag properties, the previous
+        // assertions should still hold true.
+        img.renameTagPreserveProperties("jspControl:image");
+        assertTrue(img.tag().isInline());
+        assertTrue(img.tag().isSelfClosing());
+        assertFalse(img.isBlock());
+    }
+
+    @Test
     public void testHtmlContainsOuter() {
         Document doc = Jsoup.parse("<title>Check</title> <div>Hello there</div>");
         doc.outputSettings().indentAmount(0);


### PR DESCRIPTION
This PR is tangentially related to #1428 and #502.

If I want to change the name of an element's tag as I traverse the DOM, I don't have the ability to "preserve" the properties of the underlying Tag object (for example, keeping a tag as self-closing).  A great example of this is renaming a JSP tag, where I might want to change a `<bean:message />` to a `<spring:message />`.  

This PR adds a new method to the Element class, `renameTagPreserveProperties(String)`, to support that behavior.  Also added unit tests to confirm that the behavior of the `Element.tagName(String)` method is preserved.