### PR TITLE
readd an implementation of Whitelist for backwards compatibility

### DIFF
--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -365,18 +365,22 @@ Connection con3 = session.newRequest();
         return new Cleaner(safelist).isValidBodyHtml(bodyHtml);
     }
 
+    @Deprecated
     public static String clean(String bodyHtml, String baseUri, Whitelist whitelist, Document.OutputSettings outputSettings) {
         return clean(bodyHtml, baseUri, whitelist.getSafelist(), outputSettings);
     }
 
+    @Deprecated
     public static boolean isValid(String bodyHtml, Whitelist whitelist) {
         return isValid(bodyHtml, whitelist.getSafelist());
     }
 
+    @Deprecated
     public static String clean(String bodyHtml, Whitelist whitelist) {
         return clean(bodyHtml, whitelist.getSafelist());
     }
 
+    @Deprecated
     public static String clean(String bodyHtml, String baseUri, Whitelist whitelist) {
         return clean(bodyHtml, baseUri, whitelist.getSafelist());
     }

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -7,6 +7,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
 import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Safelist;
+import org.jsoup.safety.Whitelist;
 
 import javax.annotation.Nullable;
 import javax.annotation.WillClose;
@@ -362,5 +363,21 @@ Connection con3 = session.newRequest();
      */
     public static boolean isValid(String bodyHtml, Safelist safelist) {
         return new Cleaner(safelist).isValidBodyHtml(bodyHtml);
+    }
+
+    public static String clean(String bodyHtml, String baseUri, Whitelist whitelist, Document.OutputSettings outputSettings) {
+        return clean(bodyHtml, baseUri, whitelist.getSafelist(), outputSettings);
+    }
+
+    public static boolean isValid(String bodyHtml, Whitelist whitelist) {
+        return isValid(bodyHtml, whitelist.getSafelist());
+    }
+
+    public static String clean(String bodyHtml, Whitelist whitelist) {
+        return clean(bodyHtml, whitelist.getSafelist());
+    }
+
+    public static String clean(String bodyHtml, String baseUri, Whitelist whitelist) {
+        return clean(bodyHtml, baseUri, whitelist.getSafelist());
     }
 }

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -45,6 +45,7 @@ public class Cleaner {
         this.safelist = safelist;
     }
 
+    @Deprecated
     public Cleaner(Whitelist whitelist) {
         this(whitelist.getSafelist());
     }

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -45,6 +45,10 @@ public class Cleaner {
         this.safelist = safelist;
     }
 
+    public Cleaner(Whitelist whitelist) {
+        this(whitelist.getSafelist());
+    }
+
     /**
      Creates a new, clean document, from the original dirty document, containing only elements allowed by the safelist.
      The original document is not modified. Only elements from the dirty document's <code>body</code> are used. The

--- a/src/main/java/org/jsoup/safety/Safelist.java
+++ b/src/main/java/org/jsoup/safety/Safelist.java
@@ -613,7 +613,16 @@ public class Safelist {
         }
         return attrs;
     }
-    
+
+    protected Set<TagName> getTagNames() {
+        return this.tagNames;
+    }
+
+    protected Safelist setPreserverRelativeLinks(boolean preserve) {
+        this.preserveRelativeLinks = preserve;
+        return this;
+    }
+
     // named types for config. All just hold strings, but here for my sanity.
 
     static class TagName extends TypedValue {

--- a/src/main/java/org/jsoup/safety/Whitelist.java
+++ b/src/main/java/org/jsoup/safety/Whitelist.java
@@ -1,0 +1,96 @@
+package org.jsoup.safety;
+
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.jsoup.safety.Safelist.TagName;
+
+public class Whitelist {
+
+    protected Safelist safelist;
+
+    public Whitelist() {
+        this.safelist = new Safelist();
+    }
+
+    public Whitelist(Whitelist copy) {
+        this.safelist = new Safelist(copy.safelist);
+    }
+
+    private Whitelist(Safelist embedded) {
+        this.safelist = embedded;
+    }
+
+    public static Whitelist none() {
+        return new Whitelist();
+    }
+
+    public static Whitelist simpleText() {
+        return new Whitelist(Safelist.simpleText());
+    }
+
+    public static Whitelist basic() {
+        return new Whitelist(Safelist.basic());
+    }
+
+    public Safelist getSafelist() {
+        return this.safelist;
+    }
+
+    public Whitelist addTags(String... tags) {
+        this.safelist.addTags(tags);
+        return this;
+    }
+
+    public Whitelist removeTags(String... tags) {
+        this.safelist.removeTags(tags);
+        return this;
+    }
+
+    public Whitelist addAttributes(String tag, String... attributes) {
+        this.safelist.addAttributes(tag, attributes);
+        return this;
+    }
+
+    public Whitelist removeAttributes(String tag, String... attributes) {
+        this.safelist.removeAttributes(tag, attributes);
+        return this;
+    }
+
+    public Whitelist addEnforcedAttribute(String tag, String attribute, String value) {
+        this.safelist.addEnforcedAttribute(tag, attribute, value);
+        return this;
+    }
+
+    public Whitelist removeEnforcedAttribute(String tag, String attribute) {
+        this.safelist.removeEnforcedAttribute(tag, attribute);
+        return this;
+    }
+
+    public Whitelist preserveRelativeLinks(boolean preserve) {
+        this.safelist.setPreserverRelativeLinks(preserve);
+        return this;
+    }
+
+    public Whitelist addProtocols(String tag, String attribute, String... protocols) {
+        this.safelist.addProtocols(tag, attribute, protocols);
+        return this;
+    }
+
+    public Whitelist removeProtocols(String tag, String attribute, String... removeProtocols) {
+        this.safelist.removeProtocols(tag, attribute, removeProtocols);
+        return this;
+    }
+
+    public boolean isSafeTag(String tag) {
+        return this.safelist.getTagNames().contains(TagName.valueOf(tag));
+    }
+
+    public boolean isSafeAttribute(String tagName, Element el, Attribute attr) {
+        return this.safelist.isSafeAttribute(tagName, el, attr);
+    }
+
+    public Attributes getEnforcedAttributes(String tagName) {
+        return this.safelist.getEnforcedAttributes(tagName);
+    }
+}

--- a/src/main/java/org/jsoup/safety/Whitelist.java
+++ b/src/main/java/org/jsoup/safety/Whitelist.java
@@ -5,6 +5,7 @@ import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Element;
 import org.jsoup.safety.Safelist.TagName;
 
+@Deprecated
 public class Whitelist {
 
     protected Safelist safelist;

--- a/src/test/java/org/jsoup/safety/WhitelistTest.java
+++ b/src/test/java/org/jsoup/safety/WhitelistTest.java
@@ -1,0 +1,77 @@
+package org.jsoup.safety;
+
+import org.jsoup.helper.ValidationException;
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WhitelistTest {
+    private static final String TEST_TAG = "testTag";
+    private static final String TEST_ATTRIBUTE = "testAttribute";
+    private static final String TEST_SCHEME = "valid-scheme";
+    private static final String TEST_VALUE = TEST_SCHEME + "://testValue";
+
+    @Test
+    public void testCopyConstructor_noSideEffectOnTags() {
+        Whitelist whitelist1 = Whitelist.none().addTags(TEST_TAG);
+        Whitelist whitelist2 = new Whitelist(whitelist1);
+        whitelist1.addTags("invalidTag");
+
+        assertFalse(whitelist2.isSafeTag("invalidTag"));
+    }
+
+    @Test
+    public void testCopyConstructor_noSideEffectOnAttributes() {
+        Whitelist whitelist1 = Whitelist.none().addAttributes(TEST_TAG, TEST_ATTRIBUTE);
+        Whitelist whitelist2 = new Whitelist(whitelist1);
+        whitelist1.addAttributes(TEST_TAG, "invalidAttribute");
+
+        assertFalse(whitelist2.isSafeAttribute(TEST_TAG, null, new Attribute("invalidAttribute", TEST_VALUE)));
+    }
+
+    @Test
+    public void testCopyConstructor_noSideEffectOnEnforcedAttributes() {
+        Whitelist whitelist1 = Whitelist.none().addEnforcedAttribute(TEST_TAG, TEST_ATTRIBUTE, TEST_VALUE);
+        Whitelist whitelist2 = new Whitelist(whitelist1);
+        whitelist1.addEnforcedAttribute(TEST_TAG, TEST_ATTRIBUTE, "invalidValue");
+
+        for (Attribute enforcedAttribute : whitelist2.getEnforcedAttributes(TEST_TAG)) {
+            assertNotEquals("invalidValue", enforcedAttribute.getValue());
+        }
+    }
+
+    @Test
+    public void testCopyConstructor_noSideEffectOnProtocols() {
+        final String invalidScheme = "invalid-scheme";
+        Whitelist whitelist1 = Whitelist.none()
+                .addAttributes(TEST_TAG, TEST_ATTRIBUTE)
+                .addProtocols(TEST_TAG, TEST_ATTRIBUTE, TEST_SCHEME);
+        Whitelist whitelist2 = new Whitelist(whitelist1);
+        whitelist1.addProtocols(TEST_TAG, TEST_ATTRIBUTE, invalidScheme);
+
+        Attributes attributes = new Attributes();
+        Attribute invalidAttribute = new Attribute(TEST_ATTRIBUTE, invalidScheme + "://someValue");
+        attributes.put(invalidAttribute);
+        Element invalidElement = new Element(Tag.valueOf(TEST_TAG), "", attributes);
+
+        assertFalse(whitelist2.isSafeAttribute(TEST_TAG, invalidElement, invalidAttribute));
+    }
+
+    @Test
+    void noscriptIsBlocked() {
+        boolean threw = false;
+        Whitelist whitelist = null;
+        try {
+            whitelist = Whitelist.none().addTags("NOSCRIPT");
+        } catch (ValidationException validationException) {
+            threw = true;
+            assertTrue(validationException.getMessage().contains("unsupported"));
+        }
+        assertTrue(threw);
+        assertNull(whitelist);
+    }
+}


### PR DESCRIPTION
First off, thanks for jsoup - i've used it in multiple settings and it is a pleasure to use.

In this case however, we are not the direct user of jsoup. We use some software, where we do not control the dependency chain and that still depends on jsoup <1.15.x. For security reason we would like to update to the latest version - as is also the recommendation in the security policy[1] . However the recent ABI breaking change renaming the Whitelist class to Safelist prevents us from doing so.

This PR readds a Whitelist class, that uses a Safelist internally. It works for us and it may be useful to others.
Thanks

[1] https://github.com/jhy/jsoup/blob/master/SECURITY.md