### PR TITLE
Repackaged the library with native (vs automatic) JPMS module support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         # choosing to run a reduced set of LTS, current, and next, to balance coverage and execution time
-        java: [9, 17, 21]
+        java: [11, 17, 21]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         # choosing to run a reduced set of LTS, current, and next, to balance coverage and execution time
-        java: [8, 17, 21]
+        java: [9, 17, 21]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
     steps:

--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Release 1.17.1 [PENDING]
   * Improvement: added the `:is(selector list)` pseudo-selector, which finds elements that match any of the selectors in
     the selector list. Useful for making large ORed selectors more readable.
 
+  * Improvement: repackaged the library with native (vs automatic) JPMS module support.
+
   * Bugfix: when outputting with XML syntax, HTML elements that were parsed as data nodes (<script> and <style>) should
     be emitted as CDATA nodes, so that they can be parsed correctly by an XML parser.
     <https://github.com/jhy/jsoup/pull/1720>

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Release 1.17.1 [PENDING]
     the selector list. Useful for making large ORed selectors more readable.
 
   * Improvement: repackaged the library with native (vs automatic) JPMS module support.
+    <https://github.com/jhy/jsoup/pull/2025>
 
   * Bugfix: when outputting with XML syntax, HTML elements that were parsed as data nodes (<script> and <style>) should
     be emitted as CDATA nodes, so that they can be parsed correctly by an XML parser.

--- a/pom.xml
+++ b/pom.xml
@@ -38,13 +38,12 @@
 
   <build>
     <plugins>
+      <!-- Compile -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
           <encoding>UTF-8</encoding>
           <compilerArgs>
             <!-- saves output for package-info.java, so mvn sees it has completed it, so incremental compile works -->
@@ -53,9 +52,34 @@
           <!-- this means incremental = true... -->
           <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
+        <executions>
+          <execution>
+            <id>compile-java-8</id>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-java-9</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+              </compileSourceRoots>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+
       </plugin>
+
+      <!-- Ensure Java 8 and Android 10 API compatibility -->
       <plugin>
-        <!-- Ensure Java 8 and Android 10 API compatibility -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <version>1.23</version>
@@ -136,7 +160,7 @@
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
             <manifestEntries>
-              <Automatic-Module-Name>org.jsoup</Automatic-Module-Name>
+              <Multi-Release>true</Multi-Release>
             </manifestEntries>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,0 +1,10 @@
+module org.jsoup {
+    exports org.jsoup;
+    exports org.jsoup.helper;
+    exports org.jsoup.nodes;
+    exports org.jsoup.parser;
+    exports org.jsoup.safety;
+    exports org.jsoup.select;
+
+    requires transitive java.xml; // for org.w3c.dom out of W3CDom
+}


### PR DESCRIPTION
Adds an explicit `module-info.java` file. As a native module, tools requiring modules such as jlink will operate correctly without warnings.

This makes jsoup a multi-release jar so it's still compatible with java 8. The `module-info.java` file is:

```java
module org.jsoup {
    exports org.jsoup;
    exports org.jsoup.helper;
    exports org.jsoup.nodes;
    exports org.jsoup.parser;
    exports org.jsoup.safety;
    exports org.jsoup.select;

    requires transitive java.xml; // for org.w3c.dom out of W3CDom
}
```

**Nullability annotations**
I looked at having also a `requires static jsr305` entry as well. That's a build time dependency for our javax nonnull annotations. However as that's an automodule, we get the compile warning `Required filename-based automodules detected: [jsr305-3.0.2.jar]. Please don't publish this project to a public artifact repository!`. So I'm keeping it out. Everything still works and downstream consumers will still get nullability warnings in their IDE. However jsoup developers will see edit-time errors / warnings on the import and use of these annotations. Perhaps now is a good time to implement #1992.

**Java 8 tests**
This change requires a minimum Java version of 9, and the min CI builder is changed to 11 (LTS). We should add a CI action to test a built jar under Java 8. Tracked in #2026.

Fixes #1943
Fixes #1466
