### PR TITLE
Migrate Nullability assertions to jspecify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
           <instructions>
             <Bundle-DocURL>https://jsoup.org/</Bundle-DocURL>
             <Export-Package>org.jsoup.*</Export-Package>
-            <Import-Package>javax.annotation;version=!;resolution:=optional,javax.annotation.meta;version=!;resolution:=optional,*</Import-Package>
+            <Import-Package>org.jspecify.annotations;version=!;resolution:=optional,*</Import-Package>
           </instructions>
         </configuration>
       </plugin>
@@ -232,7 +232,7 @@
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
             <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
             <excludes>
-              <exclude>@java.lang.Deprecated</exclude>
+              <!-- <exclude>@java.lang.Deprecated</exclude> -->
             </excludes>
             <overrideCompatibilityChangeParameters>
               <!-- allows new default and move to default methods. compatible as long as existing binaries aren't making calls via reflection. if so, they need to catch errors anyway. -->
@@ -415,10 +415,10 @@
     </dependency>
 
     <dependency>
-      <!-- javax.annotations.nonnull, with Apache 2 (not GPL) license. Build time only. -->
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
+      <!-- org.jspecify.annotations.nonnull, with Apache 2 license. Build time only. -->
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>0.3.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -3,8 +3,8 @@ package org.jsoup;
 import org.jsoup.helper.RequestAuthenticator;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.BufferedInputStream;
 import java.io.IOException;

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -7,9 +7,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
 import org.jsoup.safety.Cleaner;
 import org.jsoup.safety.Safelist;
-
-import javax.annotation.Nullable;
-import javax.annotation.WillClose;
+import org.jspecify.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -196,7 +194,7 @@ Connection con3 = session.newRequest();
 
      @throws IOException if the file could not be found, or read, or if the charsetName is invalid.
      */
-    public static Document parse(@WillClose InputStream in, @Nullable String charsetName, String baseUri) throws IOException {
+    public static Document parse(InputStream in, @Nullable String charsetName, String baseUri) throws IOException {
         return DataUtil.load(in, charsetName, baseUri);
     }
 

--- a/src/main/java/org/jsoup/helper/AuthenticationHandler.java
+++ b/src/main/java/org/jsoup/helper/AuthenticationHandler.java
@@ -1,6 +1,7 @@
 package org.jsoup.helper;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.lang.reflect.Constructor;
 import java.net.Authenticator;
 import java.net.HttpURLConnection;

--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -10,9 +10,7 @@ import org.jsoup.nodes.Node;
 import org.jsoup.nodes.XmlDeclaration;
 import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
-
-import javax.annotation.Nullable;
-import javax.annotation.WillClose;
+import org.jspecify.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.CharArrayReader;
@@ -105,7 +103,7 @@ public final class DataUtil {
      * @return Document
      * @throws IOException on IO error
      */
-    public static Document load(@WillClose InputStream in, @Nullable String charsetName, String baseUri) throws IOException {
+    public static Document load(InputStream in, @Nullable String charsetName, String baseUri) throws IOException {
         return parseInputStream(in, charsetName, baseUri, Parser.htmlParser());
     }
 
@@ -118,7 +116,7 @@ public final class DataUtil {
      * @return Document
      * @throws IOException on IO error
      */
-    public static Document load(@WillClose InputStream in, @Nullable String charsetName, String baseUri, Parser parser) throws IOException {
+    public static Document load(InputStream in, @Nullable String charsetName, String baseUri, Parser parser) throws IOException {
         return parseInputStream(in, charsetName, baseUri, parser);
     }
 
@@ -136,7 +134,7 @@ public final class DataUtil {
         }
     }
 
-    static Document parseInputStream(@Nullable @WillClose InputStream input, @Nullable String charsetName, String baseUri, Parser parser) throws IOException  {
+    static Document parseInputStream(@Nullable InputStream input, @Nullable String charsetName, String baseUri, Parser parser) throws IOException  {
         if (input == null) // empty body
             return new Document(baseUri);
         input = ConstrainableInputStream.wrap(input, bufferSize, 0);

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -9,8 +9,8 @@ import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import org.jsoup.parser.TokenQueue;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.BufferedInputStream;
@@ -111,7 +111,7 @@ public class HttpConnection implements Connection {
     }
 
     private HttpConnection.Request req;
-    private @Nullable Connection.Response res;
+    private Connection.@Nullable Response res;
 
     @Override
     public Connection newRequest() {
@@ -539,7 +539,7 @@ public class HttpConnection implements Connection {
             return Collections.emptyList();
         }
 
-        private @Nullable Map.Entry<String, List<String>> scanHeaders(String name) {
+        private Map.@Nullable Entry<String, List<String>> scanHeaders(String name) {
             String lc = lowerCase(name);
             for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
                 if (lowerCase(entry.getKey()).equals(lc))
@@ -1061,7 +1061,7 @@ public class HttpConnection implements Connection {
         }
 
         // set up url, method, header, cookies
-        private Response(HttpURLConnection conn, HttpConnection.Request request, @Nullable HttpConnection.Response previousResponse) throws IOException {
+        private Response(HttpURLConnection conn, HttpConnection.Request request, HttpConnection.@Nullable Response previousResponse) throws IOException {
             this.conn = conn;
             this.req = request;
             method = Method.valueOf(conn.getRequestMethod());

--- a/src/main/java/org/jsoup/helper/RequestAuthenticator.java
+++ b/src/main/java/org/jsoup/helper/RequestAuthenticator.java
@@ -1,8 +1,8 @@
 package org.jsoup.helper;
 
 import org.jsoup.Connection;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 import java.net.URL;

--- a/src/main/java/org/jsoup/helper/UrlBuilder.java
+++ b/src/main/java/org/jsoup/helper/UrlBuilder.java
@@ -2,8 +2,8 @@ package org.jsoup.helper;
 
 import org.jsoup.Connection;
 import org.jsoup.internal.StringUtil;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.IDN;
 import java.net.MalformedURLException;

--- a/src/main/java/org/jsoup/helper/Validate.java
+++ b/src/main/java/org/jsoup/helper/Validate.java
@@ -1,6 +1,6 @@
 package org.jsoup.helper;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Validators to check that method arguments meet expectations. 

--- a/src/main/java/org/jsoup/helper/W3CDom.java
+++ b/src/main/java/org/jsoup/helper/W3CDom.java
@@ -17,8 +17,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -353,7 +353,7 @@ public class W3CDom {
         private final Stack<HashMap<String, String>> namespacesStack = new Stack<>(); // stack of namespaces, prefix => urn
         private Node dest;
         private Syntax syntax = Syntax.xml; // the syntax (to coerce attributes to). From the input doc if available.
-        @Nullable private final org.jsoup.nodes.Element contextElement;
+        /*@Nullable*/ private final org.jsoup.nodes.Element contextElement; // todo - unsure why this can't be marked nullable?
 
         public W3CBuilder(Document doc) {
             this.doc = doc;

--- a/src/main/java/org/jsoup/helper/package-info.java
+++ b/src/main/java/org/jsoup/helper/package-info.java
@@ -1,7 +1,7 @@
 /**
  Package containing classes supporting the core jsoup code.
  */
-@NonnullByDefault
+@NullMarked
 package org.jsoup.helper;
 
-import org.jsoup.internal.NonnullByDefault;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/jsoup/internal/FieldsAreNonnullByDefault.java
+++ b/src/main/java/org/jsoup/internal/FieldsAreNonnullByDefault.java
@@ -1,19 +1,17 @@
 package org.jsoup.internal;
 
-import javax.annotation.Nonnull;
-import javax.annotation.meta.TypeQualifierDefault;
+import org.jspecify.annotations.NullMarked;
+
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- Indicates that fields types are not nullable, unless otherwise specified by @Nullable.
- @see javax.annotation.ParametersAreNonnullByDefault
+ @deprecated Previously indicated that fields types are not nullable, unless otherwise specified by @Nullable.
  */
+@Deprecated
 @Documented
-@Nonnull
-@TypeQualifierDefault(ElementType.FIELD)
+@NullMarked
 @Retention(value = RetentionPolicy.CLASS)
 public @interface FieldsAreNonnullByDefault {
 }

--- a/src/main/java/org/jsoup/internal/NonnullByDefault.java
+++ b/src/main/java/org/jsoup/internal/NonnullByDefault.java
@@ -1,19 +1,17 @@
 package org.jsoup.internal;
 
-import javax.annotation.Nonnull;
-import javax.annotation.meta.TypeQualifierDefault;
+import org.jspecify.annotations.NullMarked;
+
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- Indicates that all components (methods, returns, fields) are not nullable, unless otherwise specified by @Nullable.
- @see javax.annotation.ParametersAreNonnullByDefault
+ @deprecated Previously indicated that all components (methods, returns, fields) are not nullable, unless otherwise specified by @Nullable.
  */
+@Deprecated
 @Documented
-@Nonnull
-@TypeQualifierDefault({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
+@NullMarked
 @Retention(value = RetentionPolicy.CLASS)
 public @interface NonnullByDefault {
 }

--- a/src/main/java/org/jsoup/internal/ReturnsAreNonnullByDefault.java
+++ b/src/main/java/org/jsoup/internal/ReturnsAreNonnullByDefault.java
@@ -1,19 +1,17 @@
 package org.jsoup.internal;
 
-import javax.annotation.Nonnull;
-import javax.annotation.meta.TypeQualifierDefault;
+import org.jspecify.annotations.NullMarked;
+
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- Indicates return types are not nullable, unless otherwise specified by @Nullable.
- @see javax.annotation.ParametersAreNonnullByDefault
+ @deprecated Previously indicated that return types are not nullable, unless otherwise specified by @Nullable.
  */
+@Deprecated
 @Documented
-@Nonnull
-@TypeQualifierDefault(ElementType.METHOD)
+@NullMarked
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface ReturnsAreNonnullByDefault {
 }

--- a/src/main/java/org/jsoup/internal/StringUtil.java
+++ b/src/main/java/org/jsoup/internal/StringUtil.java
@@ -1,8 +1,8 @@
 package org.jsoup.internal;
 
 import org.jsoup.helper.Validate;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;

--- a/src/main/java/org/jsoup/internal/package-info.java
+++ b/src/main/java/org/jsoup/internal/package-info.java
@@ -2,4 +2,7 @@
  * Util methods used by Jsoup. Please don't depend on the APIs implemented here as the contents may change without
  * notice.
  */
+@NullMarked
 package org.jsoup.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -5,8 +5,8 @@ import org.jsoup.helper.Validate;
 import org.jsoup.internal.Normalizer;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Document.OutputSettings.Syntax;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Map;

--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -4,8 +4,8 @@ import org.jsoup.SerializationException;
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.parser.ParseSettings;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.AbstractSet;

--- a/src/main/java/org/jsoup/nodes/Comment.java
+++ b/src/main/java/org/jsoup/nodes/Comment.java
@@ -2,8 +2,8 @@ package org.jsoup.nodes;
 
 import org.jsoup.parser.ParseSettings;
 import org.jsoup.parser.Parser;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -11,8 +11,8 @@ import org.jsoup.parser.Tag;
 import org.jsoup.select.Elements;
 import org.jsoup.select.Evaluator;
 import org.jsoup.select.Selector;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.util.List;

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -15,8 +15,8 @@ import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
 import org.jsoup.select.QueryParser;
 import org.jsoup.select.Selector;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;

--- a/src/main/java/org/jsoup/nodes/Entities.java
+++ b/src/main/java/org/jsoup/nodes/Entities.java
@@ -6,8 +6,8 @@ import org.jsoup.helper.Validate;
 import org.jsoup.nodes.Document.OutputSettings;
 import org.jsoup.parser.CharacterReader;
 import org.jsoup.parser.Parser;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.CharsetEncoder;
 import java.util.Arrays;

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -6,8 +6,8 @@ import org.jsoup.internal.StringUtil;
 import org.jsoup.select.NodeFilter;
 import org.jsoup.select.NodeTraversor;
 import org.jsoup.select.NodeVisitor;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/org/jsoup/nodes/package-info.java
+++ b/src/main/java/org/jsoup/nodes/package-info.java
@@ -1,7 +1,7 @@
 /**
  HTML document structure nodes.
  */
-@NonnullByDefault
+@NullMarked
 package org.jsoup.nodes;
 
-import org.jsoup.internal.NonnullByDefault;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/jsoup/package-info.java
+++ b/src/main/java/org/jsoup/package-info.java
@@ -1,7 +1,7 @@
 /**
  Contains the main {@link org.jsoup.Jsoup} class, which provides convenient static access to the jsoup functionality.
  */
-@NonnullByDefault
+@NullMarked
 package org.jsoup;
 
-import org.jsoup.internal.NonnullByDefault;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/jsoup/parser/CharacterReader.java
+++ b/src/main/java/org/jsoup/parser/CharacterReader.java
@@ -2,8 +2,8 @@ package org.jsoup.parser;
 
 import org.jsoup.UncheckedIOException;
 import org.jsoup.helper.Validate;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -12,9 +12,8 @@ import org.jsoup.nodes.FormElement;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
 import org.jsoup.parser.Token.StartTag;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -75,7 +74,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
         return new HtmlTreeBuilder();
     }
 
-    @Override @ParametersAreNonnullByDefault
+    @Override
     protected void initialiseParse(Reader input, String baseUri, Parser parser) {
         super.initialiseParse(input, baseUri, parser);
 

--- a/src/main/java/org/jsoup/parser/ParseSettings.java
+++ b/src/main/java/org/jsoup/parser/ParseSettings.java
@@ -1,7 +1,8 @@
 package org.jsoup.parser;
 
 import org.jsoup.nodes.Attributes;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import static org.jsoup.internal.Normalizer.lowerCase;
 
 /**

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -2,8 +2,8 @@ package org.jsoup.parser;
 
 import org.jsoup.helper.Validate;
 import org.jsoup.nodes.Attributes;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 
 /**
  * Parse tokens for the Tokeniser.

--- a/src/main/java/org/jsoup/parser/Tokeniser.java
+++ b/src/main/java/org/jsoup/parser/Tokeniser.java
@@ -3,8 +3,8 @@ package org.jsoup.parser;
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Entities;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
 
 /**

--- a/src/main/java/org/jsoup/parser/TreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilder.java
@@ -6,9 +6,8 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.Range;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,7 +36,6 @@ abstract class TreeBuilder {
 
     private boolean trackSourceRange;  // optionally tracks the source range of nodes
 
-    @ParametersAreNonnullByDefault
     protected void initialiseParse(Reader input, String baseUri, Parser parser) {
         Validate.notNullParam(input, "input");
         Validate.notNullParam(baseUri, "baseUri");
@@ -57,7 +55,6 @@ abstract class TreeBuilder {
         this.baseUri = baseUri;
     }
 
-    @ParametersAreNonnullByDefault
     Document parse(Reader input, String baseUri, Parser parser) {
         initialiseParse(input, baseUri, parser);
         runParser();

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -10,8 +10,8 @@ import org.jsoup.nodes.Entities;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
 import org.jsoup.nodes.XmlDeclaration;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.List;
@@ -30,7 +30,7 @@ public class XmlTreeBuilder extends TreeBuilder {
         return ParseSettings.preserveCase;
     }
 
-    @Override @ParametersAreNonnullByDefault
+    @Override
     protected void initialiseParse(Reader input, String baseUri, Parser parser) {
         super.initialiseParse(input, baseUri, parser);
         stack.add(doc); // place the document onto the stack. differs from HtmlTreeBuilder (not on stack)

--- a/src/main/java/org/jsoup/parser/package-info.java
+++ b/src/main/java/org/jsoup/parser/package-info.java
@@ -1,7 +1,7 @@
 /**
  Contains the HTML parser, tag specifications, and HTML tokeniser.
  */
-@NonnullByDefault
+@NullMarked
 package org.jsoup.parser;
 
-import org.jsoup.internal.NonnullByDefault;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/jsoup/safety/package-info.java
+++ b/src/main/java/org/jsoup/safety/package-info.java
@@ -1,4 +1,7 @@
 /**
  Contains the jsoup HTML cleaner, and safelist definitions.
  */
+@NullMarked
 package org.jsoup.safety;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/jsoup/select/Collector.java
+++ b/src/main/java/org/jsoup/select/Collector.java
@@ -2,8 +2,7 @@ package org.jsoup.select;
 
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
-
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static org.jsoup.select.NodeFilter.FilterResult.CONTINUE;
 import static org.jsoup.select.NodeFilter.FilterResult.STOP;

--- a/src/main/java/org/jsoup/select/CombiningEvaluator.java
+++ b/src/main/java/org/jsoup/select/CombiningEvaluator.java
@@ -2,8 +2,8 @@ package org.jsoup.select;
 
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Element;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -8,8 +8,8 @@ import org.jsoup.nodes.Element;
 import org.jsoup.nodes.FormElement;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -2,8 +2,8 @@ package org.jsoup.select;
 
 import org.jsoup.helper.Validate;
 import org.jsoup.nodes.Element;
+import org.jspecify.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 

--- a/src/main/java/org/jsoup/select/package-info.java
+++ b/src/main/java/org/jsoup/select/package-info.java
@@ -2,7 +2,7 @@
  Packages to support the CSS-style element selector.
  {@link org.jsoup.select.Selector Selector defines the query syntax.}
  */
-@NonnullByDefault
+@NullMarked
 package org.jsoup.select;
 
-import org.jsoup.internal.NonnullByDefault;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -7,5 +7,5 @@ module org.jsoup {
     exports org.jsoup.select;
 
     requires transitive java.xml; // for org.w3c.dom out of W3CDom
-    requires static jsr305; // TODO[must] migrate to another nullable package prior to next release
+    requires static org.jspecify; // TODO[must] migrate to another nullable package prior to next release
 }

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -6,7 +6,6 @@ import org.jsoup.MultiLocaleExtension.MultiLocaleTest;
 import org.jsoup.integration.ParseTest;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.Authenticator;
 import java.net.MalformedURLException;

--- a/src/test/java/org/jsoup/parser/HtmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlTreeBuilderTest.java
@@ -1,14 +1,11 @@
 package org.jsoup.parser;
 
 
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
-
-import javax.annotation.Nonnull;
-import javax.annotation.ParametersAreNonnullByDefault;
 import java.io.Reader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,12 +28,10 @@ public class HtmlTreeBuilderTest {
     }
 
     @Test public void nonnullAssertions() throws NoSuchMethodException {
-        Method parseMethod = TreeBuilder.class.getDeclaredMethod("parse", Reader.class, String.class, Parser.class);
-        assertNotNull(parseMethod);
-        Annotation[] declaredAnnotations = parseMethod.getDeclaredAnnotations();
+        Annotation[] declaredAnnotations = TreeBuilder.class.getPackage().getDeclaredAnnotations();
         boolean seen = false;
         for (Annotation annotation : declaredAnnotations) {
-            if (annotation.annotationType().isAssignableFrom(ParametersAreNonnullByDefault.class))
+            if (annotation.annotationType().isAssignableFrom(NullMarked.class))
                 seen = true;
         }
 


### PR DESCRIPTION
Away from jsr305

With the goal of having a nullability assertion annotation that supports Java modules, so we can release the next version of jsoup.

Annotation options appear limited and does not support @​WillClose, but rest appears OK.

Fixes #2028 
Fixes #1992

Related: #1616