### PR TITLE
Avoid BufferedInputStream synchronized reads

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,12 @@ Release 1.17.1 [PENDING]
     Attribute#sourceRange() provides the ranges.
     <https://github.com/jhy/jsoup/pull/2057>
 
+  * Improvement: when running concurrently under Java 21+ Virtual Threads, virtual threads could be pinned to their
+    carrier platform thread when parsing an input stream. To improve performance, particularly when parsing fetched
+    URLs, the internal ConstrainableInputStream has been replaced by ControllableInputStream, which avoids the locking
+    which caused that pinning.
+    <https://github.com/jhy/jsoup/issues/2054>
+
   * Bugfix: when outputting with XML syntax, HTML elements that were parsed as data nodes (<script> and <style>) should
     be emitted as CDATA nodes, so that they can be parsed correctly by an XML parser.
     <https://github.com/jhy/jsoup/pull/1720>
@@ -51,6 +57,13 @@ Release 1.17.1 [PENDING]
 
   * Build Improvement: added tests for HTTPS request support, using a local self-signed cert. Includes proxy tests.
     <https://github.com/jhy/jsoup/pull/2032>
+
+  * Change: the InputStream returned in Connection.Response.bodyStream() is no longer a ConstrainedInputStream, and
+    so is not subject to settings such as timeout or maximum size. It is now a plain BufferedInputStream around the
+    response stream. Whilst this behaviour was not documented, you may have been inadvertently relying on those
+    constraints. The constraints are still applied to other methods such as .parse() and .bufferUp(). So if you do want
+    a constrained BufferedInputStream, you may do Connection.Response.bufferUp().bodyStream().
+    <https://github.com/jhy/jsoup/issues/2054>
 
 Release 1.16.2 [20-Oct-2023]
   * Improvement: optimized the performance of complex CSS selectors, by adding a cost-based query planner. Evaluators

--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -871,10 +871,15 @@ public interface Connection {
         Response bufferUp();
 
         /**
-         * Get the body of the response as a (buffered) InputStream. You should close the input stream when you're done with it.
-         * Other body methods (like bufferUp, body, parse, etc) will not work in conjunction with this method.
-         * <p>This method is useful for writing large responses to disk, without buffering them completely into memory first.</p>
-         * @return the response body input stream
+         Get the body of the response as a (buffered) InputStream. You should close the input stream when you're done
+         with it.
+         <p>Other body methods (like bufferUp, body, parse, etc) will generally not work in conjunction with this method,
+         as it consumes the InputStream.</p>
+         <p>Any configured max size or maximum read timeout applied to the connection will not be applied to this stream,
+         unless {@link #bufferUp()} is called prior.</p>
+         <p>This method is useful for writing large responses to disk, without buffering them completely into memory
+         first.</p>
+         @return the response body input stream
          */
         BufferedInputStream bodyStream();
     }

--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -1,7 +1,8 @@
 package org.jsoup.helper;
 
-import org.jsoup.internal.ConstrainableInputStream;
+import org.jsoup.internal.ControllableInputStream;
 import org.jsoup.internal.Normalizer;
+import org.jsoup.internal.SharedConstants;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.Document;
@@ -32,6 +33,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
+import static org.jsoup.internal.SharedConstants.DefaultBufferSize;
+
 /**
  * Internal static utilities for handling data.
  *
@@ -42,7 +45,6 @@ public final class DataUtil {
     public static final Charset UTF_8 = Charset.forName("UTF-8"); // Don't use StandardCharsets, as those only appear in Android API 19, and we target 10.
     static final String defaultCharsetName = UTF_8.name(); // used if not found in header or meta charset
     private static final int firstReadBufferSize = 1024 * 5;
-    static final int bufferSize = 1024 * 32;
     private static final char[] mimeBoundaryChars =
             "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
     static final int boundaryLength = 32;
@@ -127,7 +129,7 @@ public final class DataUtil {
      * @throws IOException on IO error
      */
     static void crossStreams(final InputStream in, final OutputStream out) throws IOException {
-        final byte[] buffer = new byte[bufferSize];
+        final byte[] buffer = new byte[DefaultBufferSize];
         int len;
         while ((len = in.read(buffer)) != -1) {
             out.write(buffer, 0, len);
@@ -137,13 +139,13 @@ public final class DataUtil {
     static Document parseInputStream(@Nullable InputStream input, @Nullable String charsetName, String baseUri, Parser parser) throws IOException  {
         if (input == null) // empty body
             return new Document(baseUri);
-        input = ConstrainableInputStream.wrap(input, bufferSize, 0);
+        input = ControllableInputStream.wrap(input, DefaultBufferSize, 0);
 
         @Nullable Document doc = null;
 
         // read the start of the stream and look for a BOM or meta charset
         try {
-            input.mark(bufferSize);
+            input.mark(DefaultBufferSize);
             ByteBuffer firstBytes = readToByteBuffer(input, firstReadBufferSize - 1); // -1 because we read one more to see if completed. First read is < buffer size, so can't be invalid.
             boolean fullyRead = (input.read() == -1);
             input.reset();
@@ -206,7 +208,7 @@ public final class DataUtil {
             if (doc == null) {
                 if (charsetName == null)
                     charsetName = defaultCharsetName;
-                BufferedReader reader = new BufferedReader(new InputStreamReader(input, Charset.forName(charsetName)), bufferSize); // Android level does not allow us try-with-resources
+                BufferedReader reader = new BufferedReader(new InputStreamReader(input, Charset.forName(charsetName)), DefaultBufferSize); // Android level does not allow us try-with-resources
                 try {
                     if (bomCharset != null && bomCharset.offset) { // creating the buffered reader ignores the input pos, so must skip here
                         long skipped = reader.skip(1);
@@ -245,9 +247,7 @@ public final class DataUtil {
      * @throws IOException if an exception occurs whilst reading from the input stream.
      */
     public static ByteBuffer readToByteBuffer(InputStream inStream, int maxSize) throws IOException {
-        Validate.isTrue(maxSize >= 0, "maxSize must be 0 (unlimited) or larger");
-        final ConstrainableInputStream input = ConstrainableInputStream.wrap(inStream, bufferSize, maxSize);
-        return input.readToByteBuffer(maxSize);
+        return ControllableInputStream.readToByteBuffer(inStream, maxSize);
     }
 
     static ByteBuffer emptyByteBuffer() {

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -4,7 +4,8 @@ import org.jsoup.Connection;
 import org.jsoup.HttpStatusException;
 import org.jsoup.UncheckedIOException;
 import org.jsoup.UnsupportedMimeTypeException;
-import org.jsoup.internal.ConstrainableInputStream;
+import org.jsoup.internal.ControllableInputStream;
+import org.jsoup.internal.SharedConstants;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
@@ -787,7 +788,7 @@ public class HttpConnection implements Connection {
         private final int statusCode;
         private final String statusMessage;
         private @Nullable ByteBuffer byteData;
-        private @Nullable InputStream bodyStream;
+        private @Nullable ControllableInputStream bodyStream;
         private @Nullable HttpURLConnection conn;
         private @Nullable String charset;
         private @Nullable final String contentType;
@@ -894,17 +895,15 @@ public class HttpConnection implements Connection {
 
                 res.charset = DataUtil.getCharsetFromContentType(res.contentType); // may be null, readInputStream deals with it
                 if (conn.getContentLength() != 0 && req.method() != HEAD) { // -1 means unknown, chunked. sun throws an IO exception on 500 response with no content when trying to read body
-                    res.bodyStream = conn.getErrorStream() != null ? conn.getErrorStream() : conn.getInputStream();
-                    Validate.notNull(res.bodyStream);
-                    if (res.hasHeaderWithValue(CONTENT_ENCODING, "gzip")) {
-                        res.bodyStream = new GZIPInputStream(res.bodyStream);
-                    } else if (res.hasHeaderWithValue(CONTENT_ENCODING, "deflate")) {
-                        res.bodyStream = new InflaterInputStream(res.bodyStream, new Inflater(true));
-                    }
-                    res.bodyStream = ConstrainableInputStream
-                        .wrap(res.bodyStream, DataUtil.bufferSize, req.maxBodySize())
-                        .timeout(startTime, req.timeout())
-                    ;
+                    InputStream stream = conn.getErrorStream() != null ? conn.getErrorStream() : conn.getInputStream();
+                    if (res.hasHeaderWithValue(CONTENT_ENCODING, "gzip"))
+                        stream = new GZIPInputStream(stream);
+                    else if (res.hasHeaderWithValue(CONTENT_ENCODING, "deflate"))
+                        stream = new InflaterInputStream(stream, new Inflater(true));
+                    
+                    res.bodyStream = ControllableInputStream.wrap(
+                        stream, SharedConstants.DefaultBufferSize, req.maxBodySize())
+                        .timeout(startTime, req.timeout());
                 } else {
                     res.byteData = DataUtil.emptyByteBuffer();
                 }
@@ -951,12 +950,13 @@ public class HttpConnection implements Connection {
 
         public Document parse() throws IOException {
             Validate.isTrue(executed, "Request must be executed (with .execute(), .get(), or .post() before parsing response");
+            InputStream stream = bodyStream;
             if (byteData != null) { // bytes have been read in to the buffer, parse that
-                bodyStream = new ByteArrayInputStream(byteData.array());
+                stream = new ByteArrayInputStream(byteData.array());
                 inputStreamRead = false; // ok to reparse if in bytes
             }
             Validate.isFalse(inputStreamRead, "Input stream already read and parsed, cannot re-read.");
-            Document doc = DataUtil.parseInputStream(bodyStream, charset, url.toExternalForm(), req.parser());
+            Document doc = DataUtil.parseInputStream(stream, charset, url.toExternalForm(), req.parser());
             doc.connection(new HttpConnection(req, this)); // because we're static, don't have the connection obj. // todo - maybe hold in the req?
             charset = doc.outputSettings().charset().name(); // update charset from meta-equiv, possibly
             inputStreamRead = true;
@@ -1006,9 +1006,16 @@ public class HttpConnection implements Connection {
         @Override
         public BufferedInputStream bodyStream() {
             Validate.isTrue(executed, "Request must be executed (with .execute(), .get(), or .post() before getting response body");
+
+            // if we have read to bytes (via buffer up), return those as a stream.
+            if (byteData != null) {
+                return new BufferedInputStream(new ByteArrayInputStream(byteData.array()), SharedConstants.DefaultBufferSize);
+            }
+
             Validate.isFalse(inputStreamRead, "Request has already been read");
+            Validate.notNull(bodyStream);
             inputStreamRead = true;
-            return ConstrainableInputStream.wrap(bodyStream, DataUtil.bufferSize, req.maxBodySize());
+            return bodyStream.inputStream();
         }
 
         // set up connection defaults, and details from request

--- a/src/main/java/org/jsoup/internal/ControllableInputStream.java
+++ b/src/main/java/org/jsoup/internal/ControllableInputStream.java
@@ -1,0 +1,141 @@
+package org.jsoup.internal;
+
+import org.jsoup.helper.DataUtil;
+import org.jsoup.helper.Validate;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+
+import static org.jsoup.internal.SharedConstants.DefaultBufferSize;
+
+/**
+ * A jsoup internal class (so don't use it as there is no contract API) that enables controls on a Buffered Input Stream,
+ * namely a maximum read size, and the ability to Thread.interrupt() the read.
+ */
+// reimplemented from ConstrainableInputStream for JDK21 - extending BufferedInputStream will pin threads during read
+public class ControllableInputStream extends FilterInputStream {
+    private final BufferedInputStream buff;
+    private final boolean capped;
+    private final int maxSize;
+    private long startTime;
+    private long timeout = 0; // optional max time of request
+    private int remaining;
+    private int markPos;
+    private boolean interrupted;
+
+    private ControllableInputStream(BufferedInputStream in, int maxSize) {
+        super(in);
+        Validate.isTrue(maxSize >= 0);
+        buff = in;
+        capped = maxSize != 0;
+        this.maxSize = maxSize;
+        remaining = maxSize;
+        markPos = -1;
+        startTime = System.nanoTime();
+    }
+
+    /**
+     * If this InputStream is not already a ControllableInputStream, let it be one.
+     * @param in the input stream to (maybe) wrap
+     * @param bufferSize the buffer size to use when reading
+     * @param maxSize the maximum size to allow to be read. 0 == infinite.
+     * @return a controllable input stream
+     */
+    public static ControllableInputStream wrap(InputStream in, int bufferSize, int maxSize) {
+        if (in instanceof ControllableInputStream)
+            return (ControllableInputStream) in;
+        else if (in instanceof BufferedInputStream)
+            return new ControllableInputStream((BufferedInputStream) in, maxSize);
+        else
+            return new ControllableInputStream(new BufferedInputStream(in, bufferSize), maxSize);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (interrupted || capped && remaining <= 0)
+            return -1;
+        if (Thread.currentThread().isInterrupted()) {
+            // interrupted latches, because parse() may call twice
+            interrupted = true;
+            return -1;
+        }
+        if (expired())
+            throw new SocketTimeoutException("Read timeout");
+
+        if (capped && len > remaining)
+            len = remaining; // don't read more than desired, even if available
+
+        try {
+            final int read = super.read(b, off, len);
+            remaining -= read;
+            return read;
+        } catch (SocketTimeoutException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Reads this inputstream to a ByteBuffer. The supplied max may be less than the inputstream's max, to support
+     * reading just the first bytes.
+     */
+    public static ByteBuffer readToByteBuffer(InputStream in, int max) throws IOException {
+        Validate.isTrue(max >= 0, "maxSize must be 0 (unlimited) or larger");
+        Validate.notNull(in);
+        final boolean localCapped = max > 0; // still possibly capped in total stream
+        final int bufferSize = localCapped && max < DefaultBufferSize ? max : DefaultBufferSize;
+        final byte[] readBuffer = new byte[bufferSize];
+        final ByteArrayOutputStream outStream = new ByteArrayOutputStream(bufferSize);
+
+        int read;
+        int remaining = max;
+        while (true) {
+            read = in.read(readBuffer, 0, localCapped ? Math.min(remaining, bufferSize) : bufferSize);
+            if (read == -1) break;
+            if (localCapped) { // this local byteBuffer cap may be smaller than the overall maxSize (like when reading first bytes)
+                if (read >= remaining) {
+                    outStream.write(readBuffer, 0, remaining);
+                    break;
+                }
+                remaining -= read;
+            }
+            outStream.write(readBuffer, 0, read);
+        }
+        return ByteBuffer.wrap(outStream.toByteArray());
+    }
+
+    @SuppressWarnings("NonSynchronizedMethodOverridesSynchronizedMethod") // not synchronized in later JDKs
+    @Override public void reset() throws IOException {
+        super.reset();
+        remaining = maxSize - markPos;
+    }
+
+    @SuppressWarnings("NonSynchronizedMethodOverridesSynchronizedMethod") // not synchronized in later JDKs
+    @Override public void mark(int readlimit) {
+        super.mark(readlimit);
+        markPos = maxSize - remaining;
+    }
+
+    public ControllableInputStream timeout(long startTimeNanos, long timeoutMillis) {
+        this.startTime = startTimeNanos;
+        this.timeout = timeoutMillis * 1000000;
+        return this;
+    }
+
+    private boolean expired() {
+        if (timeout == 0)
+            return false;
+
+        final long now = System.nanoTime();
+        final long dur = now - startTime;
+        return (dur > timeout);
+    }
+
+    public BufferedInputStream inputStream() {
+        return buff;
+    }
+}

--- a/src/main/java/org/jsoup/internal/SharedConstants.java
+++ b/src/main/java/org/jsoup/internal/SharedConstants.java
@@ -12,5 +12,7 @@ public final class SharedConstants {
 
     public static final String  AttrRange     = PrivatePrefix + "attrRange.";
 
+    public static final int DefaultBufferSize = 1024 * 32;
+
     private SharedConstants() {}
 }


### PR DESCRIPTION
To avoid pinning a virtual thread to a carrier thread, refactored ConstrainedInputStream into ControllableInputStream, which does not extend BufferedInputStream, but wraps it instead.

Had to provide a deprecation path in ConstrainedInputStream as changing the extends causes a binary backwards compatibility issue. Even though folks shouldn't be using Internal package classes, they may be.

Also enabled bodyStream to return a byte array stream after bufferUp(), in case constrains on the stream are still required.

This does not include a test case for pinning. Verified manually. Would be good to find a way to IT test it.

Fixes #2054 