### PR TITLE
Fix NullPointerException in case a custom document is passed to W3CDom

### DIFF
--- a/src/main/java/org/jsoup/helper/W3CDom.java
+++ b/src/main/java/org/jsoup/helper/W3CDom.java
@@ -360,12 +360,14 @@ public class W3CDom {
             namespacesStack.push(new HashMap<>());
             dest = doc;
             contextElement = (org.jsoup.nodes.Element) doc.getUserData(ContextProperty); // Track the context jsoup Element, so we can save the corresponding w3c element
-            final org.jsoup.nodes.Document inDoc = contextElement.ownerDocument();
-            if (namespaceAware && inDoc != null && inDoc.parser().getTreeBuilder() instanceof HtmlTreeBuilder) {
-              // as per the WHATWG HTML5 spec § 2.1.3, elements are in the HTML namespace by default
-              namespacesStack.peek().put("", Parser.NamespaceHtml);
+            if (contextElement != null) {
+                final org.jsoup.nodes.Document inDoc = contextElement.ownerDocument();
+                if ( namespaceAware && inDoc != null && inDoc.parser().getTreeBuilder() instanceof HtmlTreeBuilder ) {
+                    // as per the WHATWG HTML5 spec § 2.1.3, elements are in the HTML namespace by default
+                    namespacesStack.peek().put("", Parser.NamespaceHtml);
+                }
             }
-          }
+        }
 
         public void head(org.jsoup.nodes.Node source, int depth) {
             namespacesStack.push(new HashMap<>(namespacesStack.peek())); // inherit from above on the stack

--- a/src/test/java/org/jsoup/helper/W3CDomTest.java
+++ b/src/test/java/org/jsoup/helper/W3CDomTest.java
@@ -13,6 +13,7 @@ import org.xml.sax.InputSource;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
@@ -185,6 +186,20 @@ public class W3CDomTest {
         Document w3Doc = W3CDom.convert(jsoup);
         String xml = W3CDom.asString(w3Doc, W3CDom.OutputXml());
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><html xmlns=\"http://www.w3.org/1999/xhtml\"><head/><body>&lt;インセンティブで高収入！&gt;Text <p>More</p></body></html>", xml);
+    }
+
+    @Test
+    public void canConvertToCustomDocument() throws ParserConfigurationException {
+        org.jsoup.nodes.Document document = Jsoup.parse("<html><div></div></html>");
+
+        DocumentBuilderFactory localDocumentBuilderFactory = DocumentBuilderFactory.newInstance();
+        Document customDocumentResult = localDocumentBuilderFactory.newDocumentBuilder().newDocument();
+
+        W3CDom w3cDom = new W3CDom();
+        w3cDom.convert(document, customDocumentResult);
+
+        String html = W3CDom.asString(customDocumentResult, W3CDom.OutputHtml());
+        assertEquals("<html><head><META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></head><body><div></div></body></html>", html);
     }
 
     @Test


### PR DESCRIPTION
When we provide a custom output `Document` to `W3CDom#convert`, we receive a `NullPointerException` in the `W3CBuilder` constructor.

I've added a test that demonstrates the behavior. Here's the stacktrace from that test without the applied fix.

```
java.lang.NullPointerException: Cannot invoke "org.jsoup.nodes.Element.ownerDocument()" because "this.contextElement" is null

	at org.jsoup.helper.W3CDom$W3CBuilder.<init>(W3CDom.java:364)
	at org.jsoup.helper.W3CDom.convert(W3CDom.java:250)
	at org.jsoup.helper.W3CDom.convert(W3CDom.java:238)
	at org.jsoup.helper.W3CDomTest.canConvertToCustomDocument(W3CDomTest.java:199)
```