### PR TITLE
Improve buffer management throughout the load/fetch and parse lifecycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
                 <ignore>java.util.Set</ignore> <!-- Set#stream() -->
                 <ignore>java.util.Spliterator</ignore>
                 <ignore>java.util.Spliterators</ignore>
+                <ignore>java.nio.ByteBuffer</ignore> <!-- .flip(); added in API1; possibly due to .flip previously returning Buffer, later ByteBuffer; return unused -->
 
                 <ignore>java.net.HttpURLConnection</ignore><!-- .setAuthenticator(java.net.Authenticator) in Java 9; only used in multirelease 9+ version -->
               </ignores>

--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -318,7 +318,7 @@ public final class DataUtil {
         Validate.notNull(input);
         final Document doc;
         final Charset charset = charsetDoc.charset;
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, charset), DefaultBufferSize)) {
+        try (Reader reader = new InputStreamReader(input, charset)) {
             maybeSkipBom(reader, charsetDoc);
             try {
                 doc = parser.parseInput(reader, baseUri);

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -7,7 +7,6 @@ import org.jsoup.UncheckedIOException;
 import org.jsoup.UnsupportedMimeTypeException;
 import org.jsoup.internal.ControllableInputStream;
 import org.jsoup.internal.Functions;
-import org.jsoup.internal.SharedConstants;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
@@ -998,7 +997,6 @@ public class HttpConnection implements Connection {
             // set up the stream parser and rig this connection up to the parsed doc:
             StreamParser streamer = new StreamParser(req.parser());
             BufferedReader reader = new BufferedReader(new InputStreamReader(stream, charsetDoc.charset));
-            DataUtil.maybeSkipBom(reader, charsetDoc);
             streamer.parse(reader, baseUri); // initializes the parse and the document, but does not step() it
             streamer.document().connection(new HttpConnection(req, this));
             charset = charsetDoc.charset.name();

--- a/src/main/java/org/jsoup/internal/ControllableInputStream.java
+++ b/src/main/java/org/jsoup/internal/ControllableInputStream.java
@@ -5,7 +5,6 @@ import org.jsoup.helper.Validate;
 import org.jspecify.annotations.Nullable;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/org/jsoup/internal/ControllableInputStream.java
+++ b/src/main/java/org/jsoup/internal/ControllableInputStream.java
@@ -14,19 +14,19 @@ import java.nio.ByteBuffer;
 import static org.jsoup.internal.SharedConstants.DefaultBufferSize;
 
 /**
- * A jsoup internal class (so don't use it as there is no contract API) that enables controls on a Buffered Input Stream,
+ * A jsoup internal class (so don't use it as there is no contract API) that enables controls on a buffered input stream,
  * namely a maximum read size, and the ability to Thread.interrupt() the read.
  */
 // reimplemented from ConstrainableInputStream for JDK21 - extending BufferedInputStream will pin threads during read
 public class ControllableInputStream extends FilterInputStream {
-    private final InputStream buff;
-    private final boolean capped;
-    private final int maxSize;
+    private final SimpleBufferedInput buff; // super.in, but typed as SimpleBufferedInput
+    private int maxSize;
     private long startTime;
     private long timeout = 0; // optional max time of request
     private int remaining;
     private int markPos;
     private boolean interrupted;
+    private boolean allowClose = true; // for cases where we want to re-read the input, can ignore .close() from the parser
 
     // if we are tracking progress, will have the expected content length, progress callback, connection
     private @Nullable Progress<?> progress;
@@ -34,15 +34,28 @@ public class ControllableInputStream extends FilterInputStream {
     private int contentLength = -1;
     private int readPos = 0; // amount read; can be reset()
 
-    private ControllableInputStream(InputStream in, int maxSize) {
+    private ControllableInputStream(SimpleBufferedInput in, int maxSize) {
         super(in);
         Validate.isTrue(maxSize >= 0);
         buff = in;
-        capped = maxSize != 0;
         this.maxSize = maxSize;
         remaining = maxSize;
         markPos = -1;
         startTime = System.nanoTime();
+    }
+
+    /**
+     * If this InputStream is not already a ControllableInputStream, let it be one.
+     * @param in the input stream to (maybe) wrap
+     * @param maxSize the maximum size to allow to be read. 0 == infinite.
+     * @return a controllable input stream
+     */
+    public static ControllableInputStream wrap(InputStream in, int maxSize) {
+        // bufferSize currently unused; consider implementing as a min size in the SoftPool recycler
+        if (in instanceof ControllableInputStream)
+            return (ControllableInputStream) in;
+        else
+            return new ControllableInputStream(new SimpleBufferedInput(in), maxSize);
     }
 
     /**
@@ -53,19 +66,15 @@ public class ControllableInputStream extends FilterInputStream {
      * @return a controllable input stream
      */
     public static ControllableInputStream wrap(InputStream in, int bufferSize, int maxSize) {
-        // bufferSize currently unused; consider implementing as a min size in the SoftPool recycler
-        if (in instanceof ControllableInputStream)
-            return (ControllableInputStream) in;
-        else if (in instanceof BufferedInputStream)
-            return new ControllableInputStream(in, maxSize);
-        else
-            return new ControllableInputStream(new SimpleBufferedInput(in), maxSize);
+        // todo - bufferSize currently unused; consider implementing as a min size in the SoftPool recycler; or just deprecate if always DefaultBufferSize
+        return wrap(in, maxSize);
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         if (readPos == 0) emitProgress(); // emits a progress
-        
+
+        boolean capped = maxSize != 0;
         if (interrupted || capped && remaining <= 0)
             return -1;
         if (Thread.currentThread().isInterrupted()) {
@@ -73,27 +82,28 @@ public class ControllableInputStream extends FilterInputStream {
             interrupted = true;
             return -1;
         }
-        if (expired())
-            throw new SocketTimeoutException("Read timeout");
 
         if (capped && len > remaining)
             len = remaining; // don't read more than desired, even if available
 
-        try {
-            final int read = super.read(b, off, len);
-            if (read == -1) { // completed
-                contentLength = readPos;
-            } else {
-                remaining -= read;
-                readPos += read;
-            }
-            emitProgress();
-
-            return read;
-        } catch (SocketTimeoutException e) {
+        while (true) { // loop trying to read until we get some data or hit the overall timeout, if we have one
             if (expired())
-                throw e;
-            return 0;
+                throw new SocketTimeoutException("Read timeout");
+
+            try {
+                final int read = super.read(b, off, len);
+                if (read == -1) { // completed
+                    contentLength = readPos;
+                } else {
+                    remaining -= read;
+                    readPos += read;
+                }
+                emitProgress();
+                return read;
+            } catch (SocketTimeoutException e) {
+                if (expired() || timeout == 0)
+                    throw e;
+            }
         }
     }
 
@@ -146,6 +156,36 @@ public class ControllableInputStream extends FilterInputStream {
         markPos = maxSize - remaining;
     }
 
+    /**
+     Check if the underlying InputStream has been read fully. There may still content in buffers to be consumed, and
+     read methods may return -1 if hit the read limit.
+     @return true if the underlying inputstream has been read fully.
+     */
+    public boolean baseReadFully() {
+        return buff.baseReadFully();
+    }
+
+    /**
+     Get the max size of this stream (how far at most will be read from the underlying stream)
+     * @return the max size
+     */
+    public int max() {
+        return maxSize;
+    }
+
+    public void max(int newMax) {
+        remaining += newMax - maxSize; // update remaining to reflect the difference in the new maxsize
+        maxSize = newMax;
+    }
+
+    public void allowClose(boolean allowClose) {
+        this.allowClose = allowClose;
+    }
+
+    @Override public void close() throws IOException {
+        if (allowClose) super.close();
+    }
+
     public ControllableInputStream timeout(long startTimeNanos, long timeoutMillis) {
         this.startTime = startTimeNanos;
         this.timeout = timeoutMillis * 1000000;
@@ -181,8 +221,6 @@ public class ControllableInputStream extends FilterInputStream {
 
     public BufferedInputStream inputStream() {
         // called via HttpConnection.Response.bodyStream(), needs an OG BufferedInputStream
-        if (buff instanceof BufferedInputStream)
-            return (BufferedInputStream) buff; // if originally supplied a BIS in .wrap()
-        else return new BufferedInputStream(buff);
+        return new BufferedInputStream(buff);
     }
 }

--- a/src/main/java/org/jsoup/internal/SharedConstants.java
+++ b/src/main/java/org/jsoup/internal/SharedConstants.java
@@ -10,7 +10,7 @@ public final class SharedConstants {
     public static final String RangeKey = "jsoup.start";
     public static final String EndRangeKey = "jsoup.end";
 
-    public static final int DefaultBufferSize = 1024 * 32;
+    public static final int DefaultBufferSize = 8 * 1024;
 
     public static final String[] FormSubmitTags = {
         "input", "keygen", "object", "select", "textarea"

--- a/src/main/java/org/jsoup/internal/SimpleBufferedInput.java
+++ b/src/main/java/org/jsoup/internal/SimpleBufferedInput.java
@@ -1,0 +1,132 @@
+package org.jsoup.internal;
+
+import org.jsoup.helper.Validate;
+import org.jspecify.annotations.Nullable;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.jsoup.internal.SharedConstants.DefaultBufferSize;
+
+/**
+ A simple implemented of a buffered input stream, in which we can control the byte[] buffer to recycle it. Not safe for
+ use between threads; no sync or locks. The buffer is borrowed on initial demand in fill. */
+class SimpleBufferedInput extends FilterInputStream {
+    static final int BufferSize = DefaultBufferSize;
+    static final SoftPool<byte[]> BufferPool = new SoftPool<>(() -> new byte[BufferSize]);
+
+    byte @Nullable [] byteBuf; // the byte buffer; recycled via SoftPool. Created in fill if required
+    int bufPos;
+    int bufLength;
+    int bufMark = -1;
+
+    SimpleBufferedInput(InputStream in) {
+        super(in);
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (bufPos >= bufLength) {
+            fill();
+            if (bufPos >= bufLength)
+                return -1;
+        }
+        return getBuf()[bufPos++] & 0xff;
+    }
+
+    @Override
+    public int read(byte[] dest, int offset, int desiredLen) throws IOException {
+        Validate.notNull(dest);
+        if (offset < 0 || desiredLen < 0 || desiredLen > dest.length - offset) {
+            throw new IndexOutOfBoundsException();
+        } else if (desiredLen == 0) {
+            return 0;
+        }
+
+        int bufAvail = bufLength - bufPos;
+        if (bufAvail <= 0) {
+            if (desiredLen >= BufferSize && bufMark < 0) {
+                // We can skip creating / copying into a local buffer; just pass through
+                return in.read(dest, offset, desiredLen);
+            }
+            fill();
+            bufAvail = bufLength - bufPos;
+        }
+
+        int read = Math.min(bufAvail, desiredLen);
+        if (read <= 0) {
+            return -1;
+        }
+
+        System.arraycopy(getBuf(), bufPos, dest, offset, read);
+        bufPos += read;
+        return read;
+    }
+
+    private void fill() throws IOException {
+        if (byteBuf == null) { // get one on first demand
+            byteBuf = BufferPool.borrow();
+        }
+
+        if (bufMark < 0) { // no mark, can lose buffer (assumes we've read to bufLen)
+            bufPos = 0;
+        } else if (bufPos >= BufferSize) { // no room left in buffer
+            if (bufMark > 0) { // can throw away early part of the buffer
+                int size = bufPos - bufMark;
+                System.arraycopy(byteBuf, bufMark, byteBuf, 0, size);
+                bufPos = size;
+                bufMark = 0;
+            } else { // invalidate mark
+                bufMark = -1;
+                bufPos = 0;
+            }
+        }
+        bufLength = bufPos;
+        int read = in.read(byteBuf, bufPos, byteBuf.length - bufPos);
+        if (read > 0) {
+            bufLength = read + bufPos;
+            while (byteBuf.length - bufLength > 0) { // read in more if we have space, without blocking
+                if (in.available() < 1) break;
+                read = in.read(byteBuf, bufLength, byteBuf.length - bufLength);
+                if (read <= 0) break;
+                bufLength += read;
+            }
+        }
+    }
+
+    byte[] getBuf() {
+        Validate.notNull(byteBuf);
+        return byteBuf;
+    }
+
+    @Override
+    public int available() throws IOException {
+        if (byteBuf != null && bufLength - bufPos > 0)
+            return bufLength - bufPos; // doesn't include those in.available(), but mostly used as a block test
+        return in.available();
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        if (readlimit > BufferSize) {
+            throw new IllegalArgumentException("Read-ahead limit is greater than buffer size");
+        }
+        bufMark = bufPos;
+    }
+
+    @Override
+    public void reset() throws IOException {
+        if (bufMark < 0)
+            throw new IOException("Resetting to invalid mark");
+        bufPos = bufMark;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        if (byteBuf == null) return; // already closed, or never allocated
+        BufferPool.release(byteBuf); // return the buffer to the pool
+        byteBuf = null; // NPE further attempts to read
+    }
+}

--- a/src/main/java/org/jsoup/internal/SimpleBufferedInput.java
+++ b/src/main/java/org/jsoup/internal/SimpleBufferedInput.java
@@ -11,15 +11,17 @@ import static org.jsoup.internal.SharedConstants.DefaultBufferSize;
 
 /**
  A simple implemented of a buffered input stream, in which we can control the byte[] buffer to recycle it. Not safe for
- use between threads; no sync or locks. The buffer is borrowed on initial demand in fill. */
+ use between threads; no sync or locks. The buffer is borrowed on initial demand in fill.
+ @since 1.18.2
+ */
 class SimpleBufferedInput extends FilterInputStream {
     static final int BufferSize = DefaultBufferSize;
     static final SoftPool<byte[]> BufferPool = new SoftPool<>(() -> new byte[BufferSize]);
 
-    byte @Nullable [] byteBuf; // the byte buffer; recycled via SoftPool. Created in fill if required
-    int bufPos;
-    int bufLength;
-    int bufMark = -1;
+    private byte @Nullable [] byteBuf; // the byte buffer; recycled via SoftPool. Created in fill if required
+    private int bufPos;
+    private int bufLength;
+    private int bufMark = -1;
 
     SimpleBufferedInput(InputStream in) {
         super(in);
@@ -107,6 +109,7 @@ class SimpleBufferedInput extends FilterInputStream {
         return in.available();
     }
 
+    @SuppressWarnings("NonSynchronizedMethodOverridesSynchronizedMethod") // explicitly not synced
     @Override
     public void mark(int readlimit) {
         if (readlimit > BufferSize) {
@@ -115,6 +118,7 @@ class SimpleBufferedInput extends FilterInputStream {
         bufMark = bufPos;
     }
 
+    @SuppressWarnings("NonSynchronizedMethodOverridesSynchronizedMethod") // explicitly not synced
     @Override
     public void reset() throws IOException {
         if (bufMark < 0)

--- a/src/main/java/org/jsoup/internal/SoftPool.java
+++ b/src/main/java/org/jsoup/internal/SoftPool.java
@@ -10,7 +10,7 @@ import java.util.function.Supplier;
  they are no longer in use.
  <p>Like a ThreadLocal, should be stored in a static field.</p>
  @param <T> the type of object to pool.
- @since 1.18.1
+ @since 1.18.2
  */
 public class SoftPool<T> {
     final ThreadLocal<SoftReference<Stack<T>>> threadLocalStack;

--- a/src/main/java/org/jsoup/internal/SoftPool.java
+++ b/src/main/java/org/jsoup/internal/SoftPool.java
@@ -1,0 +1,66 @@
+package org.jsoup.internal;
+
+import java.lang.ref.SoftReference;
+import java.util.Stack;
+import java.util.function.Supplier;
+
+/**
+ A SoftPool is a ThreadLocal that holds a SoftReference to a pool of initializable objects. This allows us to reuse
+ expensive objects (buffers, etc.) between invocations (the ThreadLocal), but also for those objects to be reaped if
+ they are no longer in use.
+ <p>Like a ThreadLocal, should be stored in a static field.</p>
+ @param <T> the type of object to pool.
+ @since 1.18.1
+ */
+public class SoftPool<T> {
+    final ThreadLocal<SoftReference<Stack<T>>> threadLocalStack;
+    private final Supplier<T> initializer;
+    /**
+     How many total uses of the creating object might be instantiated on the same thread at once. More than this and
+     those objects aren't recycled. Doesn't need to be too conservative, as they can still be GCed as SoftRefs.
+     */
+    static final int MaxIdle = 12;
+
+    /**
+     Create a new SoftPool.
+     @param initializer a supplier that creates a new object when one is needed.
+     */
+    public SoftPool(Supplier<T> initializer) {
+        this.initializer = initializer;
+        this.threadLocalStack = ThreadLocal.withInitial(() -> new SoftReference<>(new Stack<>()));
+    }
+
+    /**
+     Borrow an object from the pool, creating a new one if the pool is empty. Make sure to release it back to the pool
+     when done, so that it can be reused.
+     @return an object from the pool, as defined by the initializer.
+     */
+    public T borrow() {
+        Stack<T> stack = getStack();
+        if (!stack.isEmpty()) {
+            return stack.pop();
+        }
+        return initializer.get();
+    }
+
+    /**
+     Release an object back to the pool. If the pool is full, the object is not retained. If you don't want to reuse a
+     borrowed object (for e.g. a StringBuilder that grew too large), just don't release it.
+     @param value the object to release back to the pool.
+     */
+    public void release(T value) {
+        Stack<T> stack = getStack();
+        if (stack.size() < MaxIdle) {
+            stack.push(value);
+        }
+    }
+
+    Stack<T> getStack() {
+        Stack<T> stack = threadLocalStack.get().get();
+        if (stack == null) {
+            stack = new Stack<>();
+            threadLocalStack.set(new SoftReference<>(stack));
+        }
+        return stack;
+    }
+}

--- a/src/main/java/org/jsoup/parser/CharacterReader.java
+++ b/src/main/java/org/jsoup/parser/CharacterReader.java
@@ -17,34 +17,35 @@ import java.util.Locale;
  */
 public final class CharacterReader {
     static final char EOF = (char) -1;
-    private static final int maxStringCacheLen = 12;
-    static final int maxBufferLen = 1024 * 32; // visible for testing
-    static final int readAheadLimit = (int) (maxBufferLen * 0.75); // visible for testing
-    private static final int minReadAheadLen = 1024; // the minimum mark length supported. No HTML entities can be larger than this.
+    private static final int MaxStringCacheLen = 12;
+    private static final int StringCacheSize = 512;
+    private String[] stringCache = new String[StringCacheSize]; // holds reused strings in this doc, to lessen garbage
 
-    private char[] charBuf;
-    private Reader reader;
-    private int bufLength;
-    private int bufSplitPoint;
-    private int bufPos;
-    private int readerPos;
-    private int bufMark = -1;
-    private static final int stringCacheSize = 512;
-    private String[] stringCache = new String[stringCacheSize]; // holds reused strings in this doc, to lessen garbage
+    static final int BufferSize = 1024 * 2;         // visible for testing
+    static final int RefillPoint = BufferSize / 2;  // when bufPos characters read, refill; visible for testing
+    private static final int RewindLimit = 1024;    // the maximum we can rewind. No HTML entities can be larger than this.
+
+    private Reader reader;      // underlying Reader, will be backed by a buffered+controlled input stream, or StringReader
+    private char[] charBuf;     // character buffer we consume from; filled from Reader
+    private int bufPos;         // position in charBuf that's been consumed to
+    private int bufLength;      // the num of characters actually buffered in charBuf, <= charBuf.length
+    private int fillPoint = 0;  // how far into the charBuf we read before re-filling. 0.5 of charBuf.length after bufferUp
+    private int consumed;       // how many characters total have been consumed from this CharacterReader (less the current bufPos)
+    private int bufMark = -1;   // if not -1, the marked rewind position
+    private boolean readFully;  // if the underlying stream has been completely read, no value in further buffering
 
     @Nullable private ArrayList<Integer> newlinePositions = null; // optionally track the pos() position of newlines - scans during bufferUp()
     private int lineNumberOffset = 1; // line numbers start at 1; += newlinePosition[indexof(pos)]
 
     public CharacterReader(Reader input, int sz) {
         Validate.notNull(input);
-        Validate.isTrue(input.markSupported(), "The supplied Reader must support mark(), but does not.");
         reader = input;
-        charBuf = new char[Math.min(sz, maxBufferLen)];
+        charBuf = new char[BufferSize]; // todo - recycle this
         bufferUp();
     }
 
     public CharacterReader(Reader input) {
-        this(input, maxBufferLen);
+        this(input, BufferSize);
     }
 
     public CharacterReader(String input) {
@@ -64,48 +65,63 @@ public final class CharacterReader {
         }
     }
 
-    private boolean readFully; // if the underlying stream has been completely read, no value in further buffering
     private void bufferUp() {
-        if (readFully || bufPos < bufSplitPoint)
+        if (readFully || bufPos < fillPoint || bufMark != -1)
             return;
+        doBufferUp(); // structured so bufferUp may become an intrinsic candidate
+    }
 
-        final int pos;
-        final int offset;
-        if (bufMark != -1) {
-            pos = bufMark;
-            offset = bufPos - bufMark;
-        } else {
-            pos = bufPos;
-            offset = 0;
-        }
-
-        try {
-            final long skipped = reader.skip(pos);
-            reader.mark(maxBufferLen);
-            int read = 0;
-            while (read <= minReadAheadLen) {
-                int thisRead = reader.read(charBuf, read, charBuf.length - read);
-                if (thisRead == -1)
+    private void doBufferUp() {
+        /*
+        The flow:
+        - if read fully, or if bufPos < fillPoint, or if marked - do not fill.
+        - update readerPos (total amount consumed from this CharacterReader) += bufPos
+        - shift charBuf contents such that bufPos = 0; set next read offset (bufLength) -= shift amount
+        - loop read the Reader until we fill charBuf. bufLength += read.
+        - readFully = true when read = -1
+         */
+        consumed += bufPos;
+        bufLength -= bufPos;
+        if (bufLength > 0)
+            System.arraycopy(charBuf, bufPos, charBuf, 0, bufLength);
+        bufPos = 0;
+        while (bufLength < BufferSize) {
+            try {
+                int read = reader.read(charBuf, bufLength, charBuf.length - bufLength);
+                if (read == -1) {
                     readFully = true;
-                if (thisRead <= 0)
                     break;
-                read += thisRead;
+                }
+                bufLength += read;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
-            reader.reset();
-            if (read > 0) {
-                Validate.isTrue(skipped == pos); // Previously asserted that there is room in buf to skip, so this will be a WTF
-                bufLength = read;
-                readerPos += pos;
-                bufPos = offset;
-                if (bufMark != -1)
-                    bufMark = 0;
-                bufSplitPoint = Math.min(bufLength, readAheadLimit);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
+        fillPoint = Math.min(bufLength, RefillPoint);
+
         scanBufferForNewlines(); // if enabled, we index newline positions for line number tracking
         lastIcSeq = null; // cache for last containsIgnoreCase(seq)
+    }
+
+    void mark() {
+        // make sure there is enough look ahead capacity
+        if (bufLength - bufPos < RewindLimit)
+            fillPoint = 0;
+
+        bufferUp();
+        bufMark = bufPos;
+    }
+
+    void unmark() {
+        bufMark = -1;
+    }
+
+    void rewindToMark() {
+        if (bufMark == -1)
+            throw new UncheckedIOException(new IOException("Mark invalid"));
+
+        bufPos = bufMark;
+        unmark();
     }
 
     /**
@@ -113,7 +129,7 @@ public final class CharacterReader {
      * @return current position
      */
     public int pos() {
-        return readerPos + bufPos;
+        return consumed + bufPos;
     }
 
     /** Tests if the buffer has been fully read. */
@@ -131,7 +147,7 @@ public final class CharacterReader {
      */
     public void trackNewlines(boolean track) {
         if (track && newlinePositions == null) {
-            newlinePositions = new ArrayList<>(maxBufferLen / 80); // rough guess of likely count
+            newlinePositions = new ArrayList<>(BufferSize / 80); // rough guess of likely count
             scanBufferForNewlines(); // first pass when enabled; subsequently called during bufferUp
         }
         else if (!track)
@@ -216,7 +232,7 @@ public final class CharacterReader {
 
         if (newlinePositions.size() > 0) {
             // work out the line number that we have read up to (as we have likely scanned past this point)
-            int index = lineNumIndex(readerPos);
+            int index = lineNumIndex(consumed);
             if (index == -1) index = 0; // first line
             int linePos = newlinePositions.get(index);
             lineNumberOffset += index; // the num lines we've read up to
@@ -226,7 +242,7 @@ public final class CharacterReader {
 
         for (int i = bufPos; i < bufLength; i++) {
             if (charBuf[i] == '\n')
-                newlinePositions.add(1 + readerPos + i);
+                newlinePositions.add(1 + consumed + i);
         }
     }
 
@@ -274,27 +290,6 @@ public final class CharacterReader {
      */
     public void advance() {
         bufPos++;
-    }
-
-    void mark() {
-        // make sure there is enough look ahead capacity
-        if (bufLength - bufPos < minReadAheadLen)
-            bufSplitPoint = 0;
-
-        bufferUp();
-        bufMark = bufPos;
-    }
-
-    void unmark() {
-        bufMark = -1;
-    }
-
-    void rewindToMark() {
-        if (bufMark == -1)
-            throw new UncheckedIOException(new IOException("Mark invalid"));
-
-        bufPos = bufMark;
-        unmark();
     }
 
     /**
@@ -717,7 +712,7 @@ public final class CharacterReader {
      */
     private static String cacheString(final char[] charBuf, final String[] stringCache, final int start, final int count) {
         // limit (no cache):
-        if (count > maxStringCacheLen)
+        if (count > MaxStringCacheLen)
             return new String(charBuf, start, count);
         if (count < 1)
             return "";
@@ -729,7 +724,7 @@ public final class CharacterReader {
         }
 
         // get from cache
-        final int index = hash & stringCacheSize - 1;
+        final int index = hash & StringCacheSize - 1;
         String cached = stringCache[index];
 
         if (cached != null && rangeEquals(charBuf, start, count, cached)) // positive hit

--- a/src/test/java/org/jsoup/helper/DataUtilTest.java
+++ b/src/test/java/org/jsoup/helper/DataUtilTest.java
@@ -331,7 +331,7 @@ public class DataUtilTest {
         VaryingReadInputStream stream = new VaryingReadInputStream(ParseTest.inputStreamFrom(input));
 
         ByteBuffer byteBuffer = DataUtil.readToByteBuffer(stream, 0);
-        String read = new String(byteBuffer.array());
+        String read = new String(byteBuffer.array(), 0, byteBuffer.limit(), StandardCharsets.UTF_8);
 
         assertEquals(input, read);
     }

--- a/src/test/java/org/jsoup/helper/DataUtilTest.java
+++ b/src/test/java/org/jsoup/helper/DataUtilTest.java
@@ -2,6 +2,7 @@ package org.jsoup.helper;
 
 import org.jsoup.Jsoup;
 import org.jsoup.integration.ParseTest;
+import org.jsoup.internal.ControllableInputStream;
 import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 import org.junit.jupiter.api.Test;
@@ -37,12 +38,12 @@ public class DataUtilTest {
         assertEquals("UTF-8", DataUtil.getCharsetFromContentType("text/html; charset='UTF-8'"));
     }
 
-    private InputStream stream(String data) {
-        return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
+    private ControllableInputStream stream(String data) {
+        return ControllableInputStream.wrap(new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8)), 0);
     }
 
-    private InputStream stream(String data, String charset) {
-        return new ByteArrayInputStream(data.getBytes(Charset.forName(charset)));
+    private ControllableInputStream stream(String data, String charset) {
+        return ControllableInputStream.wrap(new ByteArrayInputStream(data.getBytes(Charset.forName(charset))), 0);
     }
 
     @Test
@@ -143,7 +144,8 @@ public class DataUtilTest {
                 stream(firstPart),
                 stream(secondPart)
         );
-        Document doc = DataUtil.parseInputStream(sequenceStream, null, "", Parser.htmlParser());
+        ControllableInputStream stream = ControllableInputStream.wrap(sequenceStream, 0);
+        Document doc = DataUtil.parseInputStream(stream, null, "", Parser.htmlParser());
         assertEquals(fileContent, doc.outerHtml());
     }
 

--- a/src/test/java/org/jsoup/integration/ConnectIT.java
+++ b/src/test/java/org/jsoup/integration/ConnectIT.java
@@ -54,6 +54,7 @@ public class ConnectIT {
     @Test
     public void canInterruptDocumentRead() throws InterruptedException {
         // todo - implement in interruptable channels, so it's immediate
+        long start = System.currentTimeMillis();
         final String[] body = new String[1];
         Thread runner = new Thread(() -> {
             try {
@@ -68,12 +69,15 @@ public class ConnectIT {
         });
 
         runner.start();
-        Thread.sleep(1000 * 3);
+        Thread.sleep(3 * 1000);
         runner.interrupt();
         assertTrue(runner.isInterrupted());
         runner.join();
 
-        assertEquals(0, body[0].length()); // doesn't read a failed doc
+        long end = System.currentTimeMillis();
+        // check we are between 3 and connect timeout seconds (should be just over 3; but allow some slack for slow CI runners)
+        assertTrue(end - start > 3 * 1000);
+        assertTrue(end - start < 10 * 1000);
     }
 
     @Test public void canInterruptThenJoinASpawnedThread() throws InterruptedException {

--- a/src/test/java/org/jsoup/integration/ConnectTest.java
+++ b/src/test/java/org/jsoup/integration/ConnectTest.java
@@ -33,6 +33,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -603,13 +604,22 @@ public class ConnectTest {
 
     @Test
     public void canFetchBinaryAsBytes() throws IOException {
-        Connection.Response res = Jsoup.connect(FileServlet.urlTo("/htmltests/thumb.jpg"))
+        String path = "/htmltests/thumb.jpg";
+        int actualSize = 1052;
+
+        Connection.Response res = Jsoup.connect(FileServlet.urlTo(path))
             .data(FileServlet.ContentTypeParam, "image/jpeg")
             .ignoreContentType(true)
             .execute();
 
-        byte[] bytes = res.bodyAsBytes();
-        assertEquals(1052, bytes.length);
+        byte[] resBytes = res.bodyAsBytes();
+        assertEquals(actualSize, resBytes.length);
+
+        // compare the content of the file and the bytes:
+        Path filePath = ParseTest.getPath(path);
+        byte[] fileBytes = Files.readAllBytes(filePath);
+        assertEquals(actualSize, fileBytes.length);
+        assertArrayEquals(fileBytes, resBytes);
     }
 
     @Test

--- a/src/test/java/org/jsoup/integration/ConnectTest.java
+++ b/src/test/java/org/jsoup/integration/ConnectTest.java
@@ -1006,8 +1006,14 @@ public class ConnectTest {
 
         // should expect to see events relative to how large the buffer is.
         int expected = LargeDocFileLen / 8192;
-        assertTrue(numProgress.get() > expected * 0.75);
-        assertTrue(numProgress.get() < expected * 1.25);
+
+        int num = numProgress.get();
+        // debug log if not in those ranges:
+        if (num < expected * 0.75 || num > expected * 1.25) {
+            System.err.println("Expected: " + expected + ", got: " + num);
+        }
+        assertTrue(num > expected * 0.75);
+        assertTrue(num < expected * 1.25);
 
         // check the document works
         assertEquals(LargeDocTextLen, document.text().length());

--- a/src/test/java/org/jsoup/integration/ParseTest.java
+++ b/src/test/java/org/jsoup/integration/ParseTest.java
@@ -153,7 +153,8 @@ public class ParseTest {
         if (file.getName().endsWith(".gz")) {
             InputStream stream = new GZIPInputStream(new FileInputStream(file));
             ByteBuffer byteBuffer = DataUtil.readToByteBuffer(stream, 0);
-            bytes = byteBuffer.array();
+            bytes = new byte[byteBuffer.limit()];
+            System.arraycopy(byteBuffer.array(), 0, bytes, 0, byteBuffer.limit());
         } else {
             bytes = Files.readAllBytes(file.toPath());
         }

--- a/src/test/java/org/jsoup/integration/servlets/EchoServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/EchoServlet.java
@@ -90,7 +90,7 @@ public class EchoServlet extends BaseServlet {
 
         // post body
         ByteBuffer byteBuffer = DataUtil.readToByteBuffer(req.getInputStream(), 0);
-        String postData = new String(byteBuffer.array(), StandardCharsets.UTF_8);
+        String postData = new String(byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.limit(), StandardCharsets.UTF_8);
         if (!StringUtil.isBlank(postData)) {
             write(w, "Post Data", postData);
         }

--- a/src/test/java/org/jsoup/integration/servlets/InterruptedServlet.java
+++ b/src/test/java/org/jsoup/integration/servlets/InterruptedServlet.java
@@ -27,8 +27,8 @@ public class InterruptedServlet extends BaseServlet {
 
         StringBuilder sb = new StringBuilder();
         sb.append("<title>Something</title>");
-        while (sb.length() <= CharacterReaderTest.maxBufferLen) {
-            sb.append("A suitable amount of data. \n");
+        while (sb.length() <= 32 * 1024) {
+            sb.append("<div>A suitable amount of data.</div>\n");
         }
         sb.append("<p>Finale.</p>");
         String data = sb.toString();

--- a/src/test/java/org/jsoup/internal/SoftPoolTest.java
+++ b/src/test/java/org/jsoup/internal/SoftPoolTest.java
@@ -1,0 +1,139 @@
+package org.jsoup.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SoftPoolTest {
+
+    private static final int BufSize = 12;
+    private static final int NumThreads = 5;
+    private static final int NumObjects = 3;
+
+    @Test
+    public void testSoftLocalPool() throws InterruptedException {
+        SoftPool<char[]> softLocalPool = new SoftPool<>(() -> new char[BufSize]);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(NumThreads);
+        CountDownLatch latch = new CountDownLatch(NumThreads);
+
+        Set<char[]> allBuffers = new HashSet<>();
+        Set<char[]>[] threadLocalBuffers = new Set[NumThreads];
+
+        for (int i = 0; i < NumThreads; i++) {
+            threadLocalBuffers[i] = new HashSet<>();
+        }
+
+        AtomicInteger threadCount = new AtomicInteger();
+
+        Runnable task = () -> {
+            try {
+                int threadIndex = threadCount.getAndIncrement();
+                Set<char[]> localBuffers = new HashSet<>();
+                // First borrow
+                for (int i = 0; i < NumObjects; i++) {
+                    char[] buffer = softLocalPool.borrow();
+                    assertEquals(BufSize, buffer.length);
+                    localBuffers.add(buffer);
+                }
+
+                // Release buffers back to the pool
+                for (char[] buffer : localBuffers) {
+                    softLocalPool.release(buffer);
+                }
+
+                // Borrow again and ensure buffers are reused
+                for (int i = 0; i < NumObjects; i++) {
+                    char[] buffer = softLocalPool.borrow();
+                    assertTrue(localBuffers.contains(buffer), "Buffer was not reused in the same thread");
+                    threadLocalBuffers[threadIndex].add(buffer);
+                }
+
+                synchronized (allBuffers) {
+                    allBuffers.addAll(threadLocalBuffers[threadIndex]);
+                }
+            } finally {
+                latch.countDown();
+            }
+        };
+
+        // Run the tasks
+        for (int i = 0; i < NumThreads; i++) {
+            executorService.submit(task::run);
+        }
+
+        // Wait for all threads to complete
+        latch.await();
+        executorService.shutdown();
+
+        // Ensure no buffers are shared between threads
+        Set<char[]> uniqueBuffers = new HashSet<>();
+        for (Set<char[]> bufferSet : threadLocalBuffers) {
+            for (char[] buffer : bufferSet) {
+                assertTrue(uniqueBuffers.add(buffer), "Buffer was shared between threads");
+            }
+        }
+    }
+
+    @Test
+    public void testSoftReferenceBehavior() {
+        SoftPool<char[]> softLocalPool = new SoftPool<>(() -> new char[BufSize]);
+
+        // Borrow and release an object
+        char[] buffer = softLocalPool.borrow();
+        assertEquals(BufSize, buffer.length);
+        softLocalPool.release(buffer);
+
+        // Fake a GC
+        softLocalPool.threadLocalStack.get().clear();
+
+        // Ensure the object is garbage collected
+        assertNull(softLocalPool.threadLocalStack.get().get());
+
+        char[] second = softLocalPool.borrow();
+        // should be different, but same size
+        assertNotEquals(buffer, second);
+        assertEquals(BufSize, second.length);
+    }
+
+    @Test
+    public void testBorrowFromEmptyPool() {
+        SoftPool<char[]> softLocalPool = new SoftPool<>(() -> new char[BufSize]);
+
+        // Borrow from an empty pool
+        char[] buffer = softLocalPool.borrow();
+        assertNotNull(buffer, "Borrowed null from an empty pool");
+        assertEquals(BufSize, buffer.length);
+    }
+
+    @Test
+    public void testReleaseMoreThanMaxIdle() {
+        SoftPool<char[]> softLocalPool = new SoftPool<>(() -> new char[BufSize]);
+
+        // Borrow more than MaxIdle objects
+        List<char[]> borrowedBuffers = new ArrayList<>();
+        for (int i = 0; i < SoftPool.MaxIdle + 5; i++) {
+            char[] buffer = softLocalPool.borrow();
+            borrowedBuffers.add(buffer);
+        }
+
+        // Release all borrowed objects back to the pool
+        for (char[] buffer : borrowedBuffers) {
+            softLocalPool.release(buffer);
+        }
+
+        // Ensure the pool size does not exceed MaxIdle
+        Stack<char[]> stack = softLocalPool.getStack();
+        assertTrue(stack.size() <= SoftPool.MaxIdle, "Pool size exceeded MaxIdle limit");
+    }
+}

--- a/src/test/java/org/jsoup/parser/CharacterReaderTest.java
+++ b/src/test/java/org/jsoup/parser/CharacterReaderTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author Jonathan Hedley, jonathan@hedley.net
  */
 public class CharacterReaderTest {
-    public final static int maxBufferLen = CharacterReader.maxBufferLen;
+    public final static int maxBufferLen = CharacterReader.BufferSize;
 
     @Test public void consume() {
         CharacterReader r = new CharacterReader("one");
@@ -437,10 +437,10 @@ public class CharacterReaderTest {
         // get over the buffer
         while (!noTrack.matches("[foo]"))
             noTrack.consumeTo("[foo]");
-        assertEquals(32778, noTrack.pos());
+        assertEquals(2090, noTrack.pos());
         assertEquals(1, noTrack.lineNumber());
         assertEquals(noTrack.pos()+1, noTrack.columnNumber());
-        assertEquals("1:32779", noTrack.posLineCol());
+        assertEquals("1:2091", noTrack.posLineCol());
 
         // and the line numbers: "<foo>\n<bar>\n<qux>\n"
         assertEquals(0, track.pos());
@@ -468,12 +468,12 @@ public class CharacterReaderTest {
         // get over the buffer
         while (!track.matches("[foo]"))
             track.consumeTo("[foo]");
-        assertEquals(32778, track.pos());
+        assertEquals(2090, track.pos());
         assertEquals(4, track.lineNumber());
-        assertEquals(32761, track.columnNumber());
-        assertEquals("4:32761", track.posLineCol());
+        assertEquals(2073, track.columnNumber());
+        assertEquals("4:2073", track.posLineCol());
         track.consumeTo('\n');
-        assertEquals("4:32766", track.posLineCol());
+        assertEquals("4:2078", track.posLineCol());
 
         track.consumeTo("[bar]");
         assertEquals(5, track.lineNumber());
@@ -491,9 +491,11 @@ public class CharacterReaderTest {
         reader.trackNewlines(true);
 
         assertEquals("1:1", reader.posLineCol());
+        StringBuilder seen = new StringBuilder();
         while (!reader.isEmpty())
-            reader.consume();
-        assertEquals(131096, reader.pos());
+            seen.append(reader.consume());
+        assertEquals(content, seen.toString());
+        assertEquals(content.length(), reader.pos());
         assertEquals(reader.pos() + 1, reader.columnNumber());
         assertEquals(1, reader.lineNumber());
     }

--- a/src/test/java/org/jsoup/parser/CharacterReaderTest.java
+++ b/src/test/java/org/jsoup/parser/CharacterReaderTest.java
@@ -1,6 +1,7 @@
 package org.jsoup.parser;
 
 import org.jsoup.integration.ParseTest;
+import org.jsoup.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -359,24 +360,23 @@ public class CharacterReaderTest {
 
     @Test
     public void notEmptyAtBufferSplitPoint() {
-        CharacterReader r = new CharacterReader(new StringReader("How about now"), 3);
-        assertEquals("How", r.consumeTo(' '));
-        assertFalse(r.isEmpty(), "Should not be empty");
+        int len = CharacterReader.BufferSize * 12;
+        StringBuilder builder = StringUtil.borrowBuilder();
+        while (builder.length() <= len) builder.append('!');
+        CharacterReader r = new CharacterReader(builder.toString());
+        StringUtil.releaseBuilder(builder);
 
-        assertEquals(' ', r.consume());
-        assertFalse(r.isEmpty());
-        assertEquals(4, r.pos());
-        assertEquals('a', r.consume());
-        assertEquals(5, r.pos());
-        assertEquals('b', r.consume());
-        assertEquals('o', r.consume());
-        assertEquals('u', r.consume());
-        assertEquals('t', r.consume());
-        assertEquals(' ', r.consume());
-        assertEquals('n', r.consume());
-        assertEquals('o', r.consume());
-        assertEquals('w', r.consume());
+        // consume through
+        for (int pos = 0; pos < len; pos ++) {
+            assertEquals(pos, r.pos());
+            assertFalse(r.isEmpty());
+            assertEquals('!', r.consume());
+            assertEquals(pos + 1, r.pos());
+            assertFalse(r.isEmpty());
+        }
+        assertEquals('!', r.consume());
         assertTrue(r.isEmpty());
+        assertEquals(CharacterReader.EOF, r.consume());
     }
 
     @Test public void bufferUp() {

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -368,7 +368,7 @@ public class HtmlParserTest {
 
     @Test public void handlesCdataAcrossBuffer() {
         StringBuilder sb = new StringBuilder();
-        while (sb.length() <= CharacterReader.maxBufferLen) {
+        while (sb.length() <= CharacterReader.BufferSize) {
             sb.append("A suitable amount of CData.\n");
         }
         String cdata = sb.toString();

--- a/src/test/java/org/jsoup/parser/TokeniserStateTest.java
+++ b/src/test/java/org/jsoup/parser/TokeniserStateTest.java
@@ -208,21 +208,21 @@ public class TokeniserStateTest {
     @Test
     public void testUnconsumeAtBufferBoundary() {
         String triggeringSnippet = "<a href=\"\"foo";
-        char[] padding = new char[CharacterReader.readAheadLimit - triggeringSnippet.length() + 2]; // The "foo" part must be just at the limit.
+        char[] padding = new char[CharacterReader.RefillPoint - triggeringSnippet.length() + 2]; // The "foo" part must be just at the limit.
         Arrays.fill(padding, ' ');
         String paddedSnippet = String.valueOf(padding) + triggeringSnippet;
         ParseErrorList errorList = ParseErrorList.tracking(1);
 
         Parser.parseFragment(paddedSnippet, null, "", errorList);
 
-        assertEquals(CharacterReader.readAheadLimit - 1, errorList.get(0).getPosition());
+        assertEquals(CharacterReader.RefillPoint - 1, errorList.get(0).getPosition());
     }
 
     @Test
     public void testUnconsumeAfterBufferUp() {
         // test for after consume() a bufferUp occurs (look-forward) but then attempts to unconsume. Would throw a "No buffer left to unconsume"
         String triggeringSnippet = "<title>One <span>Two";
-        char[] padding = new char[CharacterReader.readAheadLimit - triggeringSnippet.length() + 8]; // The "<span" part must be just at the limit. The "containsIgnoreCase" scan does a bufferUp, losing the unconsume
+        char[] padding = new char[CharacterReader.RefillPoint - triggeringSnippet.length() + 8]; // The "<span" part must be just at the limit. The "containsIgnoreCase" scan does a bufferUp, losing the unconsume
         Arrays.fill(padding, ' ');
         String paddedSnippet = String.valueOf(padding) + triggeringSnippet;
         ParseErrorList errorList = ParseErrorList.tracking(1);

--- a/src/test/java/org/jsoup/parser/TokeniserTest.java
+++ b/src/test/java/org/jsoup/parser/TokeniserTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
-import static org.jsoup.parser.CharacterReader.maxBufferLen;
+import static org.jsoup.parser.CharacterReader.BufferSize;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TokeniserTest {
@@ -23,7 +23,7 @@ public class TokeniserTest {
             String tail = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
             StringBuilder sb = new StringBuilder(preamble);
 
-            final int charsToFillBuffer = maxBufferLen - preamble.length();
+            final int charsToFillBuffer = BufferSize - preamble.length();
             for (int i = 0; i < charsToFillBuffer; i++) {
                 sb.append('a');
             }
@@ -43,10 +43,10 @@ public class TokeniserTest {
     @Test public void handleSuperLargeTagNames() {
         // unlikely, but valid. so who knows.
 
-        StringBuilder sb = new StringBuilder(maxBufferLen);
+        StringBuilder sb = new StringBuilder(BufferSize);
         do {
             sb.append("LargeTagName");
-        } while (sb.length() < maxBufferLen);
+        } while (sb.length() < BufferSize);
         String tag = sb.toString();
         String html = "<" + tag + ">One</" + tag + ">";
 
@@ -60,10 +60,10 @@ public class TokeniserTest {
     }
 
     @Test public void handleSuperLargeAttributeName() {
-        StringBuilder sb = new StringBuilder(maxBufferLen);
+        StringBuilder sb = new StringBuilder(BufferSize);
         do {
             sb.append("LargAttributeName");
-        } while (sb.length() < maxBufferLen);
+        } while (sb.length() < BufferSize);
         String attrName = sb.toString();
         String html = "<p " + attrName + "=foo>One</p>";
 
@@ -79,10 +79,10 @@ public class TokeniserTest {
     }
 
     @Test public void handleLargeText() {
-        StringBuilder sb = new StringBuilder(maxBufferLen);
+        StringBuilder sb = new StringBuilder(BufferSize);
         do {
             sb.append("A Large Amount of Text");
-        } while (sb.length() < maxBufferLen);
+        } while (sb.length() < BufferSize);
         String text = sb.toString();
         String html = "<p>" + text + "</p>";
 
@@ -96,10 +96,10 @@ public class TokeniserTest {
     }
 
     @Test public void handleLargeComment() {
-        StringBuilder sb = new StringBuilder(maxBufferLen);
+        StringBuilder sb = new StringBuilder(BufferSize);
         do {
             sb.append("Quite a comment ");
-        } while (sb.length() < maxBufferLen);
+        } while (sb.length() < BufferSize);
         String comment = sb.toString();
         String html = "<p><!-- " + comment + " --></p>";
 
@@ -114,10 +114,10 @@ public class TokeniserTest {
     }
 
     @Test public void handleLargeCdata() {
-        StringBuilder sb = new StringBuilder(maxBufferLen);
+        StringBuilder sb = new StringBuilder(BufferSize);
         do {
             sb.append("Quite a lot of CDATA <><><><>");
-        } while (sb.length() < maxBufferLen);
+        } while (sb.length() < BufferSize);
         String cdata = sb.toString();
         String html = "<p><![CDATA[" + cdata + "]]></p>";
 
@@ -133,10 +133,10 @@ public class TokeniserTest {
     }
 
     @Test public void handleLargeTitle() {
-        StringBuilder sb = new StringBuilder(maxBufferLen);
+        StringBuilder sb = new StringBuilder(BufferSize);
         do {
             sb.append("Quite a long title");
-        } while (sb.length() < maxBufferLen);
+        } while (sb.length() < BufferSize);
         String title = sb.toString();
         String html = "<title>" + title + "</title>";
 
@@ -178,10 +178,10 @@ public class TokeniserTest {
     }
 
     @Test public void canParseVeryLongBogusComment() {
-        StringBuilder commentData = new StringBuilder(maxBufferLen);
+        StringBuilder commentData = new StringBuilder(BufferSize);
         do {
             commentData.append("blah blah blah blah ");
-        } while (commentData.length() < maxBufferLen);
+        } while (commentData.length() < BufferSize);
         String expectedCommentData = commentData.toString();
         String testMarkup = "<html><body><!" + expectedCommentData + "></body></html>";
         Parser parser = new Parser(new HtmlTreeBuilder());
@@ -196,7 +196,7 @@ public class TokeniserTest {
     @Test public void canParseCdataEndingAtEdgeOfBuffer() {
         String cdataStart = "<![CDATA[";
         String cdataEnd = "]]>";
-        int bufLen = maxBufferLen - cdataStart.length() - 1;    // also breaks with -2, but not with -3 or 0
+        int bufLen = BufferSize - cdataStart.length() - 1;    // also breaks with -2, but not with -3 or 0
         char[] cdataContentsArray = new char[bufLen];
         Arrays.fill(cdataContentsArray, 'x');
         String cdataContents = new String(cdataContentsArray);


### PR DESCRIPTION
The goal of BUFFMAN is to reduce memory consumption and reduce GC pressure within jsoup, through improved buffer management.

It picks up the thread from #1800 (by @chibenwa), which I got stalled on when reimplementing buffering in CharacterReader.

Specifically, the implementation will re-use `char[]` and `byte[]` arrays whenever possible, vs creating new ones on each read, which is the Java default pattern. And those buffers are able to be reaped by GC as the `SoftPool` implementation holds them in SoftReferences. That improves on the current implementation of this pattern in `StringUtil.borrowBuilder()`, which retains those for the lifecycle of the thread, which may be longer than the parser is required. The buffer sizes will also be lowered from the current defaults of 32K.

This initial draft includes recycling in `CharacterReader` and for `StringBuilders`. I intend to recycle the byte[] buffers used in `DataUtil` next (which is used when parsing from a connection or file). I was planning on just extending BufferedInputStream to replace the new byte[] with a recycled, but then remembered #2054 which effectively means we can't extend BIS after Java 21. So I think I'll just make a small non-synchronized impl of a BIS, similar to my impl in CharacterReader.
