### PR TITLE
[JSOUP-2224] add wildcards

### DIFF
--- a/src/main/java/org/jsoup/safety/Safelist.java
+++ b/src/main/java/org/jsoup/safety/Safelist.java
@@ -415,7 +415,7 @@ public class Safelist {
     /**
      * Add wildcard attributes
      * <p>
-     * The wildcard should be recognized by java.text.Pattern. Multiple calls
+     * The wildcard should be recognized by java.util.regex.Pattern. Multiple calls
      * will result in only the last one being used.
      * </p>
      * <p>
@@ -427,7 +427,7 @@ public class Safelist {
      * </p>
      *
      * @param tag  The tag the attributes are for.
-     * @param wildcards wildcard pattern recognized by java.text.Pattern
+     * @param wildcards wildcard pattern recognized by java.util.regex.Pattern
      * @return this Safelist, for chaining.
      */
     public Safelist addWildcardAttributes(String tag, String... wildcards) {
@@ -447,7 +447,7 @@ public class Safelist {
      * Remove wildcard attributes
      *
      * @param tag  The tag the attributes are for.
-     * @param wildcards wildcards pattern recognized by java.text.Pattern
+     * @param wildcards wildcards pattern recognized by java.util.regex.Pattern
      * @return this Safelist, for chaining.
      */
     public Safelist removeWildcardAttributes(String tag, String... wildcards) {
@@ -471,7 +471,7 @@ public class Safelist {
     /**
      * Add wildcard global attributes
      * <p>
-     * The wildcard should be recognized by java.text.Pattern. Multiple calls
+     * The wildcard should be recognized by java.util.regex.Pattern. Multiple calls
      * will result in only the last pattern being used.
      * </p>
      * <p>
@@ -482,7 +482,7 @@ public class Safelist {
      * </ul>
      * </p>
      *
-     * @param wildcards wildcard pattern recognized by java.text.Pattern
+     * @param wildcards wildcard pattern recognized by java.util.regex.Pattern
      * @return this Safelist, for chaining.
      */
     public Safelist addWildcardGlobalAttributes(String... wildcards) {
@@ -492,7 +492,7 @@ public class Safelist {
     /**
      * Remove wildcard global attributes
      *
-     * @param wildcards wildcard pattern recognized by java.text.Pattern
+     * @param wildcards wildcard pattern recognized by java.util.regex.Pattern
      * @return this Safelist, for chaining.
      */
     public Safelist removeWildcardGlobalAttributes(String wildcards) {

--- a/src/test/java/org/jsoup/safety/SafelistTest.java
+++ b/src/test/java/org/jsoup/safety/SafelistTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SafelistTest {
     private static final String TEST_TAG = "testTag";
     private static final String TEST_ATTRIBUTE = "testAttribute";
+    private static final String TEST_DATA_ATTRIBUTE = "data-" + TEST_ATTRIBUTE;
     private static final String TEST_SCHEME = "valid-scheme";
     private static final String TEST_VALUE = TEST_SCHEME + "://testValue";
 
@@ -75,5 +76,25 @@ public class SafelistTest {
         assertNull(safelist);
     }
 
+    @Test
+    public void testAttributeWildcard() {
+        Safelist safelist1 = Safelist.none();
+        Safelist safelist2 = new Safelist(safelist1).addWildcardAttributes(TEST_TAG, "data-.+");
+        Attribute attr = new Attribute(TEST_DATA_ATTRIBUTE, TEST_VALUE);
 
+        assertFalse(safelist1.isSafeAttribute(TEST_TAG, null, attr));
+        assertTrue(safelist2.isSafeAttribute(TEST_TAG, null, attr));
+        assertFalse(safelist1.isSafeAttribute(TEST_TAG + "1", null, attr));
+    }
+
+    @Test
+    public void test8GlobalAttributeWildcard() {
+        Safelist safelist1 = Safelist.none();
+        Safelist safelist2 = new Safelist(safelist1).addWildcardGlobalAttributes("data-.+");
+        Attribute attr = new Attribute(TEST_DATA_ATTRIBUTE, TEST_VALUE);
+
+        assertFalse(safelist1.isSafeAttribute(TEST_TAG, null, attr));
+        assertTrue(safelist2.isSafeAttribute(TEST_TAG, null, attr));
+        assertTrue(safelist2.isSafeAttribute(TEST_TAG + "1", null, attr));
+    }
 }


### PR DESCRIPTION
Added wildcards attributes for both tags and global scope. This allows the user to specify an unknown set of attributes, e.g., `data-*`, using a wildcard pattern. This is different from `:all` since it is selective.

This pattern must be recognized by `java.util.regex.Pattern`, e.g., `data-.+`. The pattern is case-insensiitve and must match the entire string since '^' and '$' are quietly added.

A variant approach is to extend the existing `addAttributes()` and `removeAttributes()` methods to recognize patterns, e.g., via a marker like enclosing braces. (hence `{data-.+}`). This approach could use the same implementation as below - the existing methods would simply strip the braces and call the now-private methods.