### PR TITLE
In the Cleaner, don't add nofollow to relative links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@
 
 * When cleaning HTML with a `Safelist` that preserves relative links, the `isValid()` method will now consider these
   links valid. Additionally, the enforced attribute `rel=nofollow` will only be added to external links when configured
-  in the safelist.
+  in the safelist. [2245](https://github.com/jhy/jsoup/pull/2245)
 * Added `Element#selectStream(String query)` and `Element#selectStream(Evaluator )` methods, that return a `Stream` of
   matching elements. Elements are evaluated and returned as they are found, and the stream can be
   terminated early. [2092](https://github.com/jhy/jsoup/pull/2092)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 ### Improvements
 
+* When cleaning HTML with a `Safelist` that preserves relative links, the `isValid()` method will now consider these
+  links valid. Additionally, the enforced attribute `rel=nofollow` will only be added to external links when configured
+  in the safelist.
 * Added `Element#selectStream(String query)` and `Element#selectStream(Evaluator )` methods, that return a `Stream` of
   matching elements. Elements are evaluated and returned as they are found, and the stream can be
   terminated early. [2092](https://github.com/jhy/jsoup/pull/2092)

--- a/src/main/java/org/jsoup/Jsoup.java
+++ b/src/main/java/org/jsoup/Jsoup.java
@@ -15,6 +15,8 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Path;
 
+import static org.jsoup.internal.SharedConstants.DummyUri;
+
 /**
  The core public access point to the jsoup functionality.
 
@@ -342,6 +344,10 @@ Connection con3 = session.newRequest();
      @see Cleaner#clean(Document)
      */
     public static String clean(String bodyHtml, String baseUri, Safelist safelist) {
+        if (baseUri.isEmpty() && safelist.preserveRelativeLinks()) {
+            baseUri = DummyUri; // set a placeholder URI to allow relative links to pass abs resolution for protocol tests; won't leak to output
+        }
+
         Document dirty = parseBodyFragment(bodyHtml, baseUri);
         Cleaner cleaner = new Cleaner(safelist);
         Document clean = cleaner.clean(dirty);

--- a/src/main/java/org/jsoup/internal/SharedConstants.java
+++ b/src/main/java/org/jsoup/internal/SharedConstants.java
@@ -16,5 +16,7 @@ public final class SharedConstants {
         "input", "keygen", "object", "select", "textarea"
     };
 
+    public static final String DummyUri = "https://dummy.example/"; // used as a base URI if none provided, to allow abs url resolution to preserve relative links
+
     private SharedConstants() {}
 }

--- a/src/main/java/org/jsoup/safety/Safelist.java
+++ b/src/main/java/org/jsoup/safety/Safelist.java
@@ -117,7 +117,7 @@ public class Safelist {
      </p>
      <p>
      Links (<code>a</code> elements) can point to <code>http, https, ftp, mailto</code>, and have an enforced
-     <code>rel=nofollow</code> attribute.
+     <code>rel=nofollow</code> attribute if they link offsite (as indicated by the specified base URI).
      </p>
      <p>
      Does not allow images.
@@ -140,7 +140,7 @@ public class Safelist {
                 .addProtocols("blockquote", "cite", "http", "https")
                 .addProtocols("cite", "cite", "http", "https")
 
-                .addEnforcedAttribute("a", "rel", "nofollow")
+                .addEnforcedAttribute("a", "rel", "nofollow") // has special handling for external links, in Cleaner
                 ;
 
     }
@@ -412,12 +412,6 @@ public class Safelist {
      * Configure this Safelist to preserve relative links in an element's URL attribute, or convert them to absolute
      * links. By default, this is <b>false</b>: URLs will be  made absolute (e.g. start with an allowed protocol, like
      * e.g. {@code http://}.
-     * <p>
-     * Note that when handling relative links, the input document must have an appropriate {@code base URI} set when
-     * parsing, so that the link's protocol can be confirmed. Regardless of the setting of the {@code preserve relative
-     * links} option, the link must be resolvable against the base URI to an allowed protocol; otherwise the attribute
-     * will be removed.
-     * </p>
      *
      * @param preserve {@code true} to allow relative links, {@code false} (default) to deny
      * @return this Safelist, for chaining.
@@ -426,6 +420,14 @@ public class Safelist {
     public Safelist preserveRelativeLinks(boolean preserve) {
         preserveRelativeLinks = preserve;
         return this;
+    }
+
+    /**
+     * Get the current setting for preserving relative links.
+     * @return {@code true} if relative links are preserved, {@code false} if they are converted to absolute.
+     */
+    public boolean preserveRelativeLinks() {
+        return preserveRelativeLinks;
     }
 
     /**


### PR DESCRIPTION
And allow relative links to be isValid.

Applies a dummy URI if one is not otherwise provided, to allow protocol resolution.

Fixes #1024
Fixes #643