### PR TITLE
Enforce `-release` 8 base compilation target

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,8 @@
 * In `Connection`, skip cookies that have no name, rather than throwing a validation
   exception. [2242](https://github.com/jhy/jsoup/issues/2242)
 * When running on JDK 1.8, the error `java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;`
-  could be thrown when parsing from a URL and the buffer size was exceeded.
+  could be thrown when parsing from a URL and the buffer size was
+  exceeded. [2250](https://github.com/jhy/jsoup/pull/2250)
 
 ## 1.18.3 (2024-Dec-02)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,8 @@
   "name". [2241](https://github.com/jhy/jsoup/issues/2241)
 * In `Connection`, skip cookies that have no name, rather than throwing a validation
   exception. [2242](https://github.com/jhy/jsoup/issues/2242)
+* When running on JDK 1.8, the error `java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;`
+  could be thrown when parsing from a URL and the buffer size was exceeded.
 
 ## 1.18.3 (2024-Dec-02)
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,29 +38,27 @@
 
   <build>
     <plugins>
-      <!-- Compile -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
           <encoding>UTF-8</encoding>
+          <useIncrementalCompilation>false</useIncrementalCompilation>
           <compilerArgs>
-            <!-- saves output for package-info.java, so mvn sees it has completed it, so incremental compile works -->
             <arg>-Xpkginfo:always</arg>
           </compilerArgs>
-          <!-- this means incremental = true... -->
-          <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
         <executions>
+          <!-- Disable the default compile, so the profiles activated below execute -->
           <execution>
-            <id>compile-java-8</id>
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-            </configuration>
+            <id>default-compile</id>
+            <phase>none</phase>
           </execution>
-          <!-- There is a JDK 9+ profile execution below, which adds multi-release=true and compiles module-info -->
+          <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+          </execution>
         </executions>
       </plugin>
 
@@ -83,7 +81,6 @@
                 <version>1.0</version>
               </signature>
               <ignores>
-                <ignore>java.nio.ByteBuffer</ignore> <!-- .flip(); added in API1; possibly due to .flip previously returning Buffer, later ByteBuffer; return unused -->
                 <ignore>java.net.HttpURLConnection</ignore><!-- .setAuthenticator(java.net.Authenticator) in Java 9; only used in multirelease 9+ version -->
               </ignores>
             </configuration>
@@ -292,7 +289,7 @@
             <excludes>
               <!-- <exclude>@java.lang.Deprecated</exclude> -->
               <exclude>org.jsoup.UncheckedIOException</exclude>
-              <exlude>org.jsoup.nodes.Element</exlude> <!-- forEach previously deprecated -->
+              <exclude>org.jsoup.nodes.Element</exclude> <!-- forEach previously deprecated -->
             </excludes>
             <overrideCompatibilityChangeParameters>
               <!-- allows new default and move to default methods. compatible as long as existing binaries aren't making calls via reflection. if so, they need to catch errors anyway. -->
@@ -345,6 +342,36 @@
   </distributionManagement>
 
   <profiles>
+    <!-- Profile for Java 8 -->
+    <profile>
+      <id>java-8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <source>1.8</source>
+                  <target>1.8</target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- Compiles the multi-release jar when executed on JDK9+ -->
     <profile>
       <id>compile-multi-release</id>
@@ -357,12 +384,19 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <executions>
+
               <execution>
                 <id>compile-java-8</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                  <goal>testCompile</goal>
+                </goals>
                 <configuration>
                   <release>8</release>
                 </configuration>
               </execution>
+
               <execution>
                 <id>compile-java-9</id>
                 <phase>compile</phase>
@@ -377,6 +411,7 @@
                   <multiReleaseOutput>true</multiReleaseOutput>
                 </configuration>
               </execution>
+
             </executions>
           </plugin>
         </plugins>


### PR DESCRIPTION
Restructured the compile phases in the POM so that when executing on Java 9+, the base classes are compiled with `-release 8`. This ensures that the bootstrap class path uses the Java 8 API, and so the produced jar is binary compat with Java 8. 

(Whilst that option had been previously set, it was ignored as Maven's default compile stage was executed prior; this change disables the default compilations so that the platform specific activations are activated.)

When built on Java 8, the original `source` and `target` (vs `release`) are used.

Fixes an issue where when running on Java 8 (but built on Java9+),  `java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;` would be thrown in ControllableInputStream buffering up, because the return expected `Buffer`, not the binary incompatible `ByteBuffer`.