### PR TITLE
Add `selectFirst` and `expectFirst` to Elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,8 @@
   planner. [2254](https://github.com/jhy/jsoup/issues/2254)
 * Removed the legacy parsing rules for `<isindex>` tags, which would autovivify a `form` element with labels. This is no
   longer in the spec.
+* Added `Elements.selectFirst(String cssQuery)` and `Elements.expectFirst(String cssQuery)`, to select the first
+  matching element from an `Elements` list.  [2263](https://github.com/jhy/jsoup/pull/2263/)
 
 ### Bug Fixes
 

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -453,6 +453,32 @@ public class Elements extends ArrayList<Element> {
     }
 
     /**
+     * Find the first Element that matches the {@link Selector} CSS query within this element list.
+     * <p>This is effectively the same as calling {@code elements.select(query).first()}, but is more efficient as query
+     * execution stops on the first hit.</p>
+     * @param query A {@link Selector} query
+     * @return the first matching element, or <b>{@code null}</b> if there is no match.
+     * @see #expectFirst(String)
+     */
+    public @Nullable Element selectFirst(String query) {
+        return Selector.selectFirst(query, this);
+    }
+
+    /**
+     * Just like {@link #selectFirst(String)}, but if there is no match, throws an {@link IllegalArgumentException}.
+     * @param query A {@link Selector} query
+     * @return the first matching element
+     * @throws IllegalArgumentException if no match is found
+     */
+    public Element expectFirst(String query) {
+        return (Element) Validate.ensureNotNull(
+            Selector.selectFirst(query, this),
+                "No elements matched the query '%s'."
+            , query
+        );
+    }
+
+    /**
      * Remove elements from this list that match the {@link Selector} query.
      * <p>
      * E.g. HTML: {@code <div class=logo>One</div> <div>Two</div>}<br>

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -453,28 +453,31 @@ public class Elements extends ArrayList<Element> {
     }
 
     /**
-     * Find the first Element that matches the {@link Selector} CSS query within this element list.
-     * <p>This is effectively the same as calling {@code elements.select(query).first()}, but is more efficient as query
-     * execution stops on the first hit.</p>
-     * @param query A {@link Selector} query
-     * @return the first matching element, or <b>{@code null}</b> if there is no match.
-     * @see #expectFirst(String)
+     Find the first Element that matches the {@link Selector} CSS query within this element list.
+     <p>This is effectively the same as calling {@code elements.select(query).first()}, but is more efficient as query
+     execution stops on the first hit.</p>
+
+     @param cssQuery a {@link Selector} query
+     @return the first matching element, or <b>{@code null}</b> if there is no match.
+     @see #expectFirst(String)
+     @since 1.19.1
      */
-    public @Nullable Element selectFirst(String query) {
-        return Selector.selectFirst(query, this);
+    public @Nullable Element selectFirst(String cssQuery) {
+        return Selector.selectFirst(cssQuery, this);
     }
 
     /**
-     * Just like {@link #selectFirst(String)}, but if there is no match, throws an {@link IllegalArgumentException}.
-     * @param query A {@link Selector} query
-     * @return the first matching element
-     * @throws IllegalArgumentException if no match is found
+     Just like {@link #selectFirst(String)}, but if there is no match, throws an {@link IllegalArgumentException}.
+
+     @param cssQuery a {@link Selector} query
+     @return the first matching element
+     @throws IllegalArgumentException if no match is found
+     @since 1.19.1
      */
-    public Element expectFirst(String query) {
+    public Element expectFirst(String cssQuery) {
         return (Element) Validate.ensureNotNull(
-            Selector.selectFirst(query, this),
-                "No elements matched the query '%s'."
-            , query
+            Selector.selectFirst(cssQuery, this),
+            "No elements matched the query '%s' in the elements.", cssQuery
         );
     }
 

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -200,20 +200,19 @@ public class Selector {
     /**
      Find the first element matching the query, across multiple roots.
 
-     @param query CSS selector
+     @param cssQuery CSS selector
      @param roots root elements to descend into
-     @return matching elements, empty if none
+     @return the first matching element, or {@code null} if none
+     @since 1.19.1
      */
-    public static @Nullable Element selectFirst(String query, Iterable<Element> roots) {
-        Validate.notEmpty(query);
+    public static @Nullable Element selectFirst(String cssQuery, Iterable<Element> roots) {
+        Validate.notEmpty(cssQuery);
         Validate.notNull(roots);
-        Evaluator evaluator = QueryParser.parse(query);
+        Evaluator evaluator = QueryParser.parse(cssQuery);
 
         for (Element root : roots) {
-          Element first = Collector.findFirst(evaluator, root);
-          if (first != null) {
-            return first;
-          }
+            Element first = Collector.findFirst(evaluator, root);
+            if (first != null) return first;
         }
 
         return null;

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -197,6 +197,28 @@ public class Selector {
         return Collector.findFirst(QueryParser.parse(cssQuery), root);
     }
 
+    /**
+     Find the first element matching the query, across multiple roots.
+
+     @param query CSS selector
+     @param roots root elements to descend into
+     @return matching elements, empty if none
+     */
+    public static @Nullable Element selectFirst(String query, Iterable<Element> roots) {
+        Validate.notEmpty(query);
+        Validate.notNull(roots);
+        Evaluator evaluator = QueryParser.parse(query);
+
+        for (Element root : roots) {
+          var first = Collector.findFirst(evaluator, root);
+          if (first != null) {
+            return first;
+          }
+        }
+
+        return null;
+    }
+
     public static class SelectorParseException extends IllegalStateException {
         public SelectorParseException(String msg) {
             super(msg);

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -210,7 +210,7 @@ public class Selector {
         Evaluator evaluator = QueryParser.parse(query);
 
         for (Element root : roots) {
-          var first = Collector.findFirst(evaluator, root);
+          Element first = Collector.findFirst(evaluator, root);
           if (first != null) {
             return first;
           }

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -600,27 +600,27 @@ public class ElementsTest {
         assertEquals("<div> One</div><div> Two</div><div> Three</div><div> Four</div>", TextUtil.normalizeSpaces(doc.body().html()));
     }
 
-    @Test public void selectFirst() {
+    @Test void selectFirst() {
         Document doc = Jsoup.parse("<p>One</p><p>Two <span>Jsoup</span></p><p><span>Three</span></p>");
         Element span = doc.children().selectFirst("span");
         assertNotNull(span);
         assertEquals("Jsoup", span.text());
     }
 
-    @Test public void selectFirstNullOnNoMatch() {
+    @Test void selectFirstNullOnNoMatch() {
         Document doc = Jsoup.parse("<p>One</p><p>Two</p><p>Three</p>");
         Element span = doc.children().selectFirst("span");
         assertNull(span);
     }
 
-    @Test public void expectFirst() {
+    @Test void expectFirst() {
         Document doc = Jsoup.parse("<p>One</p><p>Two <span>Jsoup</span></p><p><span>Three</span></p>");
         Element span = doc.children().expectFirst("span");
         assertNotNull(span);
         assertEquals("Jsoup", span.text());
     }
 
-    @Test public void expectFirstThrowsOnNoMatch() {
+    @Test void expectFirstThrowsOnNoMatch() {
         Document doc = Jsoup.parse("<p>One</p><p>Two</p><p>Three</p>");
 
         boolean threw = false;
@@ -628,8 +628,25 @@ public class ElementsTest {
             Element span = doc.children().expectFirst("span");
         } catch (IllegalArgumentException e) {
             threw = true;
-            assertEquals("No elements matched the query 'span'.", e.getMessage());
+            assertEquals("No elements matched the query 'span'. in the elements", e.getMessage());
         }
         assertTrue(threw);
+    }
+
+    @Test void selectFirstFromPreviousSelect() {
+        Document doc = Jsoup.parse("<div><p>One</p></div><div><p><span>Two</span></p></div><div><p><span>Three</span></p></div>");
+        Elements divs = doc.select("div");
+        assertEquals(3, divs.size());
+
+        Element span = divs.selectFirst("p span");
+        assertNotNull(span);
+        assertEquals("Two", span.text());
+
+        // test roots
+        assertNotNull(span.selectFirst("span")); // reselect self
+        assertNull(span.selectFirst(">span")); // no span>span
+
+        assertNotNull(divs.selectFirst("div")); // reselect self, similar to element.select
+        assertNull(divs.selectFirst(">div")); // no div>div
     }
 }

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -599,4 +599,37 @@ public class ElementsTest {
         // check dom
         assertEquals("<div> One</div><div> Two</div><div> Three</div><div> Four</div>", TextUtil.normalizeSpaces(doc.body().html()));
     }
+
+    @Test public void selectFirst() {
+        Document doc = Jsoup.parse("<p>One</p><p>Two <span>Jsoup</span></p><p><span>Three</span></p>");
+        Element span = doc.children().selectFirst("span");
+        assertNotNull(span);
+        assertEquals("Jsoup", span.text());
+    }
+
+    @Test public void selectFirstNullOnNoMatch() {
+        Document doc = Jsoup.parse("<p>One</p><p>Two</p><p>Three</p>");
+        Element span = doc.children().selectFirst("span");
+        assertNull(span);
+    }
+
+    @Test public void expectFirst() {
+        Document doc = Jsoup.parse("<p>One</p><p>Two <span>Jsoup</span></p><p><span>Three</span></p>");
+        Element span = doc.children().expectFirst("span");
+        assertNotNull(span);
+        assertEquals("Jsoup", span.text());
+    }
+
+    @Test public void expectFirstThrowsOnNoMatch() {
+        Document doc = Jsoup.parse("<p>One</p><p>Two</p><p>Three</p>");
+
+        boolean threw = false;
+        try {
+            Element span = doc.children().expectFirst("span");
+        } catch (IllegalArgumentException e) {
+            threw = true;
+            assertEquals("No elements matched the query 'span'.", e.getMessage());
+        }
+        assertTrue(threw);
+    }
 }

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -628,7 +628,7 @@ public class ElementsTest {
             Element span = doc.children().expectFirst("span");
         } catch (IllegalArgumentException e) {
             threw = true;
-            assertEquals("No elements matched the query 'span'. in the elements", e.getMessage());
+            assertEquals("No elements matched the query 'span' in the elements.", e.getMessage());
         }
         assertTrue(threw);
     }


### PR DESCRIPTION
Closes #2256.

I copied the docstrings, and behaviour, from the equivalent methods on `Element` and the surrounding methods on `Elements`.