### PR TITLE
Refactored tests in EntitiesTest to use parameterized unit testing

### DIFF
--- a/src/test/java/org/jsoup/nodes/EntitiesTest.java
+++ b/src/test/java/org/jsoup/nodes/EntitiesTest.java
@@ -3,6 +3,8 @@ package org.jsoup.nodes;
 import org.jsoup.Jsoup;
 import org.jsoup.parser.Parser;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.jsoup.nodes.Document.OutputSettings;
 import static org.jsoup.nodes.Entities.EscapeMode.*;
@@ -59,23 +61,37 @@ public class EntitiesTest {
         assertEquals(un, Entities.unescape(escaped));
     }
 
-    @Test public void xhtml() {
-        assertEquals(38, xhtml.codepointForName("amp"));
-        assertEquals(62, xhtml.codepointForName("gt"));
-        assertEquals(60, xhtml.codepointForName("lt"));
-        assertEquals(34, xhtml.codepointForName("quot"));
-
-        assertEquals("amp", xhtml.nameForCodepoint(38));
-        assertEquals("gt", xhtml.nameForCodepoint(62));
-        assertEquals("lt", xhtml.nameForCodepoint(60));
-        assertEquals("quot", xhtml.nameForCodepoint(34));
+    @ParameterizedTest
+    @CsvSource(value = {
+            "38, amp",
+            "62, gt",
+            "60, lt",
+            "34, quot"
+    })
+    public void xhtmlCodepointForName(int expectedCodepoint, String name) {
+        assertEquals(expectedCodepoint, xhtml.codepointForName(name));
     }
 
-    @Test public void getByName() {
-        assertEquals("≫⃒", Entities.getByName("nGt"));
-        assertEquals("fj", Entities.getByName("fjlig"));
-        assertEquals("≫", Entities.getByName("gg"));
-        assertEquals("©", Entities.getByName("copy"));
+    @ParameterizedTest
+    @CsvSource(value = {
+            "amp, 38",
+            "gt, 62",
+            "lt, 60",
+            "quot, 34"
+    })
+    public void xhtmlNameForCodepoint(String expectedName, int codepoint) {
+        assertEquals(expectedName, xhtml.nameForCodepoint(codepoint));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "≫⃒, nGt",
+            "fj, fjlig",
+            "≫, gg",
+            "©, copy"
+    })
+    public void getByName(String expected, String name) {
+        assertEquals(expected, Entities.getByName(name));
     }
 
     @Test public void escapeSupplementaryCharacter() {


### PR DESCRIPTION
Aim:
Improve the test code by avoiding code duplication, improving maintainability, and enhancing readability. By converting the test into a parameterized unit test, we reduce boilerplate code, make it easier to extend by simply adding new input values, and improve debugging by clearly identifying which test case fails instead of searching through individual assertions.


```
    @Test public void xhtml() {
        assertEquals(38, xhtml.codepointForName("amp"));
        assertEquals(62, xhtml.codepointForName("gt"));
        assertEquals(60, xhtml.codepointForName("lt"));
        assertEquals(34, xhtml.codepointForName("quot"));

        assertEquals("amp", xhtml.nameForCodepoint(38));
        assertEquals("gt", xhtml.nameForCodepoint(62));
        assertEquals("lt", xhtml.nameForCodepoint(60));
        assertEquals("quot", xhtml.nameForCodepoint(34));
    }

    @Test public void getByName() {
        assertEquals("≫⃒", Entities.getByName("nGt"));
        assertEquals("fj", Entities.getByName("fjlig"));
        assertEquals("≫", Entities.getByName("gg"));
        assertEquals("©", Entities.getByName("copy"));
    }
```

In the above in tests from EntitiesTest.java:

* The same method calls (xhtml.codepointForName, xhtml.nameForCodepoint, Entities.getByName) are repeated multiple times with different inputs, making the test harder to maintain and extend.
* When a test fails, JUnit only shows which assertion failed, but not which specific input caused the failure.
* Adding new test cases requires copying and pasting another assertEquals(...) statement instead of simply adding new data.
* Test xhtml also has two separate methods under test causing an eager test smell. 

To accomplish this, I have separated the 1st test into 2 and retrofitted all 3 into parameterized unit tests. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.