### PR TITLE
Directly parse XML declarations in XmlTreeBuilder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@
   longer in the spec.
 * Added `Elements.selectFirst(String cssQuery)` and `Elements.expectFirst(String cssQuery)`, to select the first
   matching element from an `Elements` list.  [2263](https://github.com/jhy/jsoup/pull/2263/)
+* When parsing with the XML parser, XML Declarations and Processing Instructions are directly handled, vs bouncing
+  through the HTML parser's bogus comment handler. Serialization for non-doctype declarations no longer end with a
+  spurious `!`.
 
 ### Bug Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
   matching element from an `Elements` list.  [2263](https://github.com/jhy/jsoup/pull/2263/)
 * When parsing with the XML parser, XML Declarations and Processing Instructions are directly handled, vs bouncing
   through the HTML parser's bogus comment handler. Serialization for non-doctype declarations no longer end with a
-  spurious `!`.
+  spurious `!`. [2275](https://github.com/jhy/jsoup/pull/2275)
 
 ### Bug Fixes
 

--- a/src/main/java/org/jsoup/nodes/Comment.java
+++ b/src/main/java/org/jsoup/nodes/Comment.java
@@ -55,8 +55,11 @@ public class Comment extends LeafNode {
     }
 
     /**
-     * Check if this comment looks like an XML Declaration.
+     * Check if this comment looks like an XML Declaration. This is the case when the HTML parser sees an XML
+     * declaration or processing instruction. Other than doctypes, those aren't part of HTML, and will be parsed as a
+     * bogus comment.
      * @return true if it looks like, maybe, it's an XML Declaration.
+     * @see #asXmlDeclaration()
      */
     public boolean isXmlDeclaration() {
         String data = getData();
@@ -70,6 +73,7 @@ public class Comment extends LeafNode {
     /**
      * Attempt to cast this comment to an XML Declaration node.
      * @return an XML declaration if it could be parsed as one, null otherwise.
+     * @see #isXmlDeclaration()
      */
     public @Nullable XmlDeclaration asXmlDeclaration() {
         String data = getData();

--- a/src/main/java/org/jsoup/nodes/XmlDeclaration.java
+++ b/src/main/java/org/jsoup/nodes/XmlDeclaration.java
@@ -6,20 +6,24 @@ import org.jsoup.internal.StringUtil;
 import java.io.IOException;
 
 /**
- * An XML Declaration.
+ * An XML Declaration. Includes support for treating the declaration contents as pseudo attributes.
  */
 public class XmlDeclaration extends LeafNode {
-    // todo this impl isn't really right, the data shouldn't be attributes, just a run of text after the name
-    private final boolean isProcessingInstruction; // <! if true, <? if false, declaration (and last data char should be ?)
+
+    /**
+     First char is `!` if isDeclaration, like in {@code  <!ENTITY ...>}.
+     Otherwise, is `?`, a processing instruction, like {@code <?xml .... ?>} (and note trailing `?`).
+     */
+    private final boolean isDeclaration;
 
     /**
      * Create a new XML declaration
      * @param name of declaration
-     * @param isProcessingInstruction is processing instruction
+     * @param isDeclaration {@code true} if a declaration (first char is `!`), otherwise a processing instruction (first char is `?`).
      */
-    public XmlDeclaration(String name, boolean isProcessingInstruction) {
+    public XmlDeclaration(String name, boolean isDeclaration) {
         super(name);
-        this.isProcessingInstruction = isProcessingInstruction;
+        this.isDeclaration = isDeclaration;
     }
 
     @Override public String nodeName() {
@@ -69,11 +73,11 @@ public class XmlDeclaration extends LeafNode {
     void outerHtmlHead(Appendable accum, int depth, Document.OutputSettings out) throws IOException {
         accum
             .append("<")
-            .append(isProcessingInstruction ? "!" : "?")
+            .append(isDeclaration ? "!" : "?")
             .append(coreValue());
         getWholeDeclaration(accum, out);
         accum
-            .append(isProcessingInstruction ? "!" : "?")
+            .append(isDeclaration ? "" : "?")
             .append(">");
     }
 

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -481,6 +481,34 @@ abstract class Token {
 
     }
 
+    /**
+     XmlDeclaration - extends Tag for pseudo attribute support
+     */
+    final static class XmlDecl extends Tag {
+        boolean isDeclaration = true; // <!..>, or <?...?> if false (a processing instruction)
+
+        public XmlDecl(TreeBuilder treeBuilder) {
+            super(TokenType.XmlDecl, treeBuilder);
+        }
+
+        @Override
+        XmlDecl reset() {
+            super.reset();
+            isDeclaration = true;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            String open = isDeclaration ? "<!" : "<?";
+            String close = isDeclaration ? ">" : "?>";
+            if (hasAttributes() && attributes.size() > 0)
+                return open + toStringName() + " " + attributes.toString() + close;
+            else
+                return open + toStringName() + close;
+        }
+    }
+
     final static class EOF extends Token {
         EOF() {
             super(Token.TokenType.EOF);
@@ -542,6 +570,10 @@ abstract class Token {
         return (Character) this;
     }
 
+    final XmlDecl asXmlDecl() {
+        return (XmlDecl) this;
+    }
+
     final boolean isEOF() {
         return type == TokenType.EOF;
     }
@@ -552,6 +584,7 @@ abstract class Token {
         EndTag,
         Comment,
         Character, // note no CData - treated in builder as an extension of Character
+        XmlDecl,
         EOF
     }
 }

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -64,7 +64,7 @@ public class XmlTreeBuilder extends TreeBuilder {
     protected boolean process(Token token) {
         currentToken = token;
 
-        // start tag, end tag, doctype, comment, character, eof
+        // start tag, end tag, doctype, xmldecl, comment, character, eof
         switch (token.type) {
             case StartTag:
                 insertElementFor(token.asStartTag());
@@ -80,6 +80,9 @@ public class XmlTreeBuilder extends TreeBuilder {
                 break;
             case Doctype:
                 insertDoctypeFor(token.asDoctype());
+                break;
+            case XmlDecl:
+                insertXmlDeclarationFor(token.asXmlDecl());
                 break;
             case EOF: // could put some normalisation here if desired
                 break;
@@ -132,6 +135,12 @@ public class XmlTreeBuilder extends TreeBuilder {
         DocumentType doctypeNode = new DocumentType(settings.normalizeTag(token.getName()), token.getPublicIdentifier(), token.getSystemIdentifier());
         doctypeNode.setPubSysKey(token.getPubSysKey());
         insertLeafNode(doctypeNode);
+    }
+
+    void insertXmlDeclarationFor(Token.XmlDecl token) {
+        XmlDeclaration decl = new XmlDeclaration(token.name(), token.isDeclaration);
+        if (token.attributes != null) decl.attributes().addAll(token.attributes);
+        insertLeafNode(decl);
     }
 
     /**

--- a/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
@@ -2,7 +2,6 @@ package org.jsoup.parser;
 
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
-import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.*;
 import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Disabled;
@@ -351,6 +350,39 @@ public class XmlTreeBuilderTest {
 
     private static void assertXmlNamespace(Element el) {
         assertEquals(Parser.NamespaceXml, el.tag().namespace(), String.format("Element %s not in XML namespace", el.tagName()));
+    }
+
+    @Test void declarations() {
+        String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?><!DOCTYPE html\n" +
+            "  PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n" +
+            "  \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">" +
+            "<!ELEMENT footnote (#PCDATA|a)*>";
+        Document doc = Jsoup.parse(xml, Parser.xmlParser());
+
+        XmlDeclaration proc = (XmlDeclaration) doc.childNode(0);
+        DocumentType doctype = (DocumentType) doc.childNode(1);
+        XmlDeclaration decl = (XmlDeclaration) doc.childNode(2);
+
+        assertEquals("xml", proc.name());
+        assertEquals("1.0", proc.attr("version"));
+        assertEquals("utf-8", proc.attr("encoding"));
+        assertEquals("version=\"1.0\" encoding=\"utf-8\"", proc.getWholeDeclaration());
+        assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\"?>", proc.outerHtml());
+
+        assertEquals("html", doctype.name());
+        assertEquals("-//W3C//DTD XHTML 1.0 Transitional//EN", doctype.attr("publicId"));
+        assertEquals("http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd", doctype.attr("systemId"));
+        assertEquals("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">", doctype.outerHtml());
+
+        assertEquals("ELEMENT", decl.name());
+        assertEquals("footnote (#PCDATA|a)*", decl.getWholeDeclaration());
+        assertTrue(decl.hasAttr("footNote"));
+        assertFalse(decl.hasAttr("ELEMENT"));
+        assertEquals("<!ELEMENT footnote (#PCDATA|a)*>", decl.outerHtml());
+
+        assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+            "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">" +
+            "<!ELEMENT footnote (#PCDATA|a)*>", doc.outerHtml());
     }
 
 }


### PR DESCRIPTION
Vs the old method of bouncing through the HTML parser's bogus comments.

This simplifies the parse flow for declarations and can better handle dodgy inputs.