### PR TITLE
Reimplement the adoption agency algorithm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 * When converting parsed HTML to XML or the W3C DOM, element names containing `<` are normalized to `_` to ensure valid
   XML. For example, `<foo<bar>` becomes `<foo_bar>`, as XML does not allow `<` in element names, but HTML5
   does. [2276](https://github.com/jhy/jsoup/pull/2276)
+* Reimplemented the HTML5 Adoption Agency Algorithm to the current spec. This handles mis-nested formating / structural elements. [2278](https://github.com/jhy/jsoup/pull/2278)
 
 ### Bug Fixes
 

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -59,7 +59,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     private @Nullable Element headElement; // the current head element
     private @Nullable FormElement formElement; // the current form element
     private @Nullable Element contextElement; // fragment parse root; name only copy of context. could be null even if fragment parsing
-    private ArrayList<Element> formattingElements; // active (open) formatting elements
+    ArrayList<Element> formattingElements; // active (open) formatting elements
     private ArrayList<HtmlTreeBuilderState> tmplInsertMode; // stack of Template Insertion modes
     private List<Token.Character> pendingTableCharacters; // chars in table to be shifted out
     private Token.EndTag emptyEnd; // reused empty end tag
@@ -539,6 +539,13 @@ public class HtmlTreeBuilder extends TreeBuilder {
         }
     }
 
+    /**
+     Gets the Element immediately above the supplied element on the stack. Which due to adoption, may not necessarily be
+     its parent.
+
+     @param el
+     @return the Element immediately above the supplied element, or null if there is no such element.
+     */
     @Nullable Element aboveOnStack(Element el) {
         assert onStack(el);
         for (int pos = stack.size() -1; pos >= 0; pos--) {

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -673,8 +673,10 @@ public class HtmlParserTest {
     }
 
     @Test public void handlesMisnestedAInDivs() {
-        String h = "<a href='#1'><div><div><a href='#2'>child</a></div</div></a>";
-        String w = "<a href=\"#1\"></a> <div> <a href=\"#1\"></a> <div> <a href=\"#1\"></a><a href=\"#2\">child</a> </div> </div>";
+        String h = "<a 1><div 2><div 3><a 4>child</a></div></div></a>";
+        String w = "<a 1></a> <div 2> <a 1=\"\"></a> <div 3> <a 1=\"\"></a><a 4>child</a> </div> </div>"; // chrome checked
+        // todo - come back to how we copy the attributes, to keep boolean setting (not ="")
+
         Document doc = Jsoup.parse(h);
         assertEquals(
             StringUtil.normaliseWhitespace(w),
@@ -1507,6 +1509,13 @@ public class HtmlParserTest {
         Document doc = Jsoup.parse(html);
         assertNotNull(doc);
         assertEquals("<a> <b> </b></a><b><div><a> </a><a>test</a></div></b>", TextUtil.stripNewlines(doc.body().html()));
+    }
+
+    @Test public void adoption() throws IOException {
+        // https://github.com/jhy/jsoup/issues/2267
+        File input = ParseTest.getFile("/htmltests/adopt-1.html");
+        Document doc = Jsoup.parse(input);
+        assertEquals("TEXT-AAA TEXT-BBB TEXT-CCC TEXT-DDD", doc.text());
     }
 
     @Test public void tagsMustStartWithAscii() {

--- a/src/test/resources/htmltests/adopt-1.html
+++ b/src/test/resources/htmltests/adopt-1.html
@@ -1,0 +1,69 @@
+    <b>
+        <b>
+            <p>
+                TEXT-AAA
+<div>
+    <div>
+        <div>
+            <div>
+                <span>
+                    <div>
+                        <div>
+                            <span>
+                                <span>
+                                    <span>
+                                        <div>
+                                            <span>
+                                                <span>
+                                                    <b style="">
+                                                        <span>
+                                                        </span>
+                                                        <b style="box-sizing:border-box;font-weight:600">
+                                                            <span>
+                                                                <span>
+                                                                    <span>
+                                                                        <b style="">
+                                                                            <b style="box-sizing:border-box;font-weight:600">
+                                                                                <span>
+                                                                                    <span>
+                                                                                        <span>
+                                                                                            <b>
+                                                                                                <b>
+                                                                                                    </b>
+                                                                                            </b>
+                                                                                        </span>
+                                                                                        <span>TEXT-BBB</span>
+                                                                                        <span>
+                                                                                            <b style="box-sizing:border-box;font-weight:600">
+                                                                                                <b style="box-sizing:border-box;font-weight:600">
+                                                                                                </b>
+                                                                                            </b>
+                                                                                        </span>
+                                                                                    </span>
+                                                                                </span>
+                                                                            </b>
+                                                                        </b>
+                                                                    </span>
+                                                                </span>
+                                                            </span>
+                                                            <span>
+                                                                <br>
+                                                                <span>
+                                                                    <span>TEXT-CCC</span>
+                                                                </span>
+                                                            </span>
+                                                        </b></b>
+                                                </span>
+                                            </span>
+                                        </div>
+                                        <div>
+                                            TEXT-DDD
+                                        </div>
+                                    </span>
+                                </span>
+                            </span>
+                </span>
+            </div>
+        </div>
+        </span>
+    </div>


### PR DESCRIPTION
Fixes #2267

The implementation of the adoption agency algorithm vs the HTML5 spec had drifted over time. This fixes that.

The spec for table fostering when in adoption is not presently implemented, marked as a todo.

Given the complexity of the algo and how it has changed over time, I opted to include it inline so that hopefully later changes are easier to _adopt_.