### PR TITLE
Change `TokenQueue.consumeCssIdentifier()` to support hex digit unescaping

### DIFF
--- a/src/main/java/org/jsoup/parser/TokenQueue.java
+++ b/src/main/java/org/jsoup/parser/TokenQueue.java
@@ -5,17 +5,15 @@ import org.jsoup.helper.Validate;
 
 /**
  * A character queue with parsing helpers.
- *
- * @author Jonathan Hedley
  */
 public class TokenQueue {
     private String queue;
     private int pos = 0;
     
-    private static final char ESC = '\\'; // escape char for chomp balanced.
-    private static final char HYPHEN_MINUS = '-';
-    private static final char UNICODE_NULL = '\u0000';
-    private static final char REPLACEMENT_CHARACTER = '\uFFFD';
+    private static final char Esc = '\\'; // escape char for chomp balanced.
+    private static final char Hyphen_Minus = '-';
+    private static final char Unicode_Null = '\u0000';
+    private static final char Replacement = '\uFFFD';
 
     /**
      Create a new TokenQueue.
@@ -245,7 +243,7 @@ public class TokenQueue {
         do {
             if (isEmpty()) break;
             char c = consume();
-            if (last != ESC) {
+            if (last != Esc) {
                 if (c == '\'' && c != open && !inDoubleQuote)
                     inSingleQuote = !inSingleQuote;
                 else if (c == '"' && c != open && !inSingleQuote)
@@ -288,8 +286,8 @@ public class TokenQueue {
         StringBuilder out = StringUtil.borrowBuilder();
         char last = 0;
         for (char c : in.toCharArray()) {
-            if (c == ESC) {
-                if (last == ESC) {
+            if (c == Esc) {
+                if (last == Esc) {
                     out.append(c);
                     c = 0;
                 }
@@ -312,7 +310,7 @@ public class TokenQueue {
             if (q.matchesCssIdentifier(CssIdentifierChars)) {
                 out.append(q.consume());
             } else {
-                out.append(ESC).append(q.consume());
+                out.append(Esc).append(q.consume());
             }
         }
         return StringUtil.releaseBuilder(out);
@@ -342,7 +340,6 @@ public class TokenQueue {
         return queue.substring(start, pos);
     }
 
-
     /**
      * Consume a CSS element selector (tag name, but | instead of : for namespaces (or *| for wildcard namespace), to not conflict with :pseudo selects).
      * 
@@ -355,22 +352,17 @@ public class TokenQueue {
 
     /**
      Consume a CSS identifier (ID or class) off the queue.
-     <p>
-     Note: For backwards compatibility this method supports improperly formatted CSS identifiers, e.g. {@code 1} instead
-     of {@code \31}.
-     </p>
+     <p>Note: For backwards compatibility this method supports improperly formatted CSS identifiers, e.g. {@code 1} instead
+     of {@code \31}.</p>
 
      @return The unescaped identifier.
-
      @throws IllegalArgumentException if an invalid escape sequence was found. Afterward, the state of the TokenQueue
      is undefined.
-
      @see <a href="https://www.w3.org/TR/css-syntax-3/#consume-name">CSS Syntax Module Level 3, Consume an ident sequence</a>
      @see <a href="https://www.w3.org/TR/css-syntax-3/#typedef-ident-token">CSS Syntax Module Level 3, ident-token</a>
      */
     public String consumeCssIdentifier() {
         if (isEmpty()) throw new IllegalArgumentException("CSS identifier expected, but end of input found");
-
         int start = pos;
 
         // Fast path for CSS identifiers that don't contain escape sequences.
@@ -378,7 +370,7 @@ public class TokenQueue {
             char c = current();
             if (isIdent(c)) {
                 advance();
-            } else if (c == ESC || c == UNICODE_NULL) {
+            } else if (c == Esc || c == Unicode_Null) {
                 // Exit fast path when an escape sequence or U+0000 is found.
                 break;
             } else {
@@ -398,14 +390,13 @@ public class TokenQueue {
 
         while (!isEmpty()) {
             char c = current();
-
             if (isIdent(c)) {
                 out.append(consume());
-            } else if (c == UNICODE_NULL) {
+            } else if (c == Unicode_Null) {
                 // https://www.w3.org/TR/css-syntax-3/#input-preprocessing
                 advance();
-                out.append(REPLACEMENT_CHARACTER);
-            } else if (c == ESC) {
+                out.append(Replacement);
+            } else if (c == Esc) {
                 advance();
                 if (!isEmpty() && isNewline(current())) {
                     // Not a valid escape sequence. This is treated as the end of the CSS identifier.
@@ -418,37 +409,35 @@ public class TokenQueue {
                 break;
             }
         }
-
         return StringUtil.releaseBuilder(out);
     }
 
     private void consumeCssEscapeSequenceInto(StringBuilder out) {
         if (isEmpty()) {
-            out.append(REPLACEMENT_CHARACTER);
+            out.append(Replacement);
             return;
         }
-
         int start = pos;
         char firstEscaped = consume();
-
         if (!isHexDigit(firstEscaped)) {
             out.append(firstEscaped);
         } else {
             for (int i = 0; i < 5 && !isEmpty(); i++) {
                 char escapedChar = current();
-                if (isHexDigit(escapedChar)) {
-                    advance();
-                } else {
-                    break;
-                }
+                if (isHexDigit(escapedChar)) advance();
+                else break;
             }
-
             String hexString = queue.substring(start, pos);
-            int codePoint = Integer.parseInt(hexString, 16);
+            int codePoint;
+            try {
+                codePoint = Integer.parseInt(hexString, 16);
+            } catch (NumberFormatException e) { // Won't happen as we confirmed hex above; just mollifying scanners
+                throw new IllegalArgumentException("Invalid escape sequence: " + hexString, e);
+            }
             if (isValidCodePoint(codePoint)) {
                 out.appendCodePoint(codePoint);
             } else {
-                out.append(REPLACEMENT_CHARACTER);
+                out.append(Replacement);
             }
 
             if (!isEmpty()) {
@@ -464,6 +453,8 @@ public class TokenQueue {
             }
         }
     }
+
+    // statics below specifically for CSS identifiers:
 
     private static boolean isLetter(char c) {
         return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z';
@@ -489,7 +480,7 @@ public class TokenQueue {
 
     // https://www.w3.org/TR/css-syntax-3/#ident-code-point
     private static boolean isIdent(char c) {
-        return c == HYPHEN_MINUS || isDigit(c) || isIdentStart(c);
+        return c == Hyphen_Minus || isDigit(c) || isIdentStart(c);
     }
 
     // https://www.w3.org/TR/css-syntax-3/#newline
@@ -510,7 +501,7 @@ public class TokenQueue {
         int start = pos;
         boolean escaped = false;
         while (!isEmpty()) {
-            if (queue.charAt(pos) == ESC && remainingLength() >1 ) {
+            if (queue.charAt(pos) == Esc && remainingLength() >1 ) {
                 escaped = true;
                 pos+=2; // skip the escape and the escaped
             } else if (matchesCssIdentifier(matches)) {

--- a/src/test/java/org/jsoup/parser/TokenQueueTest.java
+++ b/src/test/java/org/jsoup/parser/TokenQueueTest.java
@@ -3,8 +3,12 @@ package org.jsoup.parser;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -140,100 +144,110 @@ public class TokenQueueTest {
         assertTrue(q.isEmpty());
     }
 
-    // https://github.com/web-platform-tests/wpt/blob/36036fb5212a3fc15fc5750cecb1923ba4071668/dom/nodes/ParentNode-querySelector-escapes.html
-    @Test public void consumeCssIdentifier_WebPlatformTests() {
-        // - escape hex digit
-        assertParsedCssIdentifierEquals("0nextIsWhiteSpace", "\\30 nextIsWhiteSpace");
-        assertParsedCssIdentifierEquals("0nextIsNotHexLetters", "\\30nextIsNotHexLetters");
-        assertParsedCssIdentifierEquals("0connectHexMoreThan6Hex", "\\000030connectHexMoreThan6Hex");
-        assertParsedCssIdentifierEquals("0spaceMoreThan6Hex", "\\000030 spaceMoreThan6Hex");
-
-        // - hex digit special replacement
-        // 1. zero points
-        assertParsedCssIdentifierEquals("zero\uFFFD", "zero\\0");
-        assertParsedCssIdentifierEquals("zero\uFFFD", "zero\\000000");
-        // 2. surrogate points
-        assertParsedCssIdentifierEquals("\uFFFDsurrogateFirst", "\\d83d surrogateFirst");
-        assertParsedCssIdentifierEquals("surrogateSecond\uFFFd", "surrogateSecond\\dd11");
-        assertParsedCssIdentifierEquals("surrogatePair\uFFFD\uFFFD", "surrogatePair\\d83d\\dd11");
-        // 3. out of range points
-        assertParsedCssIdentifierEquals("outOfRange\uFFFD", "outOfRange\\110000");
-        assertParsedCssIdentifierEquals("outOfRange\uFFFD", "outOfRange\\110030");
-        assertParsedCssIdentifierEquals("outOfRange\uFFFD", "outOfRange\\555555");
-        assertParsedCssIdentifierEquals("outOfRange\uFFFD", "outOfRange\\ffffff");
-
-        // - escape anything else
-        assertParsedCssIdentifierEquals(".comma", "\\.comma");
-        assertParsedCssIdentifierEquals("-minus", "\\-minus");
-        assertParsedCssIdentifierEquals("g", "\\g");
-
-        // non edge cases
-        assertParsedCssIdentifierEquals("aBMPRegular", "\\61 BMPRegular");
-        assertParsedCssIdentifierEquals("\uD83D\uDD11nonBMP", "\\1f511 nonBMP");
-        assertParsedCssIdentifierEquals("00continueEscapes", "\\30\\30 continueEscapes");
-        assertParsedCssIdentifierEquals("00continueEscapes", "\\30 \\30 continueEscapes");
-        assertParsedCssIdentifierEquals("continueEscapes00", "continueEscapes\\30 \\30 ");
-        assertParsedCssIdentifierEquals("continueEscapes00", "continueEscapes\\30 \\30");
-        assertParsedCssIdentifierEquals("continueEscapes00", "continueEscapes\\30\\30 ");
-        assertParsedCssIdentifierEquals("continueEscapes00", "continueEscapes\\30\\30");
-
-        // ident tests case from CSS tests of chromium source: https://goo.gl/3Cxdov
-        assertParsedCssIdentifierEquals("hello", "hel\\6Co");
-        assertParsedCssIdentifierEquals("&B", "\\26 B");
-        assertParsedCssIdentifierEquals("hello", "hel\\6C o");
-        assertParsedCssIdentifierEquals("spaces", "spac\\65\r\ns");
-        assertParsedCssIdentifierEquals("spaces", "sp\\61\tc\\65\fs");
-        assertParsedCssIdentifierEquals("test\uD799", "test\\D799");
-        assertParsedCssIdentifierEquals("\uE000", "\\E000");
-        assertParsedCssIdentifierEquals("test", "te\\s\\t");
-        assertParsedCssIdentifierEquals("spaces in\tident", "spaces\\ in\\\tident");
-        assertParsedCssIdentifierEquals(".,:!", "\\.\\,\\:\\!");
-        assertParsedCssIdentifierEquals("null\uFFFD", "null\\0");
-        assertParsedCssIdentifierEquals("null\uFFFD", "null\\0000");
-        assertParsedCssIdentifierEquals("large\uFFFD", "large\\110000");
-        assertParsedCssIdentifierEquals("large\uFFFD", "large\\23456a");
-        assertParsedCssIdentifierEquals("surrogate\uFFFD", "surrogate\\D800");
-        assertParsedCssIdentifierEquals("surrogate\uFFFD", "surrogate\\0DBAC");
-        assertParsedCssIdentifierEquals("\uFFFDsurrogate", "\\00DFFFsurrogate");
-        assertParsedCssIdentifierEquals("\uDBFF\uDFFF", "\\10fFfF");
-        assertParsedCssIdentifierEquals("\uDBFF\uDFFF0", "\\10fFfF0");
-        assertParsedCssIdentifierEquals("\uDBC0\uDC0000", "\\10000000");
-        assertParsedCssIdentifierEquals("eof\uFFFD", "eof\\");
-
-        assertParsedCssIdentifierEquals("simple-ident", "simple-ident");
-        assertParsedCssIdentifierEquals("testing123", "testing123");
-        assertParsedCssIdentifierEquals("_underscore", "_underscore");
-        assertParsedCssIdentifierEquals("-text", "-text");
-        assertParsedCssIdentifierEquals("-m", "-\\6d");
-        assertParsedCssIdentifierEquals("--abc", "--abc");
-        assertParsedCssIdentifierEquals("--", "--");
-        assertParsedCssIdentifierEquals("--11", "--11");
-        assertParsedCssIdentifierEquals("---", "---");
-        assertParsedCssIdentifierEquals("\u2003", "\u2003");
-        assertParsedCssIdentifierEquals("\u00A0", "\u00A0");
-        assertParsedCssIdentifierEquals("\u1234", "\u1234");
-        assertParsedCssIdentifierEquals("\uD808\uDF45", "\uD808\uDF45");
-        assertParsedCssIdentifierEquals("\uFFFD", "\u0000");
-        assertParsedCssIdentifierEquals("ab\uFFFDc", "ab\u0000c");
+    @ParameterizedTest
+    @MethodSource("cssIdentifiers")
+    @MethodSource("cssAdditionalIdentifiers")
+    void consumeCssIdentifier_WebPlatformTests(String expected, String cssIdentifier) {
+        assertParsedCssIdentifierEquals(expected, cssIdentifier);
     }
 
-    @Test public void consumeCssIdentifier_additional() {
-        assertParsedCssIdentifierEquals("1st", "\\31\r\nst");
-        assertParsedCssIdentifierEquals("1", "\\31\r");
-        assertParsedCssIdentifierEquals("1a", "\\31\ra");
-        assertParsedCssIdentifierEquals("1", "\\031");
-        assertParsedCssIdentifierEquals("1", "\\0031");
-        assertParsedCssIdentifierEquals("1", "\\00031");
-        assertParsedCssIdentifierEquals("1", "\\000031");
-        assertParsedCssIdentifierEquals("1", "\\000031");
-        assertParsedCssIdentifierEquals("a", "a\\\nb");
+    private static Stream<Arguments> cssIdentifiers() {
+        return Stream.of(
+            // https://github.com/web-platform-tests/wpt/blob/36036fb5212a3fc15fc5750cecb1923ba4071668/dom/nodes/ParentNode-querySelector-escapes.html
+            // - escape hex digit
+            Arguments.of("0nextIsWhiteSpace", "\\30 nextIsWhiteSpace"),
+            Arguments.of("0nextIsNotHexLetters", "\\30nextIsNotHexLetters"),
+            Arguments.of("0connectHexMoreThan6Hex", "\\000030connectHexMoreThan6Hex"),
+            Arguments.of("0spaceMoreThan6Hex", "\\000030 spaceMoreThan6Hex"),
 
-        try {
-            parseCssIdentifier("");
-            fail("Expected failure");
-        } catch (IllegalArgumentException e) {
-            assertEquals("CSS identifier expected, but end of input found", e.getMessage());
-        }
+            // - hex digit special replacement
+            // 1. zero points
+            Arguments.of("zero\uFFFD", "zero\\0"),
+            Arguments.of("zero\uFFFD", "zero\\000000"),
+            // 2. surrogate points
+            Arguments.of("\uFFFDsurrogateFirst", "\\d83d surrogateFirst"),
+            Arguments.of("surrogateSecond\uFFFd", "surrogateSecond\\dd11"),
+            Arguments.of("surrogatePair\uFFFD\uFFFD", "surrogatePair\\d83d\\dd11"),
+            // 3. out of range points
+            Arguments.of("outOfRange\uFFFD", "outOfRange\\110000"),
+            Arguments.of("outOfRange\uFFFD", "outOfRange\\110030"),
+            Arguments.of("outOfRange\uFFFD", "outOfRange\\555555"),
+            Arguments.of("outOfRange\uFFFD", "outOfRange\\ffffff"),
+
+            // - escape anything else
+            Arguments.of(".comma", "\\.comma"),
+            Arguments.of("-minus", "\\-minus"),
+            Arguments.of("g", "\\g"),
+
+            // non edge cases
+            Arguments.of("aBMPRegular", "\\61 BMPRegular"),
+            Arguments.of("\uD83D\uDD11nonBMP", "\\1f511 nonBMP"),
+            Arguments.of("00continueEscapes", "\\30\\30 continueEscapes"),
+            Arguments.of("00continueEscapes", "\\30 \\30 continueEscapes"),
+            Arguments.of("continueEscapes00", "continueEscapes\\30 \\30 "),
+            Arguments.of("continueEscapes00", "continueEscapes\\30 \\30"),
+            Arguments.of("continueEscapes00", "continueEscapes\\30\\30 "),
+            Arguments.of("continueEscapes00", "continueEscapes\\30\\30"),
+
+            // ident tests case from CSS tests of chromium source: https://goo.gl/3Cxdov
+            Arguments.of("hello", "hel\\6Co"),
+            Arguments.of("&B", "\\26 B"),
+            Arguments.of("hello", "hel\\6C o"),
+            Arguments.of("spaces", "spac\\65\r\ns"),
+            Arguments.of("spaces", "sp\\61\tc\\65\fs"),
+            Arguments.of("test\uD799", "test\\D799"),
+            Arguments.of("\uE000", "\\E000"),
+            Arguments.of("test", "te\\s\\t"),
+            Arguments.of("spaces in\tident", "spaces\\ in\\\tident"),
+            Arguments.of(".,:!", "\\.\\,\\:\\!"),
+            Arguments.of("null\uFFFD", "null\\0"),
+            Arguments.of("null\uFFFD", "null\\0000"),
+            Arguments.of("large\uFFFD", "large\\110000"),
+            Arguments.of("large\uFFFD", "large\\23456a"),
+            Arguments.of("surrogate\uFFFD", "surrogate\\D800"),
+            Arguments.of("surrogate\uFFFD", "surrogate\\0DBAC"),
+            Arguments.of("\uFFFDsurrogate", "\\00DFFFsurrogate"),
+            Arguments.of("\uDBFF\uDFFF", "\\10fFfF"),
+            Arguments.of("\uDBFF\uDFFF0", "\\10fFfF0"),
+            Arguments.of("\uDBC0\uDC0000", "\\10000000"),
+            Arguments.of("eof\uFFFD", "eof\\"),
+
+            Arguments.of("simple-ident", "simple-ident"),
+            Arguments.of("testing123", "testing123"),
+            Arguments.of("_underscore", "_underscore"),
+            Arguments.of("-text", "-text"),
+            Arguments.of("-m", "-\\6d"),
+            Arguments.of("--abc", "--abc"),
+            Arguments.of("--", "--"),
+            Arguments.of("--11", "--11"),
+            Arguments.of("---", "---"),
+            Arguments.of("\u2003", "\u2003"),
+            Arguments.of("\u00A0", "\u00A0"),
+            Arguments.of("\u1234", "\u1234"),
+            Arguments.of("\uD808\uDF45", "\uD808\uDF45"),
+            Arguments.of("\uFFFD", "\u0000"),
+            Arguments.of("ab\uFFFDc", "ab\u0000c")
+        );
+    }
+
+    private static Stream<Arguments> cssAdditionalIdentifiers() {
+        return Stream.of(
+            Arguments.of("1st", "\\31\r\nst"),
+            Arguments.of("1", "\\31\r"),
+            Arguments.of("1a", "\\31\ra"),
+            Arguments.of("1", "\\031"),
+            Arguments.of("1", "\\0031"),
+            Arguments.of("1", "\\00031"),
+            Arguments.of("1", "\\000031"),
+            Arguments.of("1", "\\000031"),
+            Arguments.of("a", "a\\\nb")
+        );
+    }
+
+    @Test void consumeCssIdentifierWithEmptyInput() {
+        TokenQueue emptyQueue = new TokenQueue("");
+        Exception exception = assertThrows(IllegalArgumentException.class, emptyQueue::consumeCssIdentifier);
+        assertEquals("CSS identifier expected, but end of input found", exception.getMessage());
     }
 
     // Some of jsoup's tests depend on this behavior

--- a/src/test/java/org/jsoup/parser/TokenQueueTest.java
+++ b/src/test/java/org/jsoup/parser/TokenQueueTest.java
@@ -139,4 +139,116 @@ public class TokenQueueTest {
         assertEquals("i\\d", q.consumeCssIdentifier());
         assertTrue(q.isEmpty());
     }
+
+    // https://github.com/web-platform-tests/wpt/blob/36036fb5212a3fc15fc5750cecb1923ba4071668/dom/nodes/ParentNode-querySelector-escapes.html
+    @Test public void consumeCssIdentifier_WebPlatformTests() {
+        // - escape hex digit
+        assertParsedCssIdentifierEquals("0nextIsWhiteSpace", "\\30 nextIsWhiteSpace");
+        assertParsedCssIdentifierEquals("0nextIsNotHexLetters", "\\30nextIsNotHexLetters");
+        assertParsedCssIdentifierEquals("0connectHexMoreThan6Hex", "\\000030connectHexMoreThan6Hex");
+        assertParsedCssIdentifierEquals("0spaceMoreThan6Hex", "\\000030 spaceMoreThan6Hex");
+
+        // - hex digit special replacement
+        // 1. zero points
+        assertParsedCssIdentifierEquals("zero\uFFFD", "zero\\0");
+        assertParsedCssIdentifierEquals("zero\uFFFD", "zero\\000000");
+        // 2. surrogate points
+        assertParsedCssIdentifierEquals("\uFFFDsurrogateFirst", "\\d83d surrogateFirst");
+        assertParsedCssIdentifierEquals("surrogateSecond\uFFFd", "surrogateSecond\\dd11");
+        assertParsedCssIdentifierEquals("surrogatePair\uFFFD\uFFFD", "surrogatePair\\d83d\\dd11");
+        // 3. out of range points
+        assertParsedCssIdentifierEquals("outOfRange\uFFFD", "outOfRange\\110000");
+        assertParsedCssIdentifierEquals("outOfRange\uFFFD", "outOfRange\\110030");
+        assertParsedCssIdentifierEquals("outOfRange\uFFFD", "outOfRange\\555555");
+        assertParsedCssIdentifierEquals("outOfRange\uFFFD", "outOfRange\\ffffff");
+
+        // - escape anything else
+        assertParsedCssIdentifierEquals(".comma", "\\.comma");
+        assertParsedCssIdentifierEquals("-minus", "\\-minus");
+        assertParsedCssIdentifierEquals("g", "\\g");
+
+        // non edge cases
+        assertParsedCssIdentifierEquals("aBMPRegular", "\\61 BMPRegular");
+        assertParsedCssIdentifierEquals("\uD83D\uDD11nonBMP", "\\1f511 nonBMP");
+        assertParsedCssIdentifierEquals("00continueEscapes", "\\30\\30 continueEscapes");
+        assertParsedCssIdentifierEquals("00continueEscapes", "\\30 \\30 continueEscapes");
+        assertParsedCssIdentifierEquals("continueEscapes00", "continueEscapes\\30 \\30 ");
+        assertParsedCssIdentifierEquals("continueEscapes00", "continueEscapes\\30 \\30");
+        assertParsedCssIdentifierEquals("continueEscapes00", "continueEscapes\\30\\30 ");
+        assertParsedCssIdentifierEquals("continueEscapes00", "continueEscapes\\30\\30");
+
+        // ident tests case from CSS tests of chromium source: https://goo.gl/3Cxdov
+        assertParsedCssIdentifierEquals("hello", "hel\\6Co");
+        assertParsedCssIdentifierEquals("&B", "\\26 B");
+        assertParsedCssIdentifierEquals("hello", "hel\\6C o");
+        assertParsedCssIdentifierEquals("spaces", "spac\\65\r\ns");
+        assertParsedCssIdentifierEquals("spaces", "sp\\61\tc\\65\fs");
+        assertParsedCssIdentifierEquals("test\uD799", "test\\D799");
+        assertParsedCssIdentifierEquals("\uE000", "\\E000");
+        assertParsedCssIdentifierEquals("test", "te\\s\\t");
+        assertParsedCssIdentifierEquals("spaces in\tident", "spaces\\ in\\\tident");
+        assertParsedCssIdentifierEquals(".,:!", "\\.\\,\\:\\!");
+        assertParsedCssIdentifierEquals("null\uFFFD", "null\\0");
+        assertParsedCssIdentifierEquals("null\uFFFD", "null\\0000");
+        assertParsedCssIdentifierEquals("large\uFFFD", "large\\110000");
+        assertParsedCssIdentifierEquals("large\uFFFD", "large\\23456a");
+        assertParsedCssIdentifierEquals("surrogate\uFFFD", "surrogate\\D800");
+        assertParsedCssIdentifierEquals("surrogate\uFFFD", "surrogate\\0DBAC");
+        assertParsedCssIdentifierEquals("\uFFFDsurrogate", "\\00DFFFsurrogate");
+        assertParsedCssIdentifierEquals("\uDBFF\uDFFF", "\\10fFfF");
+        assertParsedCssIdentifierEquals("\uDBFF\uDFFF0", "\\10fFfF0");
+        assertParsedCssIdentifierEquals("\uDBC0\uDC0000", "\\10000000");
+        assertParsedCssIdentifierEquals("eof\uFFFD", "eof\\");
+
+        assertParsedCssIdentifierEquals("simple-ident", "simple-ident");
+        assertParsedCssIdentifierEquals("testing123", "testing123");
+        assertParsedCssIdentifierEquals("_underscore", "_underscore");
+        assertParsedCssIdentifierEquals("-text", "-text");
+        assertParsedCssIdentifierEquals("-m", "-\\6d");
+        assertParsedCssIdentifierEquals("--abc", "--abc");
+        assertParsedCssIdentifierEquals("--", "--");
+        assertParsedCssIdentifierEquals("--11", "--11");
+        assertParsedCssIdentifierEquals("---", "---");
+        assertParsedCssIdentifierEquals("\u2003", "\u2003");
+        assertParsedCssIdentifierEquals("\u00A0", "\u00A0");
+        assertParsedCssIdentifierEquals("\u1234", "\u1234");
+        assertParsedCssIdentifierEquals("\uD808\uDF45", "\uD808\uDF45");
+        assertParsedCssIdentifierEquals("\uFFFD", "\u0000");
+        assertParsedCssIdentifierEquals("ab\uFFFDc", "ab\u0000c");
+    }
+
+    @Test public void consumeCssIdentifier_additional() {
+        assertParsedCssIdentifierEquals("1st", "\\31\r\nst");
+        assertParsedCssIdentifierEquals("1", "\\31\r");
+        assertParsedCssIdentifierEquals("1a", "\\31\ra");
+        assertParsedCssIdentifierEquals("1", "\\031");
+        assertParsedCssIdentifierEquals("1", "\\0031");
+        assertParsedCssIdentifierEquals("1", "\\00031");
+        assertParsedCssIdentifierEquals("1", "\\000031");
+        assertParsedCssIdentifierEquals("1", "\\000031");
+        assertParsedCssIdentifierEquals("a", "a\\\nb");
+
+        try {
+            parseCssIdentifier("");
+            fail("Expected failure");
+        } catch (IllegalArgumentException e) {
+            assertEquals("CSS identifier expected, but end of input found", e.getMessage());
+        }
+    }
+
+    // Some of jsoup's tests depend on this behavior
+    @Test public void consumeCssIdentifier_invalidButSupportedForBackwardsCompatibility() {
+        assertParsedCssIdentifierEquals("1", "1");
+        assertParsedCssIdentifierEquals("-", "-");
+        assertParsedCssIdentifierEquals("-1", "-1");
+    }
+
+    private static String parseCssIdentifier(String text) {
+        TokenQueue q = new TokenQueue(text);
+        return q.consumeCssIdentifier();
+    }
+
+    private void assertParsedCssIdentifierEquals(String expected, String cssIdentifier) {
+        assertEquals(expected, parseCssIdentifier(cssIdentifier));
+    }
 }

--- a/src/test/java/org/jsoup/select/SelectorTest.java
+++ b/src/test/java/org/jsoup/select/SelectorTest.java
@@ -1450,4 +1450,15 @@ public class SelectorTest {
         assertTrue(b_needs_a.threadMemo.get().isEmpty());
         assertTrue(c_needs_b.threadMemo.get().isEmpty());
     }
+
+    @Test void hexDigitUnescape() {
+        // tests the select component of https://github.com/jhy/jsoup/pull/2297, with per-spec escapes
+        // literal is: #\30 \%\ Platform\ Image
+        String html = "<img id='0% Platform Image'>";
+        String q = "#\\30 \\%\\ Platform\\ Image";
+
+        Document doc = Jsoup.parse(html);
+        Element img = doc.expectFirst(q);
+        assertEquals("img", img.tagName());
+    }
 }


### PR DESCRIPTION
Rewrite `TokenQueue.consumeCssIdentifier()` to support escaped hex digits and to more closely match the relevant [CSS spec](https://www.w3.org/TR/css-syntax-3/#consume-name).

Part 1 of fixing #1967.