### PR TITLE
Use proper escaping in `TokenQueue.escapeCssIdentifier()`

### DIFF
--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -2,6 +2,7 @@ package org.jsoup.select;
 
 import org.jsoup.helper.Validate;
 import org.jsoup.nodes.Element;
+import org.jsoup.parser.TokenQueue;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
@@ -216,6 +217,33 @@ public class Selector {
         }
 
         return null;
+    }
+
+    /**
+     Given a CSS identifier (such as a tag, ID, or class), escape any CSS special characters that would otherwise not be
+     valid in a selector.
+
+     @see <a href="https://www.w3.org/TR/cssom-1/#serialize-an-identifier">CSS Object Model, serialize an identifier</a>
+     @since 1.20.1
+     */
+    public static String escapeCssIdentifier(String in) {
+        return TokenQueue.escapeCssIdentifier(in);
+    }
+
+    /**
+     Consume a CSS identifier (ID or class) off the queue.
+     <p>Note: For backwards compatibility this method supports improperly formatted CSS identifiers, e.g. {@code 1} instead
+     of {@code \31}.</p>
+
+     @return The unescaped identifier.
+     @throws IllegalArgumentException if an invalid escape sequence was found.
+     @see <a href="https://www.w3.org/TR/css-syntax-3/#consume-name">CSS Syntax Module Level 3, Consume an ident sequence</a>
+     @see <a href="https://www.w3.org/TR/css-syntax-3/#typedef-ident-token">CSS Syntax Module Level 3, ident-token</a>
+     @since 1.20.1
+     */
+    public static String unescapeCssIdentifier(String in) {
+        TokenQueue tq = new TokenQueue(in);
+        return tq.consumeCssIdentifier();
     }
 
     public static class SelectorParseException extends IllegalStateException {

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -2697,6 +2697,26 @@ public class ElementTest {
         assertSelectedOwnText(selected, "One");
     }
 
+    @Test void cssSelectorCombined() {
+        // https://github.com/jhy/jsoup/issues/1984
+        Document doc = Jsoup.parse("<img class='e\u0301'><p class=👨‍👨‍👧‍👧></p><a class='\uD83D\uDC68\u200D\uD83D\uDC68\u200D\uD83D\uDC67\u200D\uD83D\uDC67'></a>");
+        Element img = doc.expectFirst("img");
+        Element p = doc.expectFirst("p");
+        Element a = doc.expectFirst("a");
+
+        String imgQ = img.cssSelector();
+        String pQ = p.cssSelector();
+        String aQ = a.cssSelector();
+
+        assertEquals("html > body > img.é", imgQ); // previously was img.e\́; chrome gives literal body > img.e\\u0301
+        assertEquals("html > body > p.👨‍👨‍👧‍👧", pQ); // chrome gives body > p.👨‍👨‍👧‍👧
+        assertEquals("html > body > a.👨‍👨‍👧‍👧", aQ); // body > a.👨‍👨‍👧‍👧
+
+        assertSame(img, doc.expectFirst(imgQ));
+        assertSame(p, doc.expectFirst(pQ));
+        assertSame(a, doc.expectFirst(aQ));
+    }
+
     @Test void orphanSiblings() {
         Element el = new Element("div");
         assertEquals(0, el.siblingElements().size());

--- a/src/test/java/org/jsoup/select/SelectorTest.java
+++ b/src/test/java/org/jsoup/select/SelectorTest.java
@@ -1461,4 +1461,17 @@ public class SelectorTest {
         Element img = doc.expectFirst(q);
         assertEquals("img", img.tagName());
     }
+
+    @Test void escapeCssIdentifier() {
+        // thorough tests are in TokenQueue
+        assertEquals("-\\30 a", Selector.escapeCssIdentifier("-0a"));
+        assertEquals("a0b", Selector.escapeCssIdentifier("a0b"));
+    }
+
+    @Test void unescapeCssIdentifier() {
+        // thorough tests are in TokenQueue
+        assertEquals("-0a", Selector.unescapeCssIdentifier("-\\30 a"));
+        assertEquals("a0b", Selector.unescapeCssIdentifier("a0b"));
+    }
+
 }


### PR DESCRIPTION
Fixes #1984

Side note: This method seems useful to library users when programmatically building CSS selectors. I think it should be part of the stable API surface and not live inside of `TokenQueue`.