### PR TITLE
Store cached child els in Attributes, not field

### DIFF
--- a/src/main/java/org/jsoup/helper/ChangeNotifyingArrayList.java
+++ b/src/main/java/org/jsoup/helper/ChangeNotifyingArrayList.java
@@ -5,8 +5,9 @@ import java.util.Collection;
 
 /**
  * Implementation of ArrayList that watches out for changes to the contents.
+ @deprecated this class is no longer used and will be removed in jsoup 1.21.1.
  */
-public abstract class ChangeNotifyingArrayList<E> extends ArrayList<E> {
+@Deprecated public abstract class ChangeNotifyingArrayList<E> extends ArrayList<E> {
     public ChangeNotifyingArrayList(int initialCapacity) {
         super(initialCapacity);
     }

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -501,10 +501,6 @@ public abstract class Node implements Cloneable {
         return el;
     }
 
-    void nodelistChanged() {
-        // Element overrides this to clear its shadow children elements
-    }
-
     /**
      * Replace this node in the DOM with the supplied node.
      * @param in the node that will replace the existing node.


### PR DESCRIPTION
We keep a lazy initialized, cached copy of an Element's child Element list, to save recreating it every time they are requested.

That was stored in a nullable field. This change moves it into the userdata section of the attributes instead.

Also, rather than tracking changes to the backing node list via a ChangeNotifyingArrayList, I'm using the ArrayList's modcount instead directly. So we can deprecate the ChangeNotifyingArrayList.

Ultimately this trims the shallow size of an Element from 40 to 32 bytes, and the NodeList from 32 to 24 (20% and 25% decreases respectively)