### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,5 @@ jobs:
         run: mvn -X compile -B --file pom.xml
 
       - name: Maven Verify
-        run: mvn -X verify -B --file pom.xml
+        run: mvn -X verify -B --file pom.xml -DdisableXmlReport=true
 ...


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.