### PR TITLE
Add SimpleStreamReader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.jsoup</groupId>
   <artifactId>jsoup</artifactId>
-  <version>1.20.2-SNAPSHOT</version><!-- remember to update previous version below for japicmp -->
+  <version>1.21.1-SNAPSHOT</version><!-- remember to update previous version below for japicmp -->
   <url>https://jsoup.org/</url>
   <description>jsoup is a Java library that simplifies working with real-world HTML and XML. It offers an easy-to-use API for URL fetching, data parsing, extraction, and manipulation using DOM API methods, CSS, and xpath selectors. jsoup implements the WHATWG HTML5 specification, and parses HTML to the same DOM as modern browsers.</description>
   <inceptionYear>2009</inceptionYear>

--- a/src/main/java/org/jsoup/internal/SimpleBufferedInput.java
+++ b/src/main/java/org/jsoup/internal/SimpleBufferedInput.java
@@ -10,7 +10,7 @@ import java.io.InputStream;
 import static org.jsoup.internal.SharedConstants.DefaultBufferSize;
 
 /**
- A simple implemented of a buffered input stream, in which we can control the byte[] buffer to recycle it. Not safe for
+ A simple implementation of a buffered input stream, in which we can control the byte[] buffer to recycle it. Not safe for
  use between threads; no sync or locks. The buffer is borrowed on initial demand in fill.
  @since 1.18.2
  */

--- a/src/main/java/org/jsoup/internal/SimpleStreamReader.java
+++ b/src/main/java/org/jsoup/internal/SimpleStreamReader.java
@@ -1,0 +1,88 @@
+package org.jsoup.internal;
+
+import org.jsoup.helper.Validate;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+
+import static org.jsoup.internal.SimpleBufferedInput.BufferPool;
+
+/**
+ A simple decoding InputStreamReader that recycles internal buffers.
+ */
+public class SimpleStreamReader extends Reader {
+    private final InputStream in;
+    private final CharsetDecoder decoder;
+    private @Nullable ByteBuffer byteBuf; // null after close
+
+    public SimpleStreamReader(InputStream in, Charset charset) {
+        this.in = in;
+        this.decoder = charset.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPLACE)
+            .onUnmappableCharacter(CodingErrorAction.REPLACE);
+        byte[] buf = BufferPool.borrow(); // shared w/ SimpleBufferedInput, ControllableInput
+        byteBuf = ByteBuffer.wrap(buf);
+        byteBuf.flip(); // limit(0)
+    }
+
+    @Override
+    public int read(char[] charArray, int off, int len) throws IOException {
+        Validate.notNull(byteBuf); // can't read after close
+        CharBuffer charBuf = CharBuffer.wrap(charArray, off, len);
+        if (charBuf.position() != 0) charBuf = charBuf.slice();
+
+        boolean readFully = false;
+        while (true) {
+            CoderResult result = decoder.decode(byteBuf, charBuf, readFully);
+            if (result.isUnderflow()) {
+                if (readFully || !charBuf.hasRemaining() || (charBuf.position() > 0) && !(in.available() > 0))
+                    break;
+                int read = bufferUp();
+                if (read < 0) {
+                    readFully = true;
+                    if ((charBuf.position() == 0) && (!byteBuf.hasRemaining()))
+                        break;
+                }
+                continue;
+            }
+            if (result.isOverflow()) break;
+            result.throwException();
+        }
+
+        if (readFully) decoder.reset();
+        if (charBuf.position() == 0) return -1;
+        return charBuf.position();
+    }
+
+    private int bufferUp() throws IOException {
+        assert byteBuf != null; // already validated ^
+        byteBuf.compact();
+        try {
+            int pos = byteBuf.position();
+            int remaining = (byteBuf.limit() - pos);
+            int read = in.read(byteBuf.array(), byteBuf.arrayOffset() + pos, remaining);
+            if (read < 0) return read;
+            if (read == 0) throw new IOException("Underlying input stream returned zero bytes");
+            byteBuf.position(pos + read);
+        } finally {
+            byteBuf.flip();
+        }
+        return byteBuf.remaining();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (byteBuf == null) return;
+        BufferPool.release(byteBuf.array());
+        byteBuf = null;
+        in.close();
+    }
+}


### PR DESCRIPTION
Continuing on the work in #2186 to reuse large buffers to minimize allocations (and therefore GC) during parsing, this change allows us to reuse the byte -> char decoding buffer.

Replaces uses of InputStreamReader with a simplified version, where we recycle the underlying byte buffer, vs creating a new 8k buffer on every parse.

Gives a good performance improvements for all but the largest inputs, where the allocation cost is amortized across a longer parse.