### PR TITLE
Selectors can match against Nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Removed previously deprecated methods. [#2317](https://github.com/jhy/jsoup/pull/2317)
 
 ### Improvements
+* Enhanced the `Selector` to support direct matching against nodes such as comments and text nodes. For example, you can now find an element that follows a specific comment: `::comment:contains(prices) + p` will select `p` elements immediately after a `<!-- prices: -->` comment. Supported types include `::node`, `::leafnode`, `::comment`, `::text`, and `::data`. Node contextual selectors like `::node:contains(text)`, `:matches(regex)`, and `:blank` are also supported. Introduced `Element#selectNodes(String css)` and `Element#selectNodes(String css, Class nodeType)` for direct node selection. [#2324](https://github.com/jhy/jsoup/pull/2324)
 * Added `TagSet#onNewTag(Consumer<Tag> customizer)`: register a callback that’s invoked for each new or cloned Tag when it’s inserted into the set. Enables dynamic tweaks of tag options (for example, marking all custom tags as self-closing, or everything in a given namespace as preserving whitespace).
 * Made `TokenQueue` and `CharacterReader` autocloseable, to ensure that they will release their buffers back to the buffer pool, for later reuse.
 * Added `Selector#evaluatorOf(String css)`, as a clearer way to obtain an Evaluator from a CSS query. An alias of `QueryParser.parse(String css)`.

--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,14 @@
                 <binaryCompatible>true</binaryCompatible>
                 <sourceCompatible>true</sourceCompatible>
               </overrideCompatibilityChangeParameter>
+
+              <overrideCompatibilityChangeParameter>
+                <!-- false positive on JDK21; List interface has new defaults; Elements now extends Nodes extends ArrayList (WAS Elements extends ArrayList) -->
+                <compatibilityChange>METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE</compatibilityChange>
+                <binaryCompatible>true</binaryCompatible>
+                <sourceCompatible>true</sourceCompatible>
+              </overrideCompatibilityChangeParameter>
+
             </overrideCompatibilityChangeParameters>
           </parameter>
         </configuration>

--- a/src/main/java/org/jsoup/helper/Validate.java
+++ b/src/main/java/org/jsoup/helper/Validate.java
@@ -45,9 +45,10 @@ public final class Validate {
     /**
      Verifies the input object is not null, and returns that object. Effectively this casts a nullable object to a non-
      null object. (Works around lack of Objects.requestNonNull in Android version.)
-     * @param obj nullable object to case to not-null
+     * @param obj nullable object to cast to not-null
      * @return the object, or throws an exception if it is null
      * @throws ValidationException if the object is null
+     * @deprecated prefer to use {@link #expectNotNull(Object, String, Object...)} instead
      */
     public static Object ensureNotNull(@Nullable Object obj) {
         if (obj == null)
@@ -58,13 +59,44 @@ public final class Validate {
     /**
      Verifies the input object is not null, and returns that object. Effectively this casts a nullable object to a non-
      null object. (Works around lack of Objects.requestNonNull in Android version.)
-     * @param obj nullable object to case to not-null
+     * @param obj nullable object to cast to not-null
      * @param msg the String format message to include in the validation exception when thrown
      * @param args the arguments to the msg
      * @return the object, or throws an exception if it is null
      * @throws ValidationException if the object is null
+     * @deprecated prefer to use {@link #expectNotNull(Object, String, Object...)} instead
      */
     public static Object ensureNotNull(@Nullable Object obj, String msg, Object... args) {
+        if (obj == null)
+            throw new ValidationException(String.format(msg, args));
+        else return obj;
+    }
+
+    /**
+     Verifies the input object is not null, and returns that object, maintaining its type. Effectively this casts a
+     nullable object to a non-null object.
+
+     @param obj nullable object to cast to not-null
+     @return the object, or throws an exception if it is null
+     @throws ValidationException if the object is null
+     */
+    public static <T> T expectNotNull(@Nullable T obj) {
+        if (obj == null)
+            throw new ValidationException("Object must not be null");
+        else return obj;
+    }
+
+    /**
+     Verifies the input object is not null, and returns that object, maintaining its type. Effectively this casts a
+     nullable object to a non-null object.
+
+     @param obj nullable object to cast to not-null
+     @param msg the String format message to include in the validation exception when thrown
+     @param args the arguments to the msg
+     @return the object, or throws an exception if it is null
+     @throws ValidationException if the object is null
+     */
+    public static <T> T expectNotNull(@Nullable T obj, String msg, Object... args) {
         if (obj == null)
             throw new ValidationException(String.format(msg, args));
         else return obj;

--- a/src/main/java/org/jsoup/internal/Normalizer.java
+++ b/src/main/java/org/jsoup/internal/Normalizer.java
@@ -13,7 +13,7 @@ public final class Normalizer {
 
     /** Drops the input string to lower case. */
     public static String lowerCase(final String input) {
-        return input != null ? input.toLowerCase(Locale.ENGLISH) : "";
+        return input != null ? input.toLowerCase(Locale.ROOT) : "";
     }
 
     /** Lower-cases and trims the input string. */

--- a/src/main/java/org/jsoup/nodes/LeafNode.java
+++ b/src/main/java/org/jsoup/nodes/LeafNode.java
@@ -2,6 +2,7 @@ package org.jsoup.nodes;
 
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.QuietAppendable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -41,6 +42,16 @@ public abstract class LeafNode extends Node {
 
     String coreValue() {
         return attr(nodeName());
+    }
+
+    @Override @Nullable
+    public Element parent() {
+        return parentNode;
+    }
+
+    @Override
+    public String nodeValue() {
+        return coreValue();
     }
 
     void coreValue(String value) {

--- a/src/main/java/org/jsoup/parser/StreamParser.java
+++ b/src/main/java/org/jsoup/parser/StreamParser.java
@@ -221,7 +221,7 @@ public class StreamParser implements Closeable {
      @throws IOException if an I/O error occurs
      */
     public Element expectFirst(String query) throws IOException {
-        return (Element) Validate.ensureNotNull(
+        return Validate.expectNotNull(
             selectFirst(query),
             "No elements matched the query '%s' in the document."
             , query
@@ -269,7 +269,7 @@ public class StreamParser implements Closeable {
      @throws IOException if an I/O error occurs
      */
     public Element expectNext(String query) throws IOException {
-        return (Element) Validate.ensureNotNull(
+        return Validate.expectNotNull(
             selectNext(query),
             "No elements matched the query '%s' in the document."
             , query
@@ -368,7 +368,7 @@ public class StreamParser implements Closeable {
         // NodeVisitor Interface:
         @Override public void head(Node node, int depth) {
             if (node instanceof Element) {
-                Element prev = ((Element) node).previousElementSibling();
+                Element prev = node.previousElementSibling();
                 // We prefer to wait until an element has a next sibling before emitting it; otherwise, get it in tail
                 if (prev != null) emitQueue.add(prev);
             }

--- a/src/main/java/org/jsoup/select/Collector.java
+++ b/src/main/java/org/jsoup/select/Collector.java
@@ -1,10 +1,16 @@
 package org.jsoup.select;
 
+import org.jsoup.helper.Validate;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.LeafNode;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
 import org.jspecify.annotations.Nullable;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toCollection;
 
 /**
  * Collects a list of elements that match the supplied criteria.
@@ -22,7 +28,11 @@ public class Collector {
      @return list of matches; empty if none
      */
     public static Elements collect(Evaluator eval, Element root) {
-        return stream(eval, root).collect(Collectors.toCollection(Elements::new));
+        Stream<Element> stream = eval.wantsNodes() ?
+            streamNodes(eval, root, Element.class) :
+            stream(eval, root);
+
+        return stream.collect(toCollection(Elements::new));
     }
 
     /**
@@ -39,6 +49,22 @@ public class Collector {
     }
 
     /**
+     Obtain a Stream of nodes, of the specified type, by visiting the root and every descendant of root and testing it
+     against the evaluator.
+
+     @param evaluator Evaluator to test elements against
+     @param root root of tree to descend
+     @param type the type of node to collect (e.g. {@link Element}, {@link LeafNode}, {@link TextNode} etc)
+     @param <T> the type of node to collect
+     @return A {@link Stream} of matches
+     @since 1.21.1
+     */
+    public static <T extends Node> Stream<T> streamNodes(Evaluator evaluator, Element root, Class<T> type) {
+        evaluator.reset();
+        return root.nodeStream(type).filter(evaluator.asNodePredicate(root));
+    }
+
+    /**
      Finds the first Element that matches the Evaluator that descends from the root, and stops the query once that first
      match is found.
      @param eval Evaluator to test elements against
@@ -47,5 +73,33 @@ public class Collector {
      */
     public static @Nullable Element findFirst(Evaluator eval, Element root) {
         return stream(eval, root).findFirst().orElse(null);
+    }
+
+    /**
+     Finds the first Node that matches the Evaluator that descends from the root, and stops the query once that first
+     match is found.
+
+     @param eval Evaluator to test elements against
+     @param root root of tree to descend
+     @param type the type of node to collect (e.g. {@link Element}, {@link LeafNode}, {@link TextNode} etc)
+     @return the first match; {@code null} if none
+     @since 1.21.1
+     */
+    public static <T extends Node> @Nullable T findFirstNode(Evaluator eval, Element root, Class<T> type) {
+        return streamNodes(eval, root, type).findFirst().orElse(null);
+    }
+
+    /**
+     Build a list of nodes that match the supplied criteria, by visiting the root and every descendant of root, and
+     testing it against the Evaluator.
+
+     @param evaluator Evaluator to test elements against
+     @param root root of tree to descend
+     @param type the type of node to collect (e.g. {@link Element}, {@link LeafNode}, {@link TextNode} etc)
+     @param <T> the type of node to collect
+     @return list of matches; empty if none
+     */
+    public static <T extends Node> Nodes<T> collectNodes(Evaluator evaluator, Element root, Class<T> type) {
+        return streamNodes(evaluator, root, type).collect(toCollection(Nodes::new));
     }
 }

--- a/src/main/java/org/jsoup/select/NodeEvaluator.java
+++ b/src/main/java/org/jsoup/select/NodeEvaluator.java
@@ -1,0 +1,122 @@
+package org.jsoup.select;
+
+import org.jsoup.internal.StringUtil;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.LeafNode;
+import org.jsoup.nodes.Node;
+
+import java.util.regex.Pattern;
+
+import static org.jsoup.internal.Normalizer.lowerCase;
+import static org.jsoup.internal.StringUtil.normaliseWhitespace;
+
+abstract class NodeEvaluator extends Evaluator {
+
+    @Override
+    public boolean matches(Element root, Element element) {
+        return evaluateMatch(element);
+    }
+
+    @Override boolean matches(Element root, LeafNode leaf) {
+        return evaluateMatch(leaf);
+    }
+
+    abstract boolean evaluateMatch(Node node);
+    
+    @Override boolean wantsNodes() {
+        return true;
+    }
+
+    static class InstanceType extends NodeEvaluator {
+        final java.lang.Class<? extends Node> type;
+        final String selector;
+
+        InstanceType(java.lang.Class<? extends Node> type, String selector) {
+            super();
+            this.type = type;
+            this.selector = "::" + selector;
+        }
+
+        @Override
+        boolean evaluateMatch(Node node) {
+            return type.isInstance(node);
+        }
+
+        @Override
+        protected int cost() {
+            return 1;
+        }
+
+        @Override
+        public String toString() {
+            return selector;
+        }
+    }
+
+    static class ContainsValue extends NodeEvaluator {
+        private final String searchText;
+
+        public ContainsValue(String searchText) {
+            this.searchText = lowerCase(normaliseWhitespace(searchText));
+        }
+
+        @Override
+        boolean evaluateMatch(Node node) {
+            return lowerCase(node.nodeValue()).contains(searchText);
+        }
+
+        @Override
+        protected int cost() {
+            return 6;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(":contains(%s)", searchText);
+        }
+    }
+
+    /**
+     Matches nodes with no value or only whitespace.
+     */
+    static class BlankValue extends NodeEvaluator {
+
+        @Override
+        boolean evaluateMatch(Node node) {
+            return StringUtil.isBlank(node.nodeValue());
+        }
+
+        @Override
+        protected int cost() {
+            return 4;
+        }
+
+        @Override
+        public String toString() {
+            return ":blank";
+        }
+    }
+
+    static class MatchesValue extends NodeEvaluator {
+        private final Pattern pattern;
+
+        protected MatchesValue(Pattern pattern) {
+            this.pattern = pattern;
+        }
+
+        @Override
+        boolean evaluateMatch(Node node) {
+            return pattern.matcher(node.nodeValue()).find();
+        }
+
+        @Override
+        protected int cost() {
+            return 8;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(":matches(%s)", pattern);
+        }
+    }
+}

--- a/src/main/java/org/jsoup/select/Nodes.java
+++ b/src/main/java/org/jsoup/select/Nodes.java
@@ -1,0 +1,344 @@
+package org.jsoup.select;
+
+import org.jsoup.helper.Validate;
+import org.jsoup.internal.StringUtil;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ A list of {@link Node} objects, with methods that act on every node in the list.
+ <p>Methods that {@link #set(int, T) set}, {@link #remove(int) remove}, or
+ {@link #replaceAll(UnaryOperator)  replace} nodes in the list will also act on the underlying
+ {@link org.jsoup.nodes.Document DOM}.</p>
+
+ <p>If there are other bulk methods (perhaps from Elements) that would be useful here, please <a
+ href="https://jsoup.org/discussion">provide feedback</a>.</p>
+
+ @see Element#selectNodes(String)
+ @see Element#selectNodes(String, Class)
+ @since 1.21.1 */
+public class Nodes<T extends Node> extends ArrayList<T> {
+    public Nodes() {
+    }
+
+    public Nodes(int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    public Nodes(Collection<T> nodes) {
+        super(nodes);
+    }
+
+    public Nodes(List<T> nodes) {
+        super(nodes);
+    }
+
+    @SafeVarargs
+    public Nodes(T... nodes) {
+        super(Arrays.asList(nodes));
+    }
+
+    /**
+     * Creates a deep copy of these nodes.
+     * @return a deep copy
+     */
+    @Override
+    public Nodes<T> clone() {
+        Nodes<T> clone = new Nodes<>(size());
+        for (T node : this)
+            clone.add((T) node.clone());
+        return clone;
+    }
+
+    /**
+     Convenience method to get the Nodes as a plain ArrayList. This allows modification to the list of nodes
+     without modifying the source Document. I.e. whereas calling {@code nodes.remove(0)} will remove the nodes from
+     both the Nodes and the DOM, {@code nodes.asList().remove(0)} will remove the node from the list only.
+     <p>Each Node is still the same DOM connected Node.</p>
+
+     @return a new ArrayList containing the nodes in this list
+     @see #Nodes(List)
+     */
+    public ArrayList<T> asList() {
+        return new ArrayList<>(this);
+    }
+
+    /**
+     Remove each matched node from the DOM.
+     <p>The nodes will still be retained in this list, in case further processing of them is desired.</p>
+     <p>
+     E.g. HTML: {@code <div><p>Hello</p> <p>there</p> <img></div>}<br>
+     <code>doc.select("p").remove();</code><br>
+     HTML = {@code <div> <img></div>}
+     <p>
+     Note that this method should not be used to clean user-submitted HTML; rather, use {@link org.jsoup.safety.Cleaner}
+     to clean HTML.
+
+     @return this, for chaining
+     @see Element#empty()
+     @see Elements#empty()
+     @see #clear()
+     */
+    public Nodes<T> remove() {
+        for (T node : this) {
+            node.remove();
+        }
+        return this;
+    }
+
+    /**
+     Get the combined outer HTML of all matched nodes.
+
+     @return string of all node's outer HTML.
+     @see Elements#text()
+     @see Elements#html()
+     */
+    public String outerHtml() {
+        return stream()
+            .map(Node::outerHtml)
+            .collect(StringUtil.joining("\n"));
+    }
+
+    /**
+     Get the combined outer HTML of all matched nodes. Alias of {@link #outerHtml()}.
+
+     @return string of all the node's outer HTML.
+     @see Elements#text()
+     @see #outerHtml()
+     */
+    @Override
+    public String toString() {
+        return outerHtml();
+    }
+
+    /**
+     Insert the supplied HTML before each matched node's outer HTML.
+
+     @param html HTML to insert before each node
+     @return this, for chaining
+     @see Element#before(String)
+     */
+    public Nodes<T> before(String html) {
+        for (T node : this) {
+            node.before(html);
+        }
+        return this;
+    }
+
+    /**
+     Insert the supplied HTML after each matched nodes's outer HTML.
+
+     @param html HTML to insert after each node
+     @return this, for chaining
+     @see Element#after(String)
+     */
+    public Nodes<T> after(String html) {
+        for (T node : this) {
+            node.after(html);
+        }
+        return this;
+    }
+
+    /**
+     Wrap the supplied HTML around each matched node. For example, with HTML
+     {@code <p><b>This</b> is <b>Jsoup</b></p>},
+     <code>doc.select("b").wrap("&lt;i&gt;&lt;/i&gt;");</code>
+     becomes {@code <p><i><b>This</b></i> is <i><b>jsoup</b></i></p>}
+     @param html HTML to wrap around each node, e.g. {@code <div class="head"></div>}. Can be arbitrarily deep.
+     @return this (for chaining)
+     @see Element#wrap
+     */
+    public Nodes<T> wrap(String html) {
+        Validate.notEmpty(html);
+        for (T node : this) {
+            node.wrap(html);
+        }
+        return this;
+    }
+
+    // list-like methods
+    /**
+     Get the first matched element.
+     @return The first matched element, or <code>null</code> if contents is empty.
+     */
+    public @Nullable T first() {
+        return isEmpty() ? null : get(0);
+    }
+
+    /**
+     Get the last matched element.
+     @return The last matched element, or <code>null</code> if contents is empty.
+     */
+    public @Nullable T last() {
+        return isEmpty() ? null : get(size() - 1);
+    }
+
+    // ArrayList<T> methods that update the DOM:
+
+    /**
+     Replace the node at the specified index in this list, and in the DOM.
+
+     @param index index of the node to replace
+     @param node node to be stored at the specified position
+     @return the old Node at this index
+     */
+    @Override
+    public T set(int index, T node) {
+        Validate.notNull(node);
+        T old = super.set(index, node);
+        old.replaceWith(node);
+        return old;
+    }
+
+    /**
+     Remove the node at the specified index in this list, and from the DOM.
+
+     @param index the index of the node to be removed
+     @return the old node at this index
+     @see #deselect(int)
+     */
+    @Override
+    public T remove(int index) {
+        T old = super.remove(index);
+        old.remove();
+        return old;
+    }
+
+    /**
+     Remove the specified node from this list, and from the DOM.
+
+     @param o node to be removed from this list, if present
+     @return if this list contained the Node
+     @see #deselect(Object)
+     */
+    @Override
+    public boolean remove(Object o) {
+        int index = super.indexOf(o);
+        if (index == -1) {
+            return false;
+        } else {
+            remove(index);
+            return true;
+        }
+    }
+
+    /**
+     Remove the node at the specified index in this list, but not from the DOM.
+
+     @param index the index of the node to be removed
+     @return the old node at this index
+     @see #remove(int)
+     */
+    public T deselect(int index) {
+        return super.remove(index);
+    }
+
+    /**
+     Remove the specified node from this list, but not from the DOM.
+
+     @param o node to be removed from this list, if present
+     @return if this list contained the Node
+     @see #remove(Object)
+     */
+    public boolean deselect(Object o) {
+        return super.remove(o);
+    }
+
+    /**
+     Removes all the nodes from this list, and each of them from the DOM.
+
+     @see #deselectAll()
+     */
+    @Override
+    public void clear() {
+        remove();
+        super.clear();
+    }
+
+    /**
+     Like {@link #clear()}, removes all the nodes from this list, but not from the DOM.
+
+     @see #clear()
+     */
+    public void deselectAll() {
+        super.clear();
+    }
+
+    /**
+     Removes from this list, and from the DOM, each of the nodes that are contained in the specified collection and are
+     in this list.
+
+     @param c collection containing nodes to be removed from this list
+     @return {@code true} if nodes were removed from this list
+     */
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        boolean anyRemoved = false;
+        for (Object o : c) {
+            anyRemoved |= this.remove(o);
+        }
+        return anyRemoved;
+    }
+
+    /**
+     Retain in this list, and in the DOM, only the nodes that are in the specified collection and are in this list. In
+     other words, remove nodes from this list and the DOM any item that is in this list but not in the specified
+     collection.
+
+     @param toRemove collection containing nodes to be retained in this list
+     @return {@code true} if nodes were removed from this list
+     @since 1.17.1
+     */
+    @Override
+    public boolean retainAll(Collection<?> toRemove) {
+        boolean anyRemoved = false;
+        for (Iterator<T> it = this.iterator(); it.hasNext(); ) {
+            T el = it.next();
+            if (!toRemove.contains(el)) {
+                it.remove();
+                anyRemoved = true;
+            }
+        }
+        return anyRemoved;
+    }
+
+    /**
+     Remove from the list, and from the DOM, all nodes in this list that mach the given predicate.
+
+     @param filter a predicate which returns {@code true} for nodes to be removed
+     @return {@code true} if nodes were removed from this list
+     */
+    @Override
+    public boolean removeIf(Predicate<? super T> filter) {
+        boolean anyRemoved = false;
+        for (Iterator<T> it = this.iterator(); it.hasNext(); ) {
+            T node = it.next();
+            if (filter.test(node)) {
+                it.remove();
+                anyRemoved = true;
+            }
+        }
+        return anyRemoved;
+    }
+
+    /**
+     Replace each node in this list with the result of the operator, and update the DOM.
+
+     @param operator the operator to apply to each node
+     */
+    @Override
+    public void replaceAll(UnaryOperator<T> operator) {
+        for (int i = 0; i < this.size(); i++) {
+            this.set(i, operator.apply(this.get(i)));
+        }
+    }
+}

--- a/src/main/java/org/jsoup/select/Selector.java
+++ b/src/main/java/org/jsoup/select/Selector.java
@@ -2,6 +2,7 @@ package org.jsoup.select;
 
 import org.jsoup.helper.Validate;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
 import org.jsoup.parser.TokenQueue;
 import org.jspecify.annotations.Nullable;
 
@@ -21,8 +22,12 @@ import java.util.stream.Stream;
  The universal selector {@code *} is implicit when no element selector is supplied (i.e. {@code .header} and
  {@code *.header} are equivalent).
  </p>
+
+ <p>You can easily test different selectors using the <a href="https://try.jsoup.org/?utm_source=jsoup&amp;utm_medium=javadoc">Try jsoup online playground</a>.
+
  <style>table.syntax tr td {vertical-align: top; padding-right: 2em; padding-top:0.5em; padding-bottom:0.5em; }
  table.syntax tr:hover{background-color: #eee;} table.syntax {border-spacing: 0px 0px;}</style>
+
  <table summary="" class="syntax"><colgroup><col span="1" style="width: 20%;"><col span="1" style="width: 40%;"><col span="1" style="width: 40%;"></colgroup>
  <tr><th align="left">Pattern</th><th align="left">Matches</th><th align="left">Example</th></tr>
  <tr><td><code>*</code></td><td>any element</td><td><code>*</code></td></tr>
@@ -42,12 +47,14 @@ import java.util.stream.Stream;
  <tr><td><code>[attr~=<em>regex</em>]</code></td><td>elements with an attribute named "attr", and value matching the regular expression</td><td><code>img[src~=(?i)\\.(png|jpe?g)]</code></td></tr>
  <tr><td><code>[*]</code></td><td>elements with any attribute</td><td><code>p[*]</code> finds <code>p</code> elements that have at least one attribute; <code>p:not([*])</code> finds those with no attributes</td></tr>
  <tr><td></td><td>The above may be combined in any order</td><td><code>div.header[title]</code></td></tr>
+
  <tr><td colspan="3"><h3>Combinators</h3></td></tr>
  <tr><td><code>E F</code></td><td>an F element descended from an E element</td><td><code>div a</code>, <code>.logo h1</code></td></tr>
  <tr><td><code>E {@literal >} F</code></td><td>an F direct child of E</td><td><code>ol {@literal >} li</code></td></tr>
  <tr><td><code>E + F</code></td><td>an F element immediately preceded by sibling E</td><td><code>li + li</code>, <code>div.head + div</code></td></tr>
  <tr><td><code>E ~ F</code></td><td>an F element preceded by sibling E</td><td><code>h1 ~ p</code></td></tr>
  <tr><td><code>E, F, G</code></td><td>all matching elements E, F, or G</td><td><code>a[href], div, h3</code></td></tr>
+
  <tr><td colspan="3"><h3>Pseudo selectors</h3></td></tr>
  <tr><td><code>:lt(<em>n</em>)</code></td><td>elements whose sibling index is less than <em>n</em></td><td><code>td:lt(3)</code> finds the first 3 cells of each row</td></tr>
  <tr><td><code>:gt(<em>n</em>)</code></td><td>elements whose sibling index is greater than <em>n</em></td><td><code>td:gt(1)</code> finds cells after skipping the first two</td></tr>
@@ -65,6 +72,7 @@ import java.util.stream.Stream;
  <tr><td><code>:matchesWholeOwnText(<em>regex</em>)</code></td><td>elements whose own <b>non-normalized</b> whole text matches the specified regular expression. The text must appear in the found element, not any of its descendants.</td><td><code>td:matchesWholeOwnText(\n\\d+)</code> finds table cells directly containing digits following a neewline.</td></tr>
  <tr><td></td><td>The above may be combined in any order and with other selectors</td><td><code>.light:contains(name):eq(0)</code></td></tr>
  <tr><td><code>:matchText</code></td><td>treats text nodes as elements, and so allows you to match against and select text nodes.<p><b>Note</b> that using this selector will modify the DOM, so you may want to {@code clone} your document before using.</td><td>{@code p:matchText:firstChild} with input {@code <p>One<br />Two</p>} will return one {@link org.jsoup.nodes.PseudoTextElement} with text "{@code One}".</td></tr>
+
  <tr><td colspan="3"><h3>Structural pseudo selectors</h3></td></tr>
  <tr><td><code>:root</code></td><td>The element that is the root of the document. In HTML, this is the <code>html</code> element</td><td><code>:root</code></td></tr>
  <tr><td><code>:nth-child(<em>a</em>n+<em>b</em>)</code></td><td><p>elements that have <code><em>a</em>n+<em>b</em>-1</code> siblings <b>before</b> it in the document tree, for any positive integer or zero value of <code>n</code>, and has a parent element. For values of <code>a</code> and <code>b</code> greater than zero, this effectively divides the element's children into groups of a elements (the last group taking the remainder), and selecting the <em>b</em>th element of each group. For example, this allows the selectors to address every other row in a table, and could be used to alternate the color of paragraph text in a cycle of four. The <code>a</code> and <code>b</code> values must be integers (positive, negative, or zero). The index of the first child of an element is 1.</p>
@@ -79,13 +87,27 @@ import java.util.stream.Stream;
  <tr><td><code>:only-child</code></td><td>elements that have a parent element and whose parent element have no other element children</td><td></td></tr>
  <tr><td><code>:only-of-type</code></td><td> an element that has a parent element and whose parent element has no other element children with the same expanded element name</td><td></td></tr>
  <tr><td><code>:empty</code></td><td>elements that contain no child elements or nodes, with the exception of blank text nodes, comments, XML declarations, and doctype declarations. In other words, it matches elements that are effectively empty of meaningful content.</td><td><code>li:not(:empty)</code></td></tr>
+
+ <tr><td colspan="3"><h3>Node pseudo selectors</h3></td></tr>
+ <tr><td colspan="3">These selectors enable matching specific leaf nodes, including Comments, TextNodes. When used with {@link Element#select(String)}, these can be used with structural selectors such as <code>:has()</code> to refine which Elements are matched. To retrieve matching Nodes directly, use {@Element#selectNodes(String)}.</td></tr>
+ <tr><td>::node</td><td>Matches any node</td><td></td></tr>
+ <tr><td>::leafnode</td><td>Matches any leaf-node (this is, a Node which is not an Element)</td><td></td></tr>
+ <tr><td>::comment</td><td>Matches a Comment node</td><td></td></tr>
+ <tr><td>::text</td><td>Matches a TextNode</td><td></td></tr>
+ <tr><td>::data</td><td>Matches a DataNode</td><td></td></tr>
+ <tr><td>::node:contains(text)</td><td>Matches a node that has a (normalized, case-insensitive) value containing <i>text</i>.</td><td>::comment:contains(foo bar)</td></tr>
+ <tr><td>::node:matches(regex)</td><td>Matches a node that has a value matching the regex.</td><td>::comment:matches(\\d+)</td></tr>
+ <tr><td>::node:blank</td><td>Matches a node that has either no value, or a value of only whitespace.</td><td>::comment:not(:blank)</td></tr>
  </table>
 
  <p>A word on using regular expressions in these selectors: depending on the content of the regex, you will need to quote the pattern using <b><code>Pattern.quote("regex")</code></b> for it to parse correctly through both the selector parser and the regex parser. E.g. <code>String query = "div:matches(" + Pattern.quote(regex) + ");"</code>.</p>
  <p><b>Escaping special characters:</b> to match a tag, ID, or other selector that does not follow the regular CSS syntax, the query must be escaped with the <code>\</code> character. For example, to match by ID {@code <p id="i.d">}, use {@code document.select("#i\\.d")}.</p>
 
  @see Element#select(String css)
+ @see Element#selectFirst(String css)
  @see Element#select(Evaluator eval)
+ @see Element#selectNodes(String css)
+ @see Element#selectNodes(String css, Class nodeType)
  @see Elements#select(String css)
  @see Element#selectXpath(String xpath) */
 public class Selector {

--- a/src/test/java/org/jsoup/helper/ValidateTest.java
+++ b/src/test/java/org/jsoup/helper/ValidateTest.java
@@ -109,6 +109,23 @@ public class ValidateTest {
         assertTrue(threw);
     }
 
+    @Test void expectNotNull() {
+        String foo = "Foo";
+        String foo2 = Validate.expectNotNull(foo);
+        assertSame(foo, foo2);
+
+        // Test with a null object
+        String bar = null;
+        boolean threw = false;
+        try {
+            Validate.expectNotNull(bar);
+        } catch (ValidationException e) {
+            threw = true;
+            assertEquals("Object must not be null", e.getMessage());
+        }
+        assertTrue(threw);
+    }
+
     @Test
     public void testNotNullParam() {
         // Test with a non-null object

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -3224,4 +3224,27 @@ public class ElementTest {
         assertEquals("<script>a < b</script>", script.outerHtml()); // not encoded
         assertEquals("a < b", script.data());
     }
+
+    @Test void expectFirstNode() {
+        Document doc = Jsoup.parse("<span id=1>One</span> <span id=2>Two</span>");
+        TextNode text = doc.expectFirstNode("::text", TextNode.class);
+        assertEquals("1", text.parent().id());
+
+        TextNode text2 = doc.selectFirstNode("::text", TextNode.class);
+        assertSame(text, text2);
+
+        assertNull(doc.selectFirstNode("::comment", Comment.class));
+    }
+
+    @Test void expectFirstThrows() {
+        Document doc = Jsoup.parse("<span id=1>One</span> <span id=2>Two</span>");
+        boolean threw = false;
+        try {
+            doc.expectFirstNode("::comment", Comment.class);
+        } catch (IllegalArgumentException e) {
+            threw = true;
+            assertEquals("No nodes matched the query '::comment' in the document.", e.getMessage());
+        }
+        assertTrue(threw);
+    }
 }

--- a/src/test/java/org/jsoup/nodes/NodeTest.java
+++ b/src/test/java/org/jsoup/nodes/NodeTest.java
@@ -463,6 +463,14 @@ public class NodeTest {
         assertNull(firstEl.lastElementChild());
     }
 
+    @Test void firstLastSibling() {
+        Document doc = Jsoup.parse("<div><span>One</span> Two <span>Three</span>");
+        Elements spans = doc.select("span");
+        TextNode text = (TextNode) spans.first().nextSibling();
+        assertSame(spans.get(0), text.firstSibling());
+        assertSame(spans.get(1), text.lastSibling());
+    }
+
     @Test void nodeName() {
         Element div = new Element("DIV");
         assertEquals("DIV", div.tagName());

--- a/src/test/java/org/jsoup/nodes/TextNodeTest.java
+++ b/src/test/java/org/jsoup/nodes/TextNodeTest.java
@@ -4,6 +4,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
 import org.jsoup.helper.ValidationException;
 import org.jsoup.internal.StringUtil;
+import org.jsoup.select.Nodes;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -61,14 +62,14 @@ public class TextNodeTest {
         assertSame(tn.parent(), tail.parent());
     }
 
-    @Test public void testSplitAnEmbolden() {
+    @Test public void testSplitAndEmbolden() {
         Document doc = Jsoup.parse("<div>Hello there</div>");
         Element div = doc.select("div").first();
         TextNode tn = (TextNode) div.childNode(0);
         TextNode tail = tn.splitText(6);
         tail.wrap("<b></b>");
 
-        assertEquals("Hello <b>there</b>", TextUtil.stripNewlines(div.html())); // not great that we get \n<b>there there... must correct
+        assertEquals("Hello <b>there</b>", div.html());
     }
 
     @Test void testSplitTextValidation() {
@@ -224,5 +225,15 @@ public class TextNodeTest {
         assertTrue(t.hasSameValue(clone));
         assertEquals("/foo.html", clone.attr("href"));
         assertEquals("Two", clone.text());
+    }
+
+    @Test void parentElement() {
+        Document doc = Jsoup.parse("<p>Text</p>");
+        TextNode text = doc.selectNodes("::text", TextNode.class).first();
+        assertNotNull(text);
+        Element p = text.parent();
+        assertNotNull(p);
+        p = ((Node) text).parentElement();
+        assertNotNull(p);
     }
 }

--- a/src/test/java/org/jsoup/select/EvaluatorDebug.java
+++ b/src/test/java/org/jsoup/select/EvaluatorDebug.java
@@ -48,8 +48,11 @@ public class EvaluatorDebug {
     }
 
     public static String sexpr(String query) {
-        Document doc = asDocument(query);
+        return sexpr(QueryParser.parse(query));
+    }
 
+    public static String sexpr(Evaluator eval) {
+        Document doc = asDocument(eval);
         SexprVisitor sv = new SexprVisitor();
         doc.childNode(0).traverse(sv); // skip outer #document
         return sv.result();

--- a/src/test/java/org/jsoup/select/NodesTest.java
+++ b/src/test/java/org/jsoup/select/NodesTest.java
@@ -1,0 +1,31 @@
+package org.jsoup.select;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.TextNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NodesTest {
+    @Test void before() {
+        Document doc = Jsoup.parse("<span>One</span> <span>Two</span> <span>Three</span>");
+        Nodes<TextNode> nodes = doc.selectNodes("::text:contains(o)", TextNode.class);
+        nodes.before("<wbr>");
+        assertEquals("<span><wbr>One</span> <span><wbr>Two</span> <span>Three</span>", doc.body().html());
+    }
+
+    @Test void after() {
+        Document doc = Jsoup.parse("<span>One</span> <span>Two</span> <span>Three</span>");
+        Nodes<TextNode> nodes = doc.selectNodes("::text:contains(o)", TextNode.class);
+        nodes.after("<wbr>");
+        assertEquals("<span>One<wbr></span> <span>Two<wbr></span> <span>Three</span>", doc.body().html());
+    }
+
+    @Test void wrap() {
+        Document doc = Jsoup.parse("<span>One</span> <span>Two</span> <span>Three</span>");
+        Nodes<TextNode> nodes = doc.selectNodes("::text:contains(o)", TextNode.class);
+        nodes.wrap("<b></b>");
+        assertEquals("<span><b>One</b></span> <span><b>Two</b></span> <span>Three</span>", doc.body().html());
+    }
+}

--- a/src/test/java/org/jsoup/select/QueryParserTest.java
+++ b/src/test/java/org/jsoup/select/QueryParserTest.java
@@ -228,4 +228,11 @@ public class QueryParserTest {
                 "Could not parse query '+ + div': unexpected token at '+ div'",
                 exception2.getMessage());
     }
+
+    @Test void hasNodeSelector() {
+        String q = "p:has(::comment:contains(some text))";
+        Evaluator e = QueryParser.parse(q);
+        assertEquals("(And (Tag 'p')(Has (And (InstanceType '::comment')(ContainsValue ':contains(some text)'))))", sexpr(e));
+        assertEquals(q, e.toString());
+    }
 }


### PR DESCRIPTION
This extends the QueryParser and Evaluators to support matching nodes (including specific node types, and their nodeValue contents)

Allows finding e.g. Elements following a particular comment or text node.

Also allows selecting nodes directly via 
- `Element#selectNodes(String css)` and 
- `Element#selectNodes(String css, Class nodeType)`

E.g.: `::comment:contains(prices) + p` will find `p` Elements directly after a `<!-- prices: -->` comment.

Or: `div:has(>::comment)` will find `div` Elements that directly have comment children.

Available operators:

<table>

 <tr><td colspan="3"><h3>Node pseudo selectors</h3></td></tr>
 <tr><td colspan="3">These selectors enable matching specific leaf nodes, including Comments, TextNodes. When used with `Element#select(String)`, these can be used with structural selectors such as <code>:has()</code> to refine which Elements are matched. To retrieve matching Nodes directly, use `Element#selectNodes(String)`.</td></tr>
 <tr><td>::node</td><td>Matches any node</td><td></td></tr>
 <tr><td>::leafnode</td><td>Matches any leaf-node (this is, a Node which is not an Element)</td><td></td></tr>
 <tr><td>::comment</td><td>Matches a Comment node</td><td></td></tr>
 <tr><td>::text</td><td>Matches a TextNode</td><td></td></tr>
 <tr><td>::data</td><td>Matches a DataNode</td><td></td></tr>
 <tr><td>::node:contains(text)</td><td>Matches a node that has a (normalized, case-insensitive) value containing <i>text</i>.</td><td>::comment:contains(foo bar)</td></tr>
 <tr><td>::node:matches(regex)</td><td>Matches a node that has a value matching the regex.</td><td>::comment:matches(\\d+)</td></tr>
 <tr><td>::node:blank</td><td>Matches a node that has either no value, or a value of only whitespace.</td><td>::comment:not(:blank)</td></tr>
 
 </table>



