### PR TITLE
Collapse whitespace between adjacent TextNodes (#2347)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # jsoup Changelog
 
+## 1.21.2 (PENDING)
+
+### Improvements
+* When pretty-printing, if there are consecutive text nodes (via DOM manipulation), the non-significant whitespace between them will be collapsed. [#2349](https://github.com/jhy/jsoup/pull/2349). 
+
 ## 1.21.1 (2025-Jun-23)
 
 ### Changes

--- a/src/main/java/org/jsoup/nodes/Printer.java
+++ b/src/main/java/org/jsoup/nodes/Printer.java
@@ -126,20 +126,12 @@ class Printer implements NodeVisitor {
                     options |= Entities.TrimLeading;
             }
 
-            if (next == null || !(next instanceof TextNode) && shouldIndent(next))
-                options |= Entities.TrimTrailing; // don't trim if there is a TextNode sequence
-
-            // do trim trailing whitespace if the next non-empty TextNode has leading whitespace
-            Node subsequentTextNode = next;
-            while (subsequentTextNode instanceof TextNode) {
-                String subsequentText = ((TextNode) subsequentTextNode).getWholeText();
-                if (subsequentText.isEmpty()) {
-                    subsequentTextNode = subsequentTextNode.nextSibling();
-                    continue;
-                }
-                if (StringUtil.isWhitespace(subsequentText.codePointAt(0)))
+            if (next == null || !(next instanceof TextNode) && shouldIndent(next)) {
+                options |= Entities.TrimTrailing;
+            } else { // trim trailing whitespace if the next non-empty TextNode has leading whitespace
+                next = nextNonBlank(next);
+                if (next instanceof TextNode && StringUtil.isWhitespace(next.nodeValue().codePointAt(0)))
                     options |= Entities.TrimTrailing;
-                break;
             }
 
             return options;
@@ -154,7 +146,7 @@ class Printer implements NodeVisitor {
             Node prevSib = previousNonblank(node);
             if (isBlockEl(prevSib)) return true;
 
-            Element parent = (Element) node.parentNode;
+            Element parent = node.parentNode;
             if (!isBlockEl(parent) || parent.tag().is(Tag.InlineContainer) || !hasNonTextNodes(parent))
                 return false;
 

--- a/src/main/java/org/jsoup/nodes/Printer.java
+++ b/src/main/java/org/jsoup/nodes/Printer.java
@@ -129,6 +129,19 @@ class Printer implements NodeVisitor {
             if (next == null || !(next instanceof TextNode) && shouldIndent(next))
                 options |= Entities.TrimTrailing; // don't trim if there is a TextNode sequence
 
+            // do trim trailing whitespace if the next non-empty TextNode has leading whitespace
+            Node subsequentTextNode = next;
+            while (subsequentTextNode instanceof TextNode) {
+                String subsequentText = ((TextNode) subsequentTextNode).getWholeText();
+                if (subsequentText.isEmpty()) {
+                    subsequentTextNode = subsequentTextNode.nextSibling();
+                    continue;
+                }
+                if (StringUtil.isWhitespace(subsequentText.codePointAt(0)))
+                    options |= Entities.TrimTrailing;
+                break;
+            }
+
             return options;
         }
 

--- a/src/test/java/org/jsoup/nodes/NodeTest.java
+++ b/src/test/java/org/jsoup/nodes/NodeTest.java
@@ -290,7 +290,7 @@ public class NodeTest {
         Document doc = Jsoup.parse("<div>One <span></span> Two</div>");
         Element span = doc.select("span").first();
         Node node = span.unwrap();
-        assertEquals("<div>One  Two</div>", TextUtil.stripNewlines(doc.body().html()));
+        assertEquals("<div>One Two</div>", TextUtil.stripNewlines(doc.body().html()));
         assertNull(node);
     }
 

--- a/src/test/java/org/jsoup/nodes/PrinterTest.java
+++ b/src/test/java/org/jsoup/nodes/PrinterTest.java
@@ -65,9 +65,10 @@ public class PrinterTest {
     }
 
     @Test void sequentialTextNodesCollapseAdjacentWhitespace() {
+        // https://github.com/jhy/jsoup/pull/2349
         // Tests that the pretty printer collapses whitespace between sequential text nodes into a single space.
         // This must also work with intermediate empty and blank text nodes.
-        Document doc = Jsoup.parseBodyFragment("Before <span></span> After");
+        Document doc = Jsoup.parseBodyFragment("Before <span> </span> After");
         doc.expectFirst("span")
                 .after(new TextNode("")).after(new TextNode("")).after(new TextNode(" ")).after(new TextNode(""))
                 .remove();

--- a/src/test/java/org/jsoup/nodes/PrinterTest.java
+++ b/src/test/java/org/jsoup/nodes/PrinterTest.java
@@ -64,6 +64,17 @@ public class PrinterTest {
         assertEquals("<div>\n <div></div>\n Hello there.\n</div>", div.outerHtml());
     }
 
+    @Test void sequentialTextNodesCollapseAdjacentWhitespace() {
+        // Tests that the pretty printer collapses whitespace between sequential text nodes into a single space.
+        // This must also work with intermediate empty and blank text nodes.
+        Document doc = Jsoup.parseBodyFragment("Before <span></span> After");
+        doc.expectFirst("span")
+                .after(new TextNode("")).after(new TextNode("")).after(new TextNode(" ")).after(new TextNode(""))
+                .remove();
+        assertEquals(6, doc.body().textNodes().size()); // no collapse before printing
+        assertEquals("Before After", doc.body().html());
+    }
+
     @Test void dontCollapseTextAfterNonElements() {
         Document doc = Jsoup.parse("<div><div></div>Hello <!-- -_- --> there</div>");
         Element body = doc.body();


### PR DESCRIPTION
Fixes #2347

I'm not sure if this can be fixed more elegantly than looping over sequential text nodes. I'd prefer handling multiple text nodes in a single call to `Entities.doEscape`, but that would involve larger code changes.