### PR TITLE
feat: add OutputSettings option to sort attributes during HTML serial…

### DIFF
--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -12,6 +12,7 @@ import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -490,17 +491,25 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         html(QuietAppendable.wrap(sb), new Document.OutputSettings()); // output settings a bit funky, but this html() seldom used
         return StringUtil.releaseBuilder(sb);
     }
-
+    
     final void html(final QuietAppendable accum, final Document.OutputSettings out) {
-        final int sz = size;
-        for (int i = 0; i < sz; i++) {
-            String key = keys[i];
-            assert key != null;
-            if (isInternalKey(key))
-                continue;
-            final String validated = Attribute.getValidKey(key, out.syntax());
-            if (validated != null)
-                Attribute.htmlNoValidate(validated, (String) vals[i], accum.append(' '), out);
+        if (out.sortAttributes()) {
+            List<Attribute> attrList = asList();
+            attrList.sort(Comparator.comparing(Attribute::getKey));
+            for (Attribute attr : attrList) {
+                attr.html(accum.append(' '), out);
+            }
+        } else {
+            final int sz = size;
+            for (int i = 0; i < sz; i++) {
+                String key = keys[i];
+                assert key != null;
+                if (isInternalKey(key))
+                    continue;
+                final String validated = Attribute.getValidKey(key, out.syntax());
+                if (validated != null)
+                    Attribute.htmlNoValidate(validated, (String) vals[i], accum.append(' '), out);
+            }
         }
     }
 

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -374,7 +374,10 @@ public class Document extends Element {
             this.escapeMode = escapeMode;
             return this;
         }
+        private boolean sortAttributes = false;
 
+        public boolean sortAttributes() { return sortAttributes; }
+        public OutputSettings sortAttributes(boolean sort) { this.sortAttributes = sort; return this; }
         /**
          * Get the document's current output charset, which is used to control which characters are escaped when
          * generating HTML (via the <code>html()</code> methods), and which are kept intact.


### PR DESCRIPTION
…ization

### What does this PR do?
This PR introduces a new configuration option in `Document.OutputSettings`:

public boolean sortAttributes();
public OutputSettings sortAttributes(boolean sort);

By default, attributes are emitted in the order they were added. When sortAttributes is set to true, attributes are sorted by their key before being written to the serialized HTML output.

Why is this useful?
It makes generated HTML output more consistent and predictable.

It helps when diffing HTML output in tests (attribute order can vary otherwise).

It improves reproducibility when serializing elements programmatically.

What changed?
✅ Added sortAttributes field and accessors in Document.OutputSettings.
✅ Updated Attributes.html() to sort attributes when the option is enabled.
✅ Preserved existing behavior when the option is not enabled (default = false).

Example usage
Document doc = Jsoup.parse("<div b='2' a='1'></div>");
doc.outputSettings().sortAttributes(true);
System.out.println(doc.body().html());
// Outputs: <div a="1" b="2"></div>
Tests
(TODO: Add unit test to verify attribute order with sortAttributes = true / false.)

Backward compatibility
✅ No breaking changes
✅ Default behavior remains unchanged unless the new option is explicitly enabled