### PR TITLE
Fix always close resources

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -1238,8 +1238,14 @@ public class HttpConnection implements Connection {
         }
 
         static void writePost(final HttpConnection.Request req, final OutputStream outputStream) throws IOException {
+            try (OutputStreamWriter osw = new OutputStreamWriter(outputStream, req.postDataCharset());
+                 BufferedWriter w = new BufferedWriter(osw)) {
+                implWritePost(req, w, outputStream);
+            }
+        }
+
+        private static void implWritePost(final HttpConnection.Request req, final BufferedWriter w, final OutputStream outputStream) throws IOException {
             final Collection<Connection.KeyVal> data = req.data();
-            final BufferedWriter w = new BufferedWriter(new OutputStreamWriter(outputStream, req.postDataCharset()));
             final String boundary = req.mimeBoundary;
 
             if (boundary != null) { // a multipart post
@@ -1290,7 +1296,6 @@ public class HttpConnection implements Connection {
                     w.write(URLEncoder.encode(keyVal.value(), req.postDataCharset()));
                 }
             }
-            w.close();
         }
 
         // for get url reqs, serialise the data map into the url


### PR DESCRIPTION
Hi,

Previously, resources were generally closed in most cases, but there was an issue where resources were not properly closed when exceptions occurred.
In this PR, try-with-resources was applied to ensure that resources are always safely closed, even if an exception is thrown.

Thanks for reviewing!