### PR TITLE
Add Connection#sslContext(), deprecate sslSocketFactory()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,13 @@
 
 ### Changes
 * Deprecated internal (yet visible) methods `Normalizer#normalize(String, bool)` and `Attribute#shouldCollapseAttribute(Document.OutputSettings)`. These will be removed in a future version.
+* Deprecated `Connection#sslSocketFactory(SSLSocketFactory)` in favor of the new `Connection#sslContext(SSLContext)`. Using `sslSocketFactory` will force the use of the legacy `HttpUrlConnection` implementation, which does not support HTTP/2.
 
 ### Improvements
 * When pretty-printing, if there are consecutive text nodes (via DOM manipulation), the non-significant whitespace between them will be collapsed. [#2349](https://github.com/jhy/jsoup/pull/2349).
 * Updated `Connection.Response#statusMessage()` to return a simple loggable string message (e.g. "OK") when using the `HttpClient` implementation, which doesn't otherwise return any server-set status message. [#2356](https://github.com/jhy/jsoup/issues/2346) 
 * `Attributes#size()` and `Attributes#isEmpty()` now exclude any internal attributes (such as user data) from their count. This aligns with the attributes' serialized output and iterator. [#2369](https://github.com/jhy/jsoup/pull/2369)
+* Added `Connection#sslContext(SSLContext)` to provide a custom SSL (TLS) context to requests, supporting both the `HttpClient` and the legacy `HttUrlConnection` implementations. 
 
 ### Bug Fixes
 * When parsing from an InputStream and a multibyte character happened to straddle a buffer boundary, the stream would not be completely read. [#2353](https://github.com/jhy/jsoup/issues/2353).

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -11,6 +11,7 @@ import org.jsoup.parser.Parser;
 import org.jsoup.parser.StreamParser;
 import org.jspecify.annotations.Nullable;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -221,6 +222,12 @@ public class HttpConnection implements Connection {
     public Connection sslSocketFactory(SSLSocketFactory sslSocketFactory) {
 	    req.sslSocketFactory(sslSocketFactory);
 	    return this;
+    }
+
+    @Override
+    public Connection sslContext(SSLContext sslContext) {
+        req.sslContext(sslContext);
+        return this;
     }
 
     @Override
@@ -618,6 +625,7 @@ public class HttpConnection implements Connection {
         private boolean parserDefined = false; // called parser(...) vs initialized in ctor
         private String postDataCharset = DataUtil.defaultCharsetName;
         private @Nullable SSLSocketFactory sslSocketFactory;
+        @Nullable SSLContext sslContext;
         private CookieManager cookieManager;
         @Nullable RequestAuthenticator authenticator;
         private @Nullable Progress<Connection.Response> responseProgress;
@@ -652,6 +660,7 @@ public class HttpConnection implements Connection {
             parser = copy.parser.newInstance(); // parsers and their tree-builders maintain state, so need a fresh copy
             parserDefined = copy.parserDefined;
             sslSocketFactory = copy.sslSocketFactory; // these are all synchronized so safe to share
+            sslContext = copy.sslContext;
             cookieManager = copy.cookieManager;
             authenticator = copy.authenticator;
             responseProgress = copy.responseProgress;
@@ -722,6 +731,18 @@ public class HttpConnection implements Connection {
         @Override
         public void sslSocketFactory(SSLSocketFactory sslSocketFactory) {
             this.sslSocketFactory = sslSocketFactory;
+        }
+
+        @Override @Nullable
+        public SSLContext sslContext() {
+            return sslContext;
+        }
+
+        @Override
+        public Connection.Request sslContext(SSLContext sslContext) {
+            this.sslContext = sslContext;
+            this.sslSocketFactory = sslContext.getSocketFactory();
+            return this;
         }
 
         @Override

--- a/src/main/java/org/jsoup/helper/RequestDispatch.java
+++ b/src/main/java/org/jsoup/helper/RequestDispatch.java
@@ -9,7 +9,7 @@ import static org.jsoup.helper.HttpConnection.Response;
 import java.lang.reflect.Constructor;
 
 /**
- Handles requests using either HttpClient (available in JDK 11+) or HttpURLConnection. During initialization, the
+ Handles requests using either HttpClient (available in JVM 11+) or HttpURLConnection. During initialization, the
  HttpClientExecutor class is used if it can be instantiated, unless the system property
  {@link SharedConstants#UseHttpClient} is explicitly set to {@code false}.
  */
@@ -32,6 +32,10 @@ class RequestDispatch {
 
     static RequestExecutor get(Request request, @Nullable Response previousResponse) {
         boolean useHttpClient = Boolean.parseBoolean(System.getProperty(SharedConstants.UseHttpClient, "true"));
+
+        if (request.sslSocketFactory() != null) // downgrade if a socket factory is set, as it can't be supplied to the HttpClient
+            useHttpClient = false;
+
         if (useHttpClient && clientConstructor != null) {
             try {
                 return clientConstructor.newInstance(request, previousResponse);

--- a/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
+++ b/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
@@ -9,7 +9,7 @@ public class HttpClientExecutorTest {
     @Test void getsHttpClient() {
         try {
             enableHttpClient();
-            RequestExecutor executor = RequestDispatch.get(null, null);
+            RequestExecutor executor = RequestDispatch.get(new HttpConnection.Request(), null);
             //assertInstanceOf(HttpClientExecutor.class, executor);
             assertEquals("org.jsoup.helper.HttpClientExecutor", executor.getClass().getName());
             // Haven't figured out how to get Maven to allow this mjar code to be on the classpath for the surefire tests, hence not instanceof
@@ -20,7 +20,7 @@ public class HttpClientExecutorTest {
 
     @Test void getsHttpUrlConnectionByDefault() {
         System.clearProperty(SharedConstants.UseHttpClient);
-        RequestExecutor executor = RequestDispatch.get(null, null);
+        RequestExecutor executor = RequestDispatch.get(new HttpConnection.Request(), null);
         assertEquals("org.jsoup.helper.HttpClientExecutor", executor.getClass().getName());
     }
 


### PR DESCRIPTION
And when sslSocketFactory is used, don't use HttpClient.

Fixes #2365