### PR TITLE
Java11 test helper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,27 @@
       </activation>
       <build>
         <plugins>
+          <!-- Sets up test/java11 -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.6.1</version>
+            <executions>
+              <execution>
+                <id>add-java11-test-source</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>${project.basedir}/src/test/java11</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
@@ -412,23 +433,6 @@
                   <multiReleaseOutput>true</multiReleaseOutput>
                 </configuration>
               </execution>
-
-              <!-- Tests for multi-release jar on 11: mark tests to be compiled; then and add to class path -->
-              <execution>
-                <id>testcompile-java-11</id>
-                <phase>test-compile</phase>
-                <goals>
-                  <goal>testCompile</goal>
-                </goals>
-                <configuration>
-                  <release>11</release>
-
-                  <compileSourceRoots>
-                    <compileSourceRoot>${project.basedir}/src/test/java11</compileSourceRoot>
-                  </compileSourceRoots>
-                </configuration>
-              </execution>
-
             </executions>
           </plugin>
 

--- a/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
+++ b/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
@@ -2,7 +2,6 @@ package org.jsoup.helper;
 import org.jsoup.internal.SharedConstants;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class HttpClientExecutorTest {
@@ -10,9 +9,7 @@ public class HttpClientExecutorTest {
         try {
             enableHttpClient();
             RequestExecutor executor = RequestDispatch.get(new HttpConnection.Request(), null);
-            //assertInstanceOf(HttpClientExecutor.class, executor);
-            assertEquals("org.jsoup.helper.HttpClientExecutor", executor.getClass().getName());
-            // Haven't figured out how to get Maven to allow this mjar code to be on the classpath for the surefire tests, hence not instanceof
+            assertInstanceOf(HttpClientExecutor.class, executor);
         } finally {
             disableHttpClient(); // reset to previous default for JDK8 compat tests
         }
@@ -21,7 +18,7 @@ public class HttpClientExecutorTest {
     @Test void getsHttpUrlConnectionByDefault() {
         System.clearProperty(SharedConstants.UseHttpClient);
         RequestExecutor executor = RequestDispatch.get(new HttpConnection.Request(), null);
-        assertEquals("org.jsoup.helper.HttpClientExecutor", executor.getClass().getName());
+        assertInstanceOf(HttpClientExecutor.class, executor);
     }
 
     public static void enableHttpClient() {


### PR DESCRIPTION
Fixes an issue where IntelliJ wasn't identifying the java11 test source root correctly.