### PR TITLE
Performance optimizations for some DOM methods

### DIFF
--- a/src/main/java/org/jsoup/internal/StringUtil.java
+++ b/src/main/java/org/jsoup/internal/StringUtil.java
@@ -148,8 +148,8 @@ public final class StringUtil {
      * @param string string to test
      * @return if string is blank
      */
-    public static boolean isBlank(final String string) {
-        if (string == null || string.length() == 0)
+    public static boolean isBlank(@Nullable String string) {
+        if (string == null || string.isEmpty())
             return true;
 
         int l = string.length();

--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -159,7 +159,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         if (i != NotFound)
             vals[i] = value;
         else
-            add(key, value);
+            addObject(key, value);
         return this;
     }
 
@@ -184,6 +184,13 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
     }
 
     /**
+     Check if these attributes have any user data associated with them.
+     */
+    boolean hasUserData() {
+        return hasKey(SharedConstants.UserDataKey);
+    }
+
+    /**
      Get an arbitrary user-data object by key.
      * @param key case-sensitive key to the object.
      * @return the object associated to this key, or {@code null} if not found.
@@ -193,7 +200,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
     @Nullable
     public Object userData(String key) {
         Validate.notNull(key);
-        if (!hasKey(SharedConstants.UserDataKey)) return null; // no user data exists
+        if (!hasUserData()) return null; // no user data exists
         Map<String, Object> userData = userData();
         return userData.get(key);
     }
@@ -225,7 +232,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
                 keys[i] = key;
         }
         else
-            add(key, value);
+            addObject(key, value);
     }
 
     /**
@@ -365,7 +372,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
             if (needsPut)
                 put(attr);
             else
-                add(attr.getKey(), attr.getValue());
+                addObject(attr.getKey(), attr.getValue());
         }
     }
 

--- a/src/main/java/org/jsoup/nodes/Document.java
+++ b/src/main/java/org/jsoup/nodes/Document.java
@@ -220,7 +220,10 @@ public class Document extends Element {
      @return new element
      */
     public Element createElement(String tagName) {
-        return new Element(parser.tagSet().valueOf(tagName, parser.defaultNamespace(), ParseSettings.preserveCase), this.baseUri());
+        return new Element(
+            parser.tagSet().valueOf(tagName, parser.defaultNamespace(), ParseSettings.preserveCase),
+            searchUpForAttribute(this, BaseUriKey)
+        );
     }
 
     @Override

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -306,9 +306,9 @@ public class HtmlTreeBuilder extends TreeBuilder {
     Element createElementFor(Token.StartTag startTag, String namespace, boolean forcePreserveCase) {
         // dedupe and normalize the attributes:
         Attributes attributes = startTag.attributes;
-        if (!forcePreserveCase)
-            attributes = settings.normalizeAttributes(attributes);
         if (attributes != null && !attributes.isEmpty()) {
+            if (!forcePreserveCase)
+                settings.normalizeAttributes(attributes);
             int dupes = attributes.deduplicate(settings);
             if (dupes > 0) {
                 error("Dropped duplicate attribute(s) in tag [%s]", startTag.normalName);

--- a/src/main/java/org/jsoup/parser/ParseSettings.java
+++ b/src/main/java/org/jsoup/parser/ParseSettings.java
@@ -75,11 +75,10 @@ public class ParseSettings {
         return name;
     }
 
-    @Nullable Attributes normalizeAttributes(@Nullable Attributes attributes) {
-        if (attributes != null && !preserveAttributeCase) {
+    void normalizeAttributes(Attributes attributes) {
+        if (!preserveAttributeCase) {
             attributes.normalize();
         }
-        return attributes;
     }
 
     /** Returns the normal name that a Tag will have (trimmed and lower-cased) */

--- a/src/main/java/org/jsoup/parser/Parser.java
+++ b/src/main/java/org/jsoup/parser/Parser.java
@@ -295,13 +295,7 @@ public class Parser implements Cloneable {
         Document doc = Document.createShell(baseUri);
         Element body = doc.body();
         List<Node> nodeList = parseFragment(bodyHtml, body, baseUri);
-        Node[] nodes = nodeList.toArray(new Node[0]); // the node list gets modified when re-parented
-        for (int i = nodes.length - 1; i > 0; i--) {
-            nodes[i].remove();
-        }
-        for (Node node : nodes) {
-            body.appendChild(node);
-        }
+        body.appendChildren(nodeList);
         return doc;
     }
 
@@ -312,6 +306,8 @@ public class Parser implements Cloneable {
      * @return an unescaped string
      */
     public static String unescapeEntities(String string, boolean inAttribute) {
+        Validate.notNull(string);
+        if (string.indexOf('&') < 0) return string; // nothing to unescape
         Parser parser = Parser.htmlParser();
         parser.treeBuilder.initialiseParse(new StringReader(string), "", parser);
         Tokeniser tokeniser = new Tokeniser(parser.treeBuilder);

--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -200,7 +200,7 @@ public class Tag implements Cloneable {
      * @return The tag, either defined or new generic.
      */
     public static Tag valueOf(String tagName, String namespace, ParseSettings settings) {
-        return TagSet.Html().valueOf(tagName, ParseSettings.normalName(tagName), namespace, settings.preserveTagCase());
+        return TagSet.Html().valueOf(tagName, null, namespace, settings.preserveTagCase());
     }
 
     /**

--- a/src/main/java/org/jsoup/parser/TagSet.java
+++ b/src/main/java/org/jsoup/parser/TagSet.java
@@ -103,8 +103,11 @@ public class TagSet {
         return null;
     }
 
-    /** Tag.valueOf with the normalName via the token.normalName, to save redundant lower-casing passes. */
-    Tag valueOf(String tagName, String normalName, String namespace, boolean preserveTagCase) {
+    /**
+     Tag.valueOf with the normalName via the token.normalName, to save redundant lower-casing passes.
+     Provide a null normalName unless we already have one; will be normalized if required from tagName.
+     */
+    Tag valueOf(String tagName, @Nullable String normalName, String namespace, boolean preserveTagCase) {
         Validate.notNull(tagName);
         Validate.notNull(namespace);
         tagName = tagName.trim();
@@ -113,6 +116,7 @@ public class TagSet {
         if (tag != null) return tag;
 
         // not found by tagName, try by normal
+        if (normalName == null) normalName = ParseSettings.normalName(tagName);
         tagName = preserveTagCase ? tagName : normalName;
         tag = get(normalName, namespace);
         if (tag != null) {
@@ -141,7 +145,7 @@ public class TagSet {
      @return The tag, either defined or new generic.
      */
     public Tag valueOf(String tagName, String namespace, ParseSettings settings) {
-        return valueOf(tagName, ParseSettings.normalName(tagName), namespace, settings.preserveTagCase());
+        return valueOf(tagName, null, namespace, settings.preserveTagCase());
     }
 
     /**

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -145,6 +145,7 @@ public class XmlTreeBuilder extends TreeBuilder {
 
         Attributes attributes = startTag.attributes;
         if (attributes != null) {
+            settings.normalizeAttributes(attributes);
             attributes.deduplicate(settings);
             processNamespaces(attributes, namespaces);
             applyNamespacesToAttributes(attributes, namespaces);
@@ -153,7 +154,7 @@ public class XmlTreeBuilder extends TreeBuilder {
         String tagName = startTag.tagName.value();
         String ns = resolveNamespace(tagName, namespaces);
         Tag tag = tagFor(tagName, startTag.normalName, ns, settings);
-        Element el = new Element(tag, null, settings.normalizeAttributes(attributes));
+        Element el = new Element(tag, null, attributes);
         currentElement().appendChild(el);
         push(el);
 

--- a/src/test/java/org/jsoup/nodes/LeafNodeTest.java
+++ b/src/test/java/org/jsoup/nodes/LeafNodeTest.java
@@ -13,8 +13,10 @@ public class LeafNodeTest {
     public void doesNotGetAttributesTooEasily() {
         // test to make sure we're not setting attributes on all nodes right away
         String body = "<p>One <!-- Two --> Three<![CDATA[Four]]></p>";
-        Document doc = Jsoup.parse(body);
+        Document doc = Jsoup.parse(body, "https://example.com/");
         assertTrue(hasAnyAttributes(doc)); // should have one - the base uri on the doc
+
+        assertFalse(hasAnyAttributes(Jsoup.parse("<div>None</div>"))); // no base uri
 
         Element html = doc.child(0);
         assertFalse(hasAnyAttributes(html));

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -471,6 +471,22 @@ public class HtmlParserTest {
         assertEquals("<input>\n<table></table>", doc.body().html());
     }
 
+    @Test public void siblingIndexFromFragment() {
+        Document doc = Jsoup.parseBodyFragment("<table><input></table>");
+        Element input = doc.expectFirst("input");
+        Element table = doc.expectFirst("table");
+        assertEquals(0, input.siblingIndex());
+        assertEquals(1, table.siblingIndex());
+    }
+
+    @Test public void siblingIndexFromParse() {
+        Document doc = Jsoup.parse("<table><input></table>");
+        Element input = doc.expectFirst("input");
+        Element table = doc.expectFirst("table");
+        assertEquals(0, input.siblingIndex());
+        assertEquals(1, table.siblingIndex());
+    }
+
     @Test public void handlesUnknownNamespaceTags() {
         String h = "<foo:bar id='1' /><abc:def id=2>Foo<p>Hello</p></abc:def><foo:bar>There</foo:bar>";
         Parser parser = Parser.htmlParser();

--- a/src/test/java/org/jsoup/parser/ParserSettingsTest.java
+++ b/src/test/java/org/jsoup/parser/ParserSettingsTest.java
@@ -48,8 +48,7 @@ public class ParserSettingsTest {
         Attributes attributes = new Attributes();
         attributes.put("ITEM", "1");
 
-        Attributes normalizedAttributes = parseSettings.normalizeAttributes(attributes);
-
-        assertEquals("item", normalizedAttributes.asList().get(0).getKey());
+        parseSettings.normalizeAttributes(attributes);
+        assertEquals("item", attributes.asList().get(0).getKey());
     }
 }


### PR DESCRIPTION
The primary optimization is to invalidate sibling indexes on modification, vs re-calculating them immediately. When called in a loop of `element.child(0).remove()`, the previous implementation was effectively O(n²), and is now just O(n).

Also includes optimizations for `Document.createElement()`, setting attributes, and when parsing a body fragment with many direct children.