### PR TITLE
Fix: Use system default ProxySelector in HttpClient #2388

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # jsoup Changelog
 
+* When using the JDK HttpClient, any system default proxy (`ProxySelector.getDefault()`) was ignored. Now, the system proxy is used if a per-request proxy is not set. [#2388](https://github.com/jhy/jsoup/issues/2388), [#2390](https://github.com/jhy/jsoup/pull/2390)
+
+
 ## 1.21.2 (2025-Aug-25)
 
 ### Changes

--- a/src/main/java11/org/jsoup/helper/HttpClientExecutor.java
+++ b/src/main/java11/org/jsoup/helper/HttpClientExecutor.java
@@ -31,7 +31,7 @@ class HttpClientExecutor extends RequestExecutor {
     // HttpClient expects proxy settings per client; we do per request, so held as a thread local. Can't do same for
     // auth because that callback is on a worker thread, so can only do auth per Connection. So we create a new client
     // if the authenticator is different between requests
-    static ThreadLocal<Proxy> perRequestProxy = new ThreadLocal<>();
+    static ThreadLocal<@Nullable Proxy> perRequestProxy = new ThreadLocal<>();
 
     @Nullable
     HttpResponse<InputStream> hRes;
@@ -167,7 +167,7 @@ class HttpClientExecutor extends RequestExecutor {
                 return Collections.singletonList(proxy);
             }
             ProxySelector defaultSelector = ProxySelector.getDefault();
-            if (defaultSelector != null) {
+            if (defaultSelector != null && defaultSelector != this) { // avoid recursion if we were set as default
                 return defaultSelector.select(uri);
             }
             return NoProxy;
@@ -179,7 +179,7 @@ class HttpClientExecutor extends RequestExecutor {
                 return;  // no-op
             }
             ProxySelector defaultSelector = ProxySelector.getDefault();
-            if (defaultSelector != null) {
+            if (defaultSelector != null && defaultSelector != this) {
                 defaultSelector.connectFailed(uri, sa, ioe);
             }
         }

--- a/src/main/java11/org/jsoup/helper/HttpClientExecutor.java
+++ b/src/main/java11/org/jsoup/helper/HttpClientExecutor.java
@@ -175,12 +175,9 @@ class HttpClientExecutor extends RequestExecutor {
 
         @Override
         public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
-            // perRequestProxy를 사용한 경우: defaultSelector와 무관하므로 무시
             if (perRequestProxy.get() != null) {
                 return;  // no-op
             }
-            
-            // defaultSelector를 사용한 경우에만 전달
             ProxySelector defaultSelector = ProxySelector.getDefault();
             if (defaultSelector != null) {
                 defaultSelector.connectFailed(uri, sa, ioe);

--- a/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
+++ b/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
@@ -2,7 +2,14 @@ package org.jsoup.helper;
 import org.jsoup.internal.SharedConstants;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.net.*;
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class HttpClientExecutorTest {
     @Test void getsHttpClient() {
@@ -27,5 +34,40 @@ public class HttpClientExecutorTest {
 
     public static void disableHttpClient() {
         System.setProperty(SharedConstants.UseHttpClient, "false");
+    }
+
+    @Test void proxyWrapUsesSystemDefaultProxySelector() {
+        ProxySelector originalSelector = ProxySelector.getDefault();
+        
+        try {
+            ProxySelector.setDefault(new ProxySelector() {
+                @Override
+                public List<Proxy> select(URI uri) {
+                    return Collections.singletonList(
+                        new Proxy(Proxy.Type.HTTP, new InetSocketAddress("system.proxy", 8080))
+                    );
+                }
+                
+                @Override
+                public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {}
+            });
+
+            HttpClientExecutor.ProxyWrap wrap = new HttpClientExecutor.ProxyWrap();
+            List<Proxy> proxies = wrap.select(URI.create("http://example.com"));
+            
+            assertEquals(1, proxies.size());
+            assertEquals("system.proxy", ((InetSocketAddress) proxies.get(0).address()).getHostName());
+        } finally {
+            ProxySelector.setDefault(originalSelector);
+        }
+    }
+
+    @Test void proxyWrapConnectFailedOnlyForSystemProxy() {
+        HttpClientExecutor.ProxyWrap wrap = new HttpClientExecutor.ProxyWrap();
+        HttpClientExecutor.perRequestProxy.set(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("custom", 9090)));
+        wrap.connectFailed(URI.create("http://example.com"), 
+            new InetSocketAddress("custom", 9090), 
+            new IOException("test"));
+        HttpClientExecutor.perRequestProxy.remove();
     }
 }


### PR DESCRIPTION
@jhy 
  ## Description
  Fixes #2388

  ## Problem
  HttpClient ignores system default proxy (`ProxySelector.getDefault()`).

  ## Solution
  select(): perRequestProxy → system ProxySelector → NoProxy

  connectFailed() (One tiny opinion): 
  Only forwards to system ProxySelector when it was actually used
  Returns early for perRequestProxy (prevents incorrect failure reporting)

  ## Testing
  - All 1696 tests pass
  - Added 2 unit tests for the new behavior

  Thanks to @robseidel for reporting and suggesting the fix.
