### PR TITLE
Added a `Parser#unsescape` method, to support error tracking

### DIFF
--- a/src/main/java/org/jsoup/parser/Parser.java
+++ b/src/main/java/org/jsoup/parser/Parser.java
@@ -300,17 +300,36 @@ public class Parser implements Cloneable {
     }
 
     /**
-     * Utility method to unescape HTML entities from a string
-     * @param string HTML escaped string
-     * @param inAttribute if the string is to be escaped in strict mode (as attributes are)
-     * @return an unescaped string
+     Utility method to unescape HTML entities from a string.
+     <p>To track errors while unescaping, use
+     {@link #unescape(String, boolean)} with a Parser instance that has error tracking enabled.</p>
+
+     @param string HTML escaped string
+     @param inAttribute if the string is to be escaped in strict mode (as attributes are)
+     @return an unescaped string
+     @see #unescape(String, boolean)
      */
     public static String unescapeEntities(String string, boolean inAttribute) {
         Validate.notNull(string);
         if (string.indexOf('&') < 0) return string; // nothing to unescape
-        Parser parser = Parser.htmlParser();
-        parser.treeBuilder.initialiseParse(new StringReader(string), "", parser);
-        Tokeniser tokeniser = new Tokeniser(parser.treeBuilder);
+        return Parser.htmlParser().unescape(string, inAttribute);
+    }
+
+    /**
+     Utility method to unescape HTML entities from a string, using this {@code Parser}'s configuration (for example, to
+     collect errors while unescaping).
+
+     @param string HTML escaped string
+     @param inAttribute if the string is to be escaped in strict mode (as attributes are)
+     @return an unescaped string
+     @see #setTrackErrors(int)
+     @see #unescapeEntities(String, boolean)
+     */
+    public String unescape(String string, boolean inAttribute) {
+        Validate.notNull(string);
+        if (string.indexOf('&') < 0) return string; // nothing to unescape
+        this.treeBuilder.initialiseParse(new StringReader(string), "", this);
+        Tokeniser tokeniser = new Tokeniser(this.treeBuilder);
         return tokeniser.unescapeEntities(inAttribute);
     }
 

--- a/src/test/java/org/jsoup/parser/ParserTest.java
+++ b/src/test/java/org/jsoup/parser/ParserTest.java
@@ -30,6 +30,24 @@ public class ParserTest {
         assertEquals(body, Parser.unescapeEntities(body, false));
     }
 
+    @Test public void unescapeTracksErrors() {
+        Parser parser = Parser.htmlParser();
+        parser.setTrackErrors(10);
+
+        String s = parser.unescape("One &bogus; &amp; &gt Two", false);
+        assertEquals("One &bogus; & > Two", s);
+        ParseErrorList errors = parser.getErrors();
+        assertEquals(2, errors.size());
+        assertEquals("<1:6>: Invalid character reference: invalid named reference [bogus]", errors.get(0).toString());
+        assertEquals("<1:22>: Invalid character reference: missing semicolon on [&gt]", errors.get(1).toString());
+
+        // can reuse parser; errors will be reset
+        s = parser.unescape("One &amp; &bogus; Two", false);
+        assertEquals("One & &bogus; Two", s);
+        assertEquals(1, parser.getErrors().size());
+        assertEquals("<1:12>: Invalid character reference: invalid named reference [bogus]", parser.getErrors().get(0).toString());
+    }
+
     @Test
     public void testUtf8() throws IOException {
         // testcase for https://github.com/jhy/jsoup/issues/1557. no repro.


### PR DESCRIPTION
As discussed in #2394 2394