### PR TITLE
Migrate away from internal Functions class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,7 @@
 * When using StructuralEvaluators (e.g., a `parent child` selector) across many retained threads, their memoized results could also be retained, increasing memory use. These results are now cleared immediately after use, reducing overall memory consumption. [#2411](https://github.com/jhy/jsoup/issues/2411)
 
 ### Internal Changes
-* Deprecated internal helper `org.jsoup.internal.Functions` (for removal in v1.23.1). This was previously used to support older Android API levels without full `java.util.function` coverage; jsoup now requires core library desugaring so this indirection is no longer necessary.
+* Deprecated internal helper `org.jsoup.internal.Functions` (for removal in v1.23.1). This was previously used to support older Android API levels without full `java.util.function` coverage; jsoup now requires core library desugaring so this indirection is no longer necessary. [#2412](https://github.com/jhy/jsoup/pull/2412)
 
 ## 1.21.2 (2025-Aug-25)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,9 @@
 * An IndexOutOfBoundsException could be thrown when parsing a body fragment with crafted input. Now logged as a parse error. [#2397](https://github.com/jhy/jsoup/issues/2397), [#2406](https://github.com/jhy/jsoup/issues/2406)
 * When using StructuralEvaluators (e.g., a `parent child` selector) across many retained threads, their memoized results could also be retained, increasing memory use. These results are now cleared immediately after use, reducing overall memory consumption. [#2411](https://github.com/jhy/jsoup/issues/2411)
 
+### Internal Changes
+* Deprecated internal helper `org.jsoup.internal.Functions` (for removal in v1.23.1). This was previously used to support older Android API levels without full `java.util.function` coverage; jsoup now requires core library desugaring so this indirection is no longer necessary.
+
 ## 1.21.2 (2025-Aug-25)
 
 ### Changes

--- a/src/main/java/org/jsoup/helper/UrlConnectionExecutor.java
+++ b/src/main/java/org/jsoup/helper/UrlConnectionExecutor.java
@@ -1,7 +1,6 @@
 package org.jsoup.helper;
 
 import org.jsoup.Connection;
-import org.jsoup.internal.Functions;
 import org.jspecify.annotations.Nullable;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -123,7 +122,7 @@ class UrlConnectionExecutor extends RequestExecutor {
             if (key == null || val == null)
                 continue; // skip http1.1 line
 
-            final List<String> vals = headers.computeIfAbsent(key, Functions.listFunction());
+            final List<String> vals = headers.computeIfAbsent(key, k -> new java.util.ArrayList<>());
             vals.add(val);
         }
         return headers;

--- a/src/main/java/org/jsoup/internal/Functions.java
+++ b/src/main/java/org/jsoup/internal/Functions.java
@@ -11,8 +11,10 @@ import java.util.function.Function;
 
 /**
  * An internal class containing functions for use with {@link Map#computeIfAbsent(Object, Function)}.
+ * @deprecated for removal in jsoup 1.23.1. Replace usages with direct constructor references / lambdas.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
+@Deprecated
 public final class Functions {
     private static final Function ListFunction = key -> new ArrayList<>();
     private static final Function SetFunction = key -> new HashSet<>();

--- a/src/main/java/org/jsoup/safety/Safelist.java
+++ b/src/main/java/org/jsoup/safety/Safelist.java
@@ -6,7 +6,6 @@ package org.jsoup.safety;
  */
 
 import org.jsoup.helper.Validate;
-import org.jsoup.internal.Functions;
 import org.jsoup.internal.Normalizer;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Attributes;
@@ -306,7 +305,7 @@ public class Safelist {
             Validate.notEmpty(key);
             attributeSet.add(AttributeKey.valueOf(key));
         }
-        Set<AttributeKey> currentSet = this.attributes.computeIfAbsent(tagName, Functions.setFunction());
+        Set<AttributeKey> currentSet = this.attributes.computeIfAbsent(tagName, k -> new HashSet<>());
         currentSet.addAll(attributeSet);
         return this;
     }
@@ -380,7 +379,7 @@ public class Safelist {
         AttributeKey attrKey = AttributeKey.valueOf(attribute);
         AttributeValue attrVal = AttributeValue.valueOf(value);
 
-        Map<AttributeKey, AttributeValue> attrMap = enforcedAttributes.computeIfAbsent(tagName, Functions.mapFunction());
+        Map<AttributeKey, AttributeValue> attrMap = enforcedAttributes.computeIfAbsent(tagName, k -> new HashMap<>());
         attrMap.put(attrKey, attrVal);
         return this;
     }
@@ -453,8 +452,8 @@ public class Safelist {
 
         TagName tagName = TagName.valueOf(tag);
         AttributeKey attrKey = AttributeKey.valueOf(attribute);
-        Map<AttributeKey, Set<Protocol>> attrMap = this.protocols.computeIfAbsent(tagName, Functions.mapFunction());
-        Set<Protocol> protSet = attrMap.computeIfAbsent(attrKey, Functions.setFunction());
+        Map<AttributeKey, Set<Protocol>> attrMap = this.protocols.computeIfAbsent(tagName, k -> new HashMap<>());
+        Set<Protocol> protSet = attrMap.computeIfAbsent(attrKey, k -> new HashSet<>());
 
         for (String protocol : protocols) {
             Validate.notEmpty(protocol);


### PR DESCRIPTION
This was previously used to support older Android API levels without full `java.util.function` coverage; jsoup now requires core library desugaring so this indirection is no longer necessary.