### PR TITLE
select: add `Elements.before(Node)` with per-target cloning

### DIFF
--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -17,8 +17,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import java.util.Objects;
+
 
 /**
  A list of {@link Element}s, with methods that act on every element in the list.
@@ -340,6 +343,23 @@ public class Elements extends Nodes<Element> {
         super.before(html);
         return this;
     }
+
+    /**
+     * Inserts a clone of the supplied node as a preceding sibling of each element in this collection.
+     * @param node the node to clone and insert (must not be null)
+     * @return this collection, for chaining
+     * @throws NullPointerException if node is null
+     */
+    public Elements before(final Node node) {
+        Objects.requireNonNull(node, "node must not be null");
+        for (Element el : this) {
+            // clone so each element gets its own copy; a Node can only have one parent
+            el.before(node.clone());
+        }
+        return this;
+    }
+
+
 
     /**
      Insert the supplied HTML after each matched element's outer HTML.

--- a/src/test/java/org/jsoup/select/ElementsBeforeNodeTest.java
+++ b/src/test/java/org/jsoup/select/ElementsBeforeNodeTest.java
@@ -1,0 +1,114 @@
+package org.jsoup.select;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.parser.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ElementsBeforeNodeTest {
+
+    @Test
+    public void beforeNode_onMultipleElements_clonesPerInsert() {
+        Document doc = Jsoup.parse("<div><p>A</p><p>B</p></div>");
+        Elements ps = doc.select("p");
+        TextNode tn = new TextNode("#");
+
+        ps.before(tn);
+
+        Element div = doc.selectFirst("div");
+        assertNotNull(div);
+        List<Node> kids = div.childNodes();
+
+        // Expected: TextNode("#"), <p>A</p>, TextNode("#"), <p>B</p>
+        assertEquals(4, kids.size());
+        assertTrue(kids.get(0) instanceof TextNode);
+        assertEquals("#", ((TextNode) kids.get(0)).text());
+
+        assertTrue(kids.get(1) instanceof Element);
+        assertEquals("p", ((Element) kids.get(1)).tagName());
+        assertEquals("A", ((Element) kids.get(1)).text());
+
+        assertTrue(kids.get(2) instanceof TextNode);
+        assertEquals("#", ((TextNode) kids.get(2)).text());
+
+        assertTrue(kids.get(3) instanceof Element);
+        assertEquals("p", ((Element) kids.get(3)).tagName());
+        assertEquals("B", ((Element) kids.get(3)).text());
+
+        // Original node should remain unattached (we inserted clones)
+        assertNull(tn.parent());
+    }
+
+    @Test
+    public void beforeNode_sourceHasParent_isCloned() {
+        Document doc = Jsoup.parse("<div><p>A</p><p>B</p></div>");
+        Elements ps = doc.select("p");
+
+        TextNode tn = new TextNode("#");
+        Element span = new Element(Tag.valueOf("span"), "");
+        span.appendChild(tn); // give tn a parent
+
+        ps.before(tn);
+
+        Element div = doc.selectFirst("div");
+        assertNotNull(div);
+        List<Node> kids = div.childNodes();
+
+        // Expected: TextNode("#"), <p>A</p>, TextNode("#"), <p>B</p>
+        assertEquals(4, kids.size());
+        assertTrue(kids.get(0) instanceof TextNode);
+        assertEquals("#", ((TextNode) kids.get(0)).text());
+        assertTrue(kids.get(1) instanceof Element);
+        assertEquals("p", ((Element) kids.get(1)).tagName());
+        assertEquals("A", ((Element) kids.get(1)).text());
+        assertTrue(kids.get(2) instanceof TextNode);
+        assertEquals("#", ((TextNode) kids.get(2)).text());
+        assertTrue(kids.get(3) instanceof Element);
+        assertEquals("p", ((Element) kids.get(3)).tagName());
+        assertEquals("B", ((Element) kids.get(3)).text());
+
+        // The original tn stays under <span>, proving we cloned
+        assertNotNull(tn.parent());
+        assertEquals("span", tn.parent().nodeName());
+    }
+
+    @Test
+    public void beforeString_existingBehavior_unchanged() {
+        Document doc = Jsoup.parse("<div><p>A</p><p>B</p></div>");
+        doc.select("p").before("<hr>");
+
+        Element div = doc.selectFirst("div");
+        assertNotNull(div);
+        List<Node> kids = div.childNodes();
+
+        // Expected: <hr>, <p>A</p>, <hr>, <p>B</p>
+        assertEquals(4, kids.size());
+        assertTrue(kids.get(0) instanceof Element);
+        assertEquals("hr", ((Element) kids.get(0)).tagName());
+
+        assertTrue(kids.get(1) instanceof Element);
+        assertEquals("p", ((Element) kids.get(1)).tagName());
+        assertEquals("A", ((Element) kids.get(1)).text());
+
+        assertTrue(kids.get(2) instanceof Element);
+        assertEquals("hr", ((Element) kids.get(2)).tagName());
+
+        assertTrue(kids.get(3) instanceof Element);
+        assertEquals("p", ((Element) kids.get(3)).tagName());
+        assertEquals("B", ((Element) kids.get(3)).text());
+    }
+
+    @Test
+    public void beforeNode_null_throwsNpe() {
+        Document doc = Jsoup.parse("<div><p>A</p></div>");
+        Elements ps = doc.select("p");
+        assertThrows(NullPointerException.class, () -> ps.before((Node) null));
+    }
+}


### PR DESCRIPTION
Fixes #2427 


Adds `Elements.before(Node)` that clones the supplied node per element in the selection, matching `before(String)` semantics while supporting node-based insertion.

Key points
- Clone per target (no shared parent conflicts).
- Original node (and parent, if any) remains intact.
- Null argument → NullPointerException.

Tests
- beforeNode_onMultipleElements_clonesPerInsert
- beforeNode_sourceHasParent_isCloned
- beforeString_existingBehavior_unchanged
- beforeNode_null_throwsNpe
