### PR TITLE
Make Tag flag constants final

### DIFF
--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -15,25 +15,25 @@ import static org.jsoup.parser.Parser.NamespaceHtml;
 public class Tag implements Cloneable {
     /** Tag option: the tag is known (specifically defined). This impacts if options may need to be inferred (when not
      known) in, e.g., the pretty-printer. Set when a tag is added to a TagSet, or when settings are set(). */
-    public static int Known = 1;
+    public static final int Known = 1;
     /** Tag option: the tag is a void tag (e.g., {@code <img>}), that can contain no children, and in HTML does not require closing. */
-    public static int Void = 1 << 1;
+    public static final int Void = 1 << 1;
     /** Tag option: the tag is a block tag (e.g., {@code <div>}, {@code <p>}). Causes the element to be indented when pretty-printing. If not a block, it is inline. */
-    public static int Block = 1 << 2;
+    public static final int Block = 1 << 2;
     /** Tag option: the tag is a block tag that will only hold inline tags (e.g., {@code <p>}); used for formatting. (Must also set Block.) */
-    public static int InlineContainer = 1 << 3;
+    public static final int InlineContainer = 1 << 3;
     /** Tag option: the tag can self-close (e.g., {@code <foo />}). */
-    public static int SelfClose = 1 << 4;
+    public static final int SelfClose = 1 << 4;
     /** Tag option: the tag has been seen self-closing in this parse. */
-    public static int SeenSelfClose = 1 << 5;
+    public static final int SeenSelfClose = 1 << 5;
     /** Tag option: the tag preserves whitespace (e.g., {@code <pre>}). */
-    public static int PreserveWhitespace = 1 << 6;
+    public static final int PreserveWhitespace = 1 << 6;
     /** Tag option: the tag is an RCDATA element that can have text and character references (e.g., {@code <title>}, {@code <textarea>}). */
-    public static int RcData = 1 << 7;
+    public static final int RcData = 1 << 7;
     /** Tag option: the tag is a Data element that can have text but not character references (e.g., {@code <style>}, {@code <script>}). */
-    public static int Data = 1 << 8;
+    public static final int Data = 1 << 8;
     /** Tag option: the tag's value will be included when submitting a form (e.g., {@code <input>}). */
-    public static int FormSubmittable = 1 << 9;
+    public static final int FormSubmittable = 1 << 9;
 
     String namespace;
     String tagName;


### PR DESCRIPTION
## Summary

This PR fixes SpotBugs MS_SHOULD_BE_FINAL warnings by making Tag flag constants final.

## Details

- **Tag.java**: Add `final` modifier to 10 public static int fields (lines 18-36)
- These bitmask constants were introduced in v1.20.1 (#2285)

## Problem

SpotBugs reports MS_SHOULD_BE_FINAL warnings (MALICIOUS_CODE category, priority 2) for Tag flag constants.

These constants could theoretically be modified by malicious code on the classpath:

```java
// Malicious library in classpath
import org.jsoup.parser.Tag;

static {
    Tag.Block = 0;              // Breaks block tag behavior
    Tag.SelfClose = 0xFFFF;     // Corrupts self-closing logic
}
```

## References

Static analysis performed as part of empirical study: https://doi.org/10.5281/zenodo.17625604
Wherein we identified MALICIOUS_CODE as the top SpotBugs category on jsoup, MS_SHOULD_BE_FINAL being one of them.