### PR TITLE
Refactor: extract helper method for Element#child

### DIFF
--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -360,7 +360,11 @@ public class Element extends Node implements Iterable<Element> {
         Validate.isTrue(index >= 0, "Index must be >= 0");
         List<Element> cached = cachedChildren();
         if (cached != null) return cached.get(index);
-        // otherwise, iter on elementChild; saves creating list
+
+        return childByFilteredIndex(index);
+    }
+
+    private Element childByFilteredIndex(int index) {
         int size = childNodes.size();
         for (int i = 0, e = 0; i < size; i++) { // direct iter is faster than chasing firstElSib, nextElSibd
             Node node = childNodes.get(i);


### PR DESCRIPTION
Extracted the loop that locates a child element by filtered index into a private helper method (childByFilteredIndex), improving readability while keeping the behavior unchanged.