### PR TITLE
Fix ByteBuffer API calls in SimpleStreamReader and ControllableInputStream

### DIFF
--- a/src/main/java/org/jsoup/internal/ControllableInputStream.java
+++ b/src/main/java/org/jsoup/internal/ControllableInputStream.java
@@ -1,9 +1,5 @@
 package org.jsoup.internal;
 
-import org.jsoup.Progress;
-import org.jsoup.helper.Validate;
-import org.jspecify.annotations.Nullable;
-
 import java.io.BufferedInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -11,7 +7,10 @@ import java.io.InputStream;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 
+import org.jsoup.Progress;
+import org.jsoup.helper.Validate;
 import static org.jsoup.internal.SharedConstants.DefaultBufferSize;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A jsoup internal class (so don't use it as there is no contract API) that enables controls on a buffered input stream,
@@ -134,7 +133,7 @@ public class ControllableInputStream extends FilterInputStream {
                 if (outBuf.remaining() < read) { // needs to grow
                     int newCapacity = (int) Math.max(outBuf.capacity() * 1.5, outBuf.capacity() + read);
                     ByteBuffer newBuffer = ByteBuffer.allocate(newCapacity);
-                    outBuf.flip();
+                    ((java.nio.Buffer) outBuf).flip();
                     newBuffer.put(outBuf);
                     outBuf = newBuffer;
                 }
@@ -144,7 +143,7 @@ public class ControllableInputStream extends FilterInputStream {
                     if (remaining <= 0) break;
                 }
             }
-            outBuf.flip(); // Prepare the buffer for reading
+            ((java.nio.Buffer) outBuf).flip(); // Prepare the buffer for reading
             return outBuf;
         } finally {
             SimpleBufferedInput.BufferPool.release(readBuf);

--- a/src/main/java/org/jsoup/internal/SimpleStreamReader.java
+++ b/src/main/java/org/jsoup/internal/SimpleStreamReader.java
@@ -1,8 +1,5 @@
 package org.jsoup.internal;
 
-import org.jsoup.helper.Validate;
-import org.jspecify.annotations.Nullable;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -13,7 +10,9 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
 
+import org.jsoup.helper.Validate;
 import static org.jsoup.internal.SimpleBufferedInput.BufferPool;
+import org.jspecify.annotations.Nullable;
 
 /**
  A simple decoding InputStreamReader that recycles internal buffers.
@@ -30,7 +29,7 @@ public class SimpleStreamReader extends Reader {
             .onUnmappableCharacter(CodingErrorAction.REPLACE);
         byte[] buf = BufferPool.borrow(); // shared w/ SimpleBufferedInput, ControllableInput
         byteBuf = ByteBuffer.wrap(buf);
-        byteBuf.flip(); // limit(0)
+        ((java.nio.Buffer) byteBuf).flip();
     }
 
     @Override
@@ -81,9 +80,9 @@ public class SimpleStreamReader extends Reader {
             int read = in.read(byteBuf.array(), byteBuf.arrayOffset() + pos, remaining);
             if (read < 0) return read;
             if (read == 0) throw new IOException("Underlying input stream returned zero bytes");
-            byteBuf.position(pos + read);
+            ((java.nio.Buffer) byteBuf).position(pos + read);
         } finally {
-            byteBuf.flip();
+            ((java.nio.Buffer) byteBuf).flip();
         }
         return byteBuf.remaining();
     }


### PR DESCRIPTION
ByteBuffer.flip() and ByteBuffer.position(int) were added as overrides in Java 9 that return ByteBuffer instead of Buffer. When compiled with JDK 9+, the compiler binds to the ByteBuffer return-type overloads, which don't exist in the Java 8 runtime — causing NoSuchMethodError on Java 8 and Android API < 26.

This PR casts ByteBuffer to java.nio.Buffer before calling flip() and position(), forcing the compiler to bind to the base Buffer methods that exist in all Java versions.

Specific Changes:

- ControllableInputStream.java - Cast outBuf to (java.nio.Buffer) before two flip() calls
- SimpleStreamReader.java - Cast bytebuf to java.nio.Buffer before flip() and position() calls
- Import reordering (lexicorgraphic sort, no functional change)

Why this pattern:
Buffer.flip() returns Buffer (since Java 1.0). ByteBuffer.flip() returns ByteBuffer (since Java 9, as a covariant override). By casting to the parent type, we guarantee the Java 8-compatible method signature is used regardless of compilation JDK. This is a well-known cross-compilation pitfall — the bytecode references the exact declaring class of the method, not the runtime type.

Validated by: The project's animal-sniffer plugin (api-java8 and api-android21 checks) now passes, confirming no Java 9+ API references remain.