### PR TITLE
Preserve XML doctype internal subset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 * `Cleaner` no longer duplicates enforced attributes when the input `Document` preserves attribute case. A case-variant source attribute is now replaced by the enforced attribute in the cleaned output. [#2476](https://github.com/jhy/jsoup/issues/2476)
 * If a per-request SOCKS proxy is configured, jsoup now avoids using the JDK `HttpClient`, because the JDK would silently ignore that proxy and attempt to connect directly. Those requests now fall back to the legacy `HttpURLConnection` transport instead, which does support SOCKS. [#2468](https://github.com/jhy/jsoup/issues/2468)
 * `Connection.Response.streamParser()` and `DataUtil.streamParser(Path, ...)` could fail on small inputs without a declared charset, if the initial 5 KB charset sniff fully consumed the input and closed it before the stream parse began. [#2483](https://github.com/jhy/jsoup/issues/2483)
+* In XML mode, doctypes with an internal subset (the `[...]` section inside `<!DOCTYPE ...>` used for entity declarations) now round-trip correctly. The subset is preserved as raw text only; entities are not expanded and external DTDs are not loaded. [#2486](https://github.com/jhy/jsoup/issues/2486)
 
 ## 1.22.1 (2026-Jan-01)
 

--- a/src/main/java/org/jsoup/nodes/DocumentType.java
+++ b/src/main/java/org/jsoup/nodes/DocumentType.java
@@ -18,6 +18,7 @@ public class DocumentType extends LeafNode {
     private static final String PubSysKey = "pubSysKey"; // PUBLIC or SYSTEM
     private static final String PublicId = "publicId";
     private static final String SystemId = "systemId";
+    private static final String InternalSubsetKey = Attributes.internalKey("doctypeInternalSubset");
 
     /**
      * Create a new doctype element.
@@ -39,6 +40,14 @@ public class DocumentType extends LeafNode {
     public void setPubSysKey(@Nullable String value) {
         if (value != null)
             attr(PubSysKey, value);
+    }
+
+    /**
+     Sets the raw XML internal subset for serialization.
+     @param value the internal subset contents
+     */
+    public void setInternalSubset(String value) {
+        attributes().put(InternalSubsetKey, value);
     }
 
     private void updatePubSyskey() {
@@ -93,6 +102,8 @@ public class DocumentType extends LeafNode {
             accum.append(" \"").append(attr(PublicId)).append('"');
         if (has(SystemId))
             accum.append(" \"").append(attr(SystemId)).append('"');
+        if (attributes().hasKey(InternalSubsetKey)) // only if via the xml parser; html parser will drop
+            accum.append(" [").append(attr(InternalSubsetKey)).append(']');
         accum.append('>');
     }
 

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -53,6 +53,8 @@ abstract class Token {
         @Nullable String pubSysKey = null;
         final TokenData publicIdentifier = new TokenData();
         final TokenData systemIdentifier = new TokenData();
+        final TokenData internalSubset = new TokenData();
+        boolean sawInternalSubset = false;
         boolean forceQuirks = false;
 
         Doctype() {
@@ -66,6 +68,8 @@ abstract class Token {
             pubSysKey = null;
             publicIdentifier.reset();
             systemIdentifier.reset();
+            internalSubset.reset();
+            sawInternalSubset = false;
             forceQuirks = false;
             return this;
         }
@@ -84,6 +88,14 @@ abstract class Token {
 
         public String getSystemIdentifier() {
             return systemIdentifier.value();
+        }
+
+        String getInternalSubset() {
+            return internalSubset.value();
+        }
+
+        boolean hasInternalSubset() {
+            return sawInternalSubset;
         }
 
         public boolean isForceQuirks() {

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -1,5 +1,6 @@
 package org.jsoup.parser;
 
+import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.DocumentType;
 
 import static org.jsoup.nodes.Document.OutputSettings.Syntax.xml;
@@ -1244,6 +1245,10 @@ enum TokeniserState {
             else if (r.matches('>')) {
                 t.emitDoctypePending();
                 t.advanceTransition(Data);
+            } else if (t.syntax == xml && r.matches('[')) {
+                // special case when in XML parse mode so we can support entity round trop
+                t.doctypePending.sawInternalSubset = true;
+                t.advanceTransition(DoctypeInternalSubset);
             } else if (r.matchConsumeIgnoreCase(DocumentType.PUBLIC_KEY)) {
                 t.doctypePending.pubSysKey = DocumentType.PUBLIC_KEY;
                 t.transition(AfterDoctypePublicKeyword);
@@ -1443,6 +1448,16 @@ enum TokeniserState {
                     t.emitDoctypePending();
                     t.transition(Data);
                     break;
+                case '[':
+                    if (t.syntax == xml) {
+                        t.doctypePending.sawInternalSubset = true;
+                        t.transition(DoctypeInternalSubset);
+                        break;
+                    }
+                    t.error(this);
+                    t.doctypePending.forceQuirks = true;
+                    t.transition(BogusDoctype);
+                    break;
                 case '"':
                     t.error(this);
                     // system id empty
@@ -1613,6 +1628,16 @@ enum TokeniserState {
                     t.emitDoctypePending();
                     t.transition(Data);
                     break;
+                case '[':
+                    if (t.syntax == xml) {
+                        t.doctypePending.sawInternalSubset = true;
+                        t.transition(DoctypeInternalSubset);
+                        break;
+                    }
+                    t.error(this);
+                    t.transition(BogusDoctype);
+                    // NOT force quirks
+                    break;
                 case eof:
                     t.eofError(this);
                     t.doctypePending.forceQuirks = true;
@@ -1642,6 +1667,11 @@ enum TokeniserState {
                     // ignore char
                     break;
             }
+        }
+    },
+    DoctypeInternalSubset {
+        @Override void read(Tokeniser t, CharacterReader r) {
+            readDoctypeInternalSubset(t, r, this);
         }
     },
     CdataSection {
@@ -1777,6 +1807,86 @@ enum TokeniserState {
             default:
                 r.unconsume();
                 t.transition(fallback);
+        }
+    }
+
+    /**
+     Reads an XML doctype internal subset as opaque text so it can be re-emitted without parsing declarations.
+     Only used when in XML mode; HTML spec will drop these as Bogus.
+     */
+    private static void readDoctypeInternalSubset(Tokeniser t, CharacterReader r, TokeniserState current) {
+        final byte None = 0, SingleQuote = 1, DoubleQuote = 2, Comment = 3, ProcessingInstruction = 4;
+        byte context = None;
+        TokenData subset = t.doctypePending.internalSubset;
+
+        while (true) {
+            char c = r.consume();
+            switch (c) {
+                case '\'':
+                    subset.append(c);
+                    if  (context == None) context = SingleQuote;
+                    else if (context == SingleQuote) context = None;
+                    break;
+                case '"':
+                    subset.append(c);
+                    if (context == None) context = DoubleQuote;
+                    else if (context == DoubleQuote) context = None;
+                    break;
+                case '<':
+                    subset.append(c);
+                    if (context == None) {
+                        if (r.matchConsume("!--")) {
+                            subset.append("!--");
+                            context = Comment;
+                        } else if (r.matchConsume("?")) {
+                            subset.append('?');
+                            context = ProcessingInstruction;
+                        }
+                    }
+                    break;
+                case '-':
+                    subset.append(c);
+                    if (context == Comment && r.matchConsume("->")) {
+                        subset.append("->");
+                        context = None;
+                    }
+                    break;
+                case '?':
+                    subset.append(c);
+                    if (context == ProcessingInstruction && r.matches('>')) {
+                        r.advance();
+                        subset.append('>');
+                        context = None;
+                    }
+                    break;
+                case ']':
+                    if (context == None) {
+                        String ws = r.consumeMatching(StringUtil::isWhitespace);
+                        if (r.matches('>')) {
+                            r.advance();
+                            t.emitDoctypePending();
+                            t.transition(Data);
+                            return;
+                        }
+                        subset.append(c);
+                        subset.append(ws);
+                        break;
+                    }
+                    subset.append(c);
+                    break;
+                case nullChar:
+                    t.error(current);
+                    subset.append(replacementChar);
+                    break;
+                case eof:
+                    t.eofError(current);
+                    t.emitDoctypePending();
+                    t.transition(Data);
+                    return;
+                default:
+                    subset.append(c);
+                    break;
+            }
         }
     }
 }

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -238,6 +238,8 @@ public class XmlTreeBuilder extends TreeBuilder {
     void insertDoctypeFor(Token.Doctype token) {
         DocumentType doctypeNode = new DocumentType(settings.normalizeTag(token.getName()), token.getPublicIdentifier(), token.getSystemIdentifier());
         doctypeNode.setPubSysKey(token.getPubSysKey());
+        if (token.hasInternalSubset())
+            doctypeNode.setInternalSubset(token.getInternalSubset());
         insertLeafNode(doctypeNode);
     }
 

--- a/src/test/java/org/jsoup/nodes/DocumentTypeTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTypeTest.java
@@ -61,6 +61,15 @@ public class DocumentTypeTest {
         String legacyDoc = "<!DOCTYPE html SYSTEM \"about:legacy-compat\">";
         assertEquals(legacyDoc, htmlOutput(legacyDoc));
         assertEquals(legacyDoc, xmlOutput(legacyDoc));
+
+        // round trips internal subset in xml; dropped in html
+        String internalSubset = "<!DOCTYPE svg SYSTEM \"example.dtd\" [<!ENTITY ns_extend \"http://ns.adobe.com/Extensibility/1.0/\">]>";
+        assertEquals("<!DOCTYPE svg SYSTEM \"example.dtd\">", htmlOutput(internalSubset));
+        assertEquals(internalSubset, xmlOutput(internalSubset));
+
+        String emptySubset = "<!DOCTYPE root []>";
+        assertEquals("<!doctype root>", htmlOutput(emptySubset));
+        assertEquals(emptySubset, xmlOutput(emptySubset));
     }
 
     private String htmlOutput(String in) {

--- a/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
@@ -387,6 +387,59 @@ public class XmlTreeBuilderTest {
         assertEquals(expect, doc.html());
     }
 
+    @Test void roundtripsDoctypeInternalSubset() {
+        // https://github.com/jhy/jsoup/issues/2486
+        String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+            "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\" [\n" +
+            "<!ENTITY ns_extend \"http://ns.adobe.com/Extensibility/1.0/\">\n" +
+            "<!ENTITY ns_ai \"http://ns.adobe.com/AdobeIllustrator/10.0/\">\n" +
+            "]>\n" +
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">\n" +
+            "<circle cx=\"50\" cy=\"50\" r=\"40\" fill=\"red\"/>\n" +
+            "</svg>";
+        Document doc = Jsoup.parse(xml, Parser.xmlParser());
+
+        DocumentType doctype = doc.documentType();
+        assertNotNull(doctype);
+        assertEquals("<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\" [\n" +
+            "<!ENTITY ns_extend \"http://ns.adobe.com/Extensibility/1.0/\">\n" +
+            "<!ENTITY ns_ai \"http://ns.adobe.com/AdobeIllustrator/10.0/\">\n" +
+            "]>", doctype.outerHtml());
+        assertFalse(doc.outerHtml().contains("]&gt;"));
+    }
+
+    @Test void doesNotCloseDoctypeSubsetOnQuotedGt() {
+        String xml = "<!DOCTYPE root [<!ENTITY example \"keep ]> quoted\">]><root/>";
+        Document doc = Jsoup.parse(xml, Parser.xmlParser());
+
+        assertEquals(2, doc.childNodeSize());
+        DocumentType doctype = (DocumentType) doc.childNode(0);
+        assertEquals("<!DOCTYPE root [<!ENTITY example \"keep ]> quoted\">]>", doctype.outerHtml());
+        assertEquals("<!DOCTYPE root [<!ENTITY example \"keep ]> quoted\">]><root />", doc.outerHtml());
+    }
+
+    @Test void preservesEmptyDoctypeInternalSubset() {
+        String xml = "<!DOCTYPE root []><root/>";
+        Document doc = Jsoup.parse(xml, Parser.xmlParser());
+
+        assertEquals(2, doc.childNodeSize());
+        DocumentType doctype = (DocumentType) doc.childNode(0);
+        assertEquals("<!DOCTYPE root []>", doctype.outerHtml());
+        assertEquals("<!DOCTYPE root []><root />", doc.outerHtml());
+    }
+
+    @Test void unterminatedDoctypeSubsetConsumesToEof() {
+        String xml = "<!DOCTYPE root [<!ENTITY x \"unterminated]><root/>";
+        Parser parser = Parser.xmlParser().setTrackErrors(10);
+        Document doc = Jsoup.parse(xml, "", parser);
+
+        assertEquals(1, doc.childNodeSize());
+        DocumentType doctype = (DocumentType) doc.childNode(0);
+        assertEquals("<!DOCTYPE root [<!ENTITY x \"unterminated]><root/>]>", doctype.outerHtml());
+        assertEquals(1, parser.getErrors().size());
+        assertEquals("Unexpectedly reached end of file (EOF) in input state [DoctypeInternalSubset]", parser.getErrors().get(0).getErrorMessage());
+    }
+
     @Test void canSetCustomRcdataTag() {
         String inner = "Blah\nblah\n<foo></foo>&quot;";
         String innerText = "Blah\nblah\n<foo></foo>\"";


### PR DESCRIPTION
So that we can round-trip parse -> serialize entities defined in doctype

Fixes #2486