### PR TITLE
Add Elements.before(Node) with tests

### DIFF
--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -342,6 +342,22 @@ public class Elements extends Nodes<Element> {
     }
 
     /**
+     Insert the supplied node before each matched element's outer HTML.
+
+     @param node node to insert before each element
+     @return this, for chaining
+     @see Element#before(Node)
+     */
+    public Elements before(Node node) {
+        Validate.notNull(node);
+
+        for (Element element : this) {
+            element.before(node.clone());
+        }
+        return this;
+    }
+
+    /**
      Insert the supplied HTML after each matched element's outer HTML.
 
      @param html HTML to insert after each element

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -169,6 +169,58 @@ public class ElementsTest {
         assertEquals("<p>This <span>foo</span><a>is</a> <span>foo</span><a>jsoup</a>.</p>", TextUtil.stripNewlines(doc.body().html()));
     }
 
+    @Test public void beforeNode() {
+        Document doc = Jsoup.parse("<p>One</p><p>Two</p>");
+        Elements ps = doc.select("p");
+
+        Element span = Jsoup.parse("<span>X</span>").selectFirst("span");
+        ps.before(span);
+
+        Elements bodyChildren = doc.body().children();
+        assertEquals(4, bodyChildren.size());
+        assertEquals("span", bodyChildren.get(0).tagName());
+        assertEquals("X", bodyChildren.get(0).text());
+        assertEquals("p", bodyChildren.get(1).tagName());
+        assertEquals("One", bodyChildren.get(1).text());
+        assertEquals("span", bodyChildren.get(2).tagName());
+        assertEquals("X", bodyChildren.get(2).text());
+        assertEquals("p", bodyChildren.get(3).tagName());
+        assertEquals("Two", bodyChildren.get(3).text());
+    }
+
+    @Test public void beforeNodeClonesForMultipleElements() {
+    Document doc = Jsoup.parse("<p>One</p><p>Two</p>");
+    Elements ps = doc.select("p");
+
+    Element span = Jsoup.parse("<span>X</span>").selectFirst("span");
+    ps.before(span);
+
+    Elements spans = doc.select("span");
+    assertEquals(2, spans.size()); // ensures cloning happened
+    }
+
+    @Test public void beforeNodeEmptyElements() {
+    Document doc = Jsoup.parse("<div></div>");
+    Elements ps = doc.select("p");
+
+    Element span = Jsoup.parse("<span>X</span>").selectFirst("span");
+    ps.before(span);
+
+    assertEquals("<div></div>", doc.body().html());
+    }
+
+    @Test public void beforeNodeNullThrows() {
+    Document doc = Jsoup.parse("<p>One</p>");
+    Elements ps = doc.select("p");
+
+    try {
+        ps.before((Node) null);
+        fail("Should have thrown exception");
+    } catch (IllegalArgumentException e) {
+        // expected
+    }
+    }
+
     @Test public void after() {
         Document doc = Jsoup.parse("<p>This <a>is</a> <a>jsoup</a>.</p>");
         doc.select("a").after("<span>foo</span>");


### PR DESCRIPTION
This PR adds support for Elements.before(Node node), extending the existing API to allow inserting a Node before each element in an Elements collection.

Currently, jsoup supports:
- Element.before(Node node) for single elements
- Elements.before(String html) for collections

However, there is no equivalent method for inserting a Node across an Elements collection. This requires users to convert nodes to HTML strings (e.g., via outerHtml()), which is less intuitive and less efficient.

This implementation applies the insertion to each element in the collection and clones the provided node to ensure correct DOM behavior when inserting before multiple elements.

Tests were added to verify:
- insertion before multiple elements
- correct cloning behavior
- empty element collections
- null input handling

Closes #953