### PR TITLE
Refactor source range storage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 1.23.1 (pending)
 
+### Improvements
+* Reduced retained memory when parsing with source position tracking enabled (`Parser#setTrackPosition(true)`). Source ranges are now stored in compact parser-owned span records instead of node and attribute user data, and `Position` objects are created lazily when source ranges are read. This cuts tracked DOM retained size by about 50-60% on representative benchmark documents, while keeping `Node#sourceRange()`, `Element#endSourceRange()`, and `Attribute#sourceRange()` behavior intact. [#2498](https://github.com/jhy/jsoup/pull/2498)
+
 ### Build Changes
 * Cleaned up the Maven build for the multi-release JAR so Java 8 and Java 11+ sources compile as separate source sets. This avoids spurious Java 8 compiler warnings from newer-language overlay sources, keeps long-running parser checks behind an explicit profile, and preserves the same published artifacts and runtime behavior.
 

--- a/src/main/java/org/jsoup/internal/LineMap.java
+++ b/src/main/java/org/jsoup/internal/LineMap.java
@@ -1,0 +1,79 @@
+package org.jsoup.internal;
+
+import java.util.Arrays;
+
+/**
+ Maps source offsets to line and column coordinates. Jsoup internal; API subject to change.
+ */
+public final class LineMap {
+    private static final int InitialLineCapacity = 16;
+    private static final int CapacityGrowthFactor = 2;
+    private static final int[] Empty = new int[0];
+    private int[] lineStarts = Empty;
+    private int size;
+
+    /**
+     Creates a shared line map for tracked source ranges.
+     */
+    public LineMap() {}
+
+    /**
+     Records the source offset immediately after a newline.
+     */
+    public void addLineStart(int pos) {
+        // Buffer scans overlap after compaction, so ignore line starts already recorded.
+        if (size == 0 || pos > lineStarts[size - 1]) {
+            ensureCapacity(size + 1);
+            lineStarts[size++] = pos;
+        }
+    }
+
+    /**
+     Trims the backing array after the parse has completed.
+     */
+    public void complete() {
+        if (lineStarts.length != size)
+            lineStarts = size == 0 ? Empty : Arrays.copyOf(lineStarts, size);
+    }
+
+    /**
+     Gets the 1-based line number for a source offset.
+     */
+    public int lineNumber(int pos) {
+        if (pos < 0)
+            return -1;
+        int lineIndex = lineStartIndex(pos);
+        // -1 means before the first newline, so line 1. lineStarts[0] is the start of line 2.
+        return lineIndex + 2;
+    }
+
+    /**
+     Gets the 1-based column number for a source offset.
+     */
+    public int columnNumber(int pos) {
+        if (pos < 0)
+            return -1;
+        int index = lineStartIndex(pos);
+        return index == -1 ? pos + 1 : pos - lineStarts[index] + 1;
+    }
+
+    /**
+     Finds the preceding line-start entry for a source offset.
+     */
+    private int lineStartIndex(int pos) {
+        int index = Arrays.binarySearch(lineStarts, 0, size, pos);
+        return index >= 0 ? index : -index - 2;
+    }
+
+    /**
+     Grows line-start storage with a small initial allocation and doubling growth.
+     */
+    private void ensureCapacity(int minSize) {
+        if (lineStarts.length >= minSize)
+            return;
+        int newSize = lineStarts.length == 0 ? InitialLineCapacity : lineStarts.length * CapacityGrowthFactor;
+        if (newSize < minSize)
+            newSize = minSize;
+        lineStarts = Arrays.copyOf(lineStarts, newSize);
+    }
+}

--- a/src/main/java/org/jsoup/internal/SharedConstants.java
+++ b/src/main/java/org/jsoup/internal/SharedConstants.java
@@ -6,9 +6,13 @@ package org.jsoup.internal;
  */
 public final class SharedConstants {
     public static final String UserDataKey = "/jsoup.userdata";
-    public final static String AttrRangeKey = "jsoup.attrs";
-    public static final String RangeKey = "jsoup.start";
-    public static final String EndRangeKey = "jsoup.end";
+    /** @deprecated Internal source ranges now use {@link #RangeSpansKey}. */
+    @Deprecated public final static String AttrRangeKey = "jsoup.attrs";
+    /** @deprecated Internal source ranges now use {@link #RangeSpansKey}. */
+    @Deprecated public static final String RangeKey = "jsoup.start";
+    /** @deprecated Internal source ranges now use {@link #RangeSpansKey}. */
+    @Deprecated public static final String EndRangeKey = "jsoup.end";
+    public static final String RangeSpansKey = "/jsoup.spans";
     public static final String XmlnsAttr = "jsoup.xmlns-";
 
     public static final int DefaultBufferSize = 8 * 1024;

--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -74,15 +74,8 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
         if (parent != null) {
             int i = parent.indexOfKey(this.key);
             if (i != Attributes.NotFound) {
-                String oldKey = parent.keys[i];
                 parent.keys[i] = key;
-
-                // if tracking source positions, update the key in the range map
-                Map<String, Range.AttributeRange> ranges = parent.getRanges();
-                if (ranges != null) {
-                    Range.AttributeRange range = ranges.remove(oldKey);
-                    ranges.put(key, range);
-                }
+                // Source ranges are index-aligned in the parent, so a key update keeps the same range.
             }
         }
         this.key = key;

--- a/src/main/java/org/jsoup/nodes/Attributes.java
+++ b/src/main/java/org/jsoup/nodes/Attributes.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import static org.jsoup.internal.Normalizer.lowerCase;
-import static org.jsoup.internal.SharedConstants.AttrRangeKey;
 import static org.jsoup.nodes.Range.AttributeRange.UntrackedAttr;
 
 /**
@@ -80,6 +79,35 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
                 return i;
         }
         return NotFound;
+    }
+
+    /**
+     Finds a visible attribute's range index, skipping internal metadata slots.
+     */
+    int visibleIndexOfKey(String key) {
+        Validate.notNull(key);
+        int visible = 0;
+        for (int i = 0; i < size; i++) {
+            String attrKey = keys[i];
+            if (isInternalKey(attrKey))
+                continue;
+            if (key.equals(attrKey))
+                return visible;
+            visible++;
+        }
+        return NotFound;
+    }
+
+    /**
+     Maps an attribute array slot to the matching visible attribute index.
+     */
+    private int visibleIndex(int index) {
+        int visible = 0;
+        for (int i = 0; i < index; i++) {
+            if (!isInternalKey(keys[i]))
+                visible++;
+        }
+        return visible;
     }
 
     private int indexOfKeyIgnoreCase(String key) {
@@ -166,7 +194,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
     /**
      Get the map holding any user-data associated with these Attributes. Will be created empty on first use. Held as
      an internal attribute, not a field member, to reduce the memory footprint of Attributes when not used. Can hold
-     arbitrary objects; use for source ranges, connecting W3C nodes to Elements, etc.
+     arbitrary objects; use for connecting W3C nodes to Elements, etc.
      * @return the map holding user-data
      */
     @SuppressWarnings("unchecked")
@@ -222,6 +250,37 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         return this;
     }
 
+    /**
+     Gets the range spans, if source tracking was used.
+     */
+    Range.@Nullable Spans spans() {
+        int i = indexOfKey(SharedConstants.RangeSpansKey);
+        return i == NotFound ? null : (Range.Spans) vals[i];
+    }
+
+    /**
+     Gets or creates the range spans for this attributes object.
+     */
+    Range.Spans ensureSpans() {
+        Range.Spans rangeSpans = spans();
+        if (rangeSpans == null) {
+            rangeSpans = new Range.Spans();
+            addObject(SharedConstants.RangeSpansKey, rangeSpans);
+        }
+        return rangeSpans;
+    }
+
+    /**
+     Sets the range spans when expanding compact leaf storage.
+     */
+    void putSpans(Range.Spans rangeSpans) {
+        int i = indexOfKey(SharedConstants.RangeSpansKey);
+        if (i == NotFound)
+            addObject(SharedConstants.RangeSpansKey, rangeSpans);
+        else
+            vals[i] = rangeSpans;
+    }
+
     void putIgnoreCase(String key, @Nullable String value) {
         int i = indexOfKeyIgnoreCase(key);
         if (i != NotFound) {
@@ -265,6 +324,11 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
     @SuppressWarnings("AssignmentToNull")
     private void remove(int index) {
         Validate.isFalse(index >= size);
+        Range.Spans rangeSpans = spans();
+        // Source ranges are stored by visible attribute index; internal metadata slots have no matching range record.
+        if (rangeSpans != null && !isInternalKey(keys[index]))
+            rangeSpans.removeAttributeRange(visibleIndex(index));
+
         int shifted = size - index - 1;
         if (shifted > 0) {
             System.arraycopy(keys, index + 1, keys, index, shifted);
@@ -379,7 +443,7 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
     /**
      Get the source ranges (start to end position) in the original input source from which this attribute's <b>name</b>
      and <b>value</b> were parsed.
-     <p>Position tracking must be enabled prior to parsing the content.</p>
+     <p>Position tracking must be enabled before parsing the content.</p>
      @param key the attribute name
      @return the ranges for the attribute's name and value, or {@code untracked} if the attribute does not exist or its range
      was not tracked.
@@ -390,35 +454,26 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
      @since 1.17.1
      */
     public Range.AttributeRange sourceRange(String key) {
-        if (!hasKey(key)) return UntrackedAttr;
-        Map<String, Range.AttributeRange> ranges = getRanges();
-        if (ranges == null) return Range.AttributeRange.UntrackedAttr;
-        Range.AttributeRange range = ranges.get(key);
-        return range != null ? range : Range.AttributeRange.UntrackedAttr;
-    }
-
-    /** Get the Ranges, if tracking is enabled; null otherwise. */
-    @SuppressWarnings("unchecked")
-    @Nullable Map<String, Range.AttributeRange> getRanges() {
-        return (Map<String, Range.AttributeRange>) userData(AttrRangeKey);
+        int index = visibleIndexOfKey(key);
+        if (index == NotFound) return UntrackedAttr;
+        Range.Spans rangeSpans = spans();
+        return rangeSpans != null ? rangeSpans.attributeRange(index) : UntrackedAttr;
     }
 
     /**
-     Set the source ranges (start to end position) from which this attribute's <b>name</b> and <b>value</b> were parsed.
+     Deprecated parser-internal source range setup method, retained for source compatibility. Source ranges are normally
+     produced by enabling parser position tracking before parsing.
      @param key the attribute name
      @param range the range for the attribute's name and value
      @return these attributes, for chaining
      @since 1.18.2
+     @deprecated Use parser position tracking instead. Will be removed in jsoup 1.24.1.
      */
+    @Deprecated
     public Attributes sourceRange(String key, Range.AttributeRange range) {
         Validate.notNull(key);
         Validate.notNull(range);
-        Map<String, Range.AttributeRange> ranges = getRanges();
-        if (ranges == null) {
-            ranges = new HashMap<>();
-            userData(AttrRangeKey, ranges);
-        }
-        ranges.put(key, range);
+        NodeInternals.attributeRange(this, key, range);
         return this;
     }
 
@@ -573,7 +628,13 @@ public class Attributes implements Iterable<Attribute>, Cloneable {
         // make a copy of the user data map. (Contents are shallow).
         int i = indexOfKey(SharedConstants.UserDataKey);
         if (i != NotFound) {
-            vals[i] = new HashMap<>((Map<String, Object>) vals[i]);
+            clone.vals[i] = new HashMap<>((Map<String, Object>) vals[i]);
+        }
+
+        // make a copy of the range spans, if present.
+        i = indexOfKey(SharedConstants.RangeSpansKey);
+        if (i != NotFound) {
+            clone.vals[i] = ((Range.Spans) vals[i]).copy();
         }
 
         return clone;

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -1935,7 +1935,7 @@ public class Element extends Node implements Iterable<Element> {
 
     /**
      Get the source range (start and end positions) of the end (closing) tag for this Element. Position tracking must be
-     enabled prior to parsing the content.
+     enabled before parsing the content.
      @return the range of the closing tag for this element, or {@code untracked} if its range was not tracked.
      @see org.jsoup.parser.Parser#setTrackPosition(boolean)
      @see Node#sourceRange()
@@ -1943,7 +1943,7 @@ public class Element extends Node implements Iterable<Element> {
      @since 1.15.2
      */
     public Range endSourceRange() {
-        return Range.of(this, false);
+        return Range.ofEnd(this);
     }
 
     @Override

--- a/src/main/java/org/jsoup/nodes/LeafNode.java
+++ b/src/main/java/org/jsoup/nodes/LeafNode.java
@@ -10,7 +10,7 @@ import java.util.List;
  A node that does not hold any children. E.g.: {@link TextNode}, {@link DataNode}, {@link Comment}.
  */
 public abstract class LeafNode extends Node {
-    Object value; // either a string value, or an attribute map (in the rare case multiple attributes are set)
+    Object value; // either a string, tracked string, or attributes object
 
     public LeafNode() {
         value = "";
@@ -32,16 +32,21 @@ public abstract class LeafNode extends Node {
     }
 
     private void ensureAttributes() {
-        if (!hasAttributes()) { // then value is String coreValue
-            String coreValue = (String) value;
+        if (!hasAttributes()) {
+            String coreValue = coreValue();
             Attributes attributes = new Attributes();
+            Range.Spans rangeSpans = spans();
             value = attributes;
             attributes.put(nodeName(), coreValue);
+            if (rangeSpans != null)
+                attributes.putSpans(rangeSpans);
         }
     }
 
     String coreValue() {
-        return attr(nodeName());
+        if (value instanceof Attributes)   return ((Attributes) value).get(nodeName());
+        if (value instanceof TrackedValue) return ((TrackedValue) value).coreValue;
+        return (String) value;
     }
 
     @Override @Nullable
@@ -55,21 +60,25 @@ public abstract class LeafNode extends Node {
     }
 
     void coreValue(String value) {
-        attr(nodeName(), value);
+        if (this.value instanceof Attributes)
+            ((Attributes) this.value).put(nodeName(), value);
+        else if (this.value instanceof TrackedValue)
+            ((TrackedValue) this.value).coreValue = value;
+        else
+            this.value = value;
     }
 
     @Override
     public String attr(String key) {
-        if (!hasAttributes()) {
-            return nodeName().equals(key) ? (String) value : EmptyString;
-        }
+        if (!hasAttributes())
+            return nodeName().equals(key) ? coreValue() : EmptyString;
         return super.attr(key);
     }
 
     @Override
     public Node attr(String key, String value) {
         if (!hasAttributes() && key.equals(nodeName())) {
-            this.value = value;
+            coreValue(value);
         } else {
             ensureAttributes();
             super.attr(key, value);
@@ -127,10 +136,62 @@ public abstract class LeafNode extends Node {
     protected LeafNode doClone(Node parent) {
         LeafNode clone = (LeafNode) super.doClone(parent);
 
-        // Object value could be plain string or attributes - need to clone
+        // Object value could be plain string, tracked string, or attributes - need to clone.
         if (hasAttributes())
             clone.value = ((Attributes) value).clone();
+        else if (value instanceof TrackedValue)
+            clone.value = ((TrackedValue) value).copy();
 
         return clone;
+    }
+
+    @Override Range.@Nullable Spans spans() {
+        if (value instanceof TrackedValue)
+            return ((TrackedValue) value).spans;
+        return super.spans();
+    }
+
+    @Override Range.Spans ensureSpans() {
+        // Leaf nodes normally hold just their core string. When source ranges are tracked, keep the string plus spans
+        // in a small wrapper so leaf nodes do not expand to Attributes just for parser metadata. If attributes are
+        // later requested, ensureAttributes() moves these same spans into the Attributes object.
+        if (value instanceof TrackedValue)
+            return ((TrackedValue) value).spans;
+        if (value instanceof Attributes)
+            return ((Attributes) value).ensureSpans();
+
+        TrackedValue trackedValue = new TrackedValue((String) value);
+        value = trackedValue;
+        return trackedValue.spans;
+    }
+
+    /**
+     Holds a compact leaf value plus ranges without expanding to Attributes.
+     */
+    private static final class TrackedValue {
+        String coreValue;
+        final Range.Spans spans;
+
+        /**
+         Creates a tracked leaf value around the core text.
+         */
+        TrackedValue(String coreValue) {
+            this(coreValue, new Range.Spans());
+        }
+
+        /**
+         Creates a tracked leaf value around copied range spans.
+         */
+        TrackedValue(String coreValue, Range.Spans spans) {
+            this.coreValue = coreValue;
+            this.spans = spans;
+        }
+
+        /**
+         Returns a copy so cloned leaf nodes can mutate range spans independently.
+         */
+        TrackedValue copy() {
+            return new TrackedValue(coreValue, spans.copy());
+        }
     }
 }

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -889,7 +889,22 @@ public abstract class Node implements Cloneable {
      @since 1.15.2
      */
     public Range sourceRange() {
-        return Range.of(this, true);
+        return Range.ofStart(this);
+    }
+
+    /**
+     Gets the range spans, if source tracking was used.
+     */
+    Range.@Nullable Spans spans() {
+        if (!hasAttributes()) return null;
+        return attributes().spans();
+    }
+
+    /**
+     Gets or creates range spans for this node.
+     */
+    Range.Spans ensureSpans() {
+        return attributes().ensureSpans();
     }
 
     /**

--- a/src/main/java/org/jsoup/nodes/NodeInternals.java
+++ b/src/main/java/org/jsoup/nodes/NodeInternals.java
@@ -1,0 +1,60 @@
+package org.jsoup.nodes;
+
+import org.jsoup.helper.Validate;
+import org.jsoup.internal.LineMap;
+
+/**
+ Internal hooks used by the parser and cleaner to attach source ranges to nodes and attributes.
+ <p>This class is public only because jsoup's internal packages need to cross package boundaries; it is not a supported
+ user API.</p>
+ */
+public final class NodeInternals {
+    private NodeInternals() {}
+
+    /**
+     Sets the source range for a node's start.
+     */
+    public static void sourceRange(Node node, LineMap lineMap, int startPos, int endPos) {
+        Validate.notNull(node);
+        node.ensureSpans().sourceRange(lineMap, startPos, endPos);
+    }
+
+    /**
+     Sets the source range for an element's end tag.
+     */
+    public static void endSourceRange(Element element, LineMap lineMap, int startPos, int endPos) {
+        Validate.notNull(element);
+        element.ensureSpans().endSourceRange(lineMap, startPos, endPos);
+    }
+
+    /**
+     Sets parser-tracked source offsets for an attribute.
+     */
+    public static void attributeRange(
+        Attributes attributes,
+        String key,
+        LineMap lineMap,
+        int nameStart,
+        int nameEnd,
+        int valueStart,
+        int valueEnd
+    ) {
+        Validate.notNull(attributes);
+        Validate.notNull(key);
+        int index = attributes.visibleIndexOfKey(key);
+        if (index != Attributes.NotFound)
+            attributes.ensureSpans().attributeRange(index, lineMap, nameStart, nameEnd, valueStart, valueEnd);
+    }
+
+    /**
+     Copies an existing tracked attribute range onto another attribute set.
+     */
+    public static void attributeRange(Attributes attributes, String key, Range.AttributeRange range) {
+        Validate.notNull(attributes);
+        Validate.notNull(key);
+        Validate.notNull(range);
+        int index = attributes.visibleIndexOfKey(key);
+        if (index != Attributes.NotFound && range.isTracked())
+            attributes.ensureSpans().attributeRange(index, range);
+    }
+}

--- a/src/main/java/org/jsoup/nodes/Range.java
+++ b/src/main/java/org/jsoup/nodes/Range.java
@@ -1,75 +1,115 @@
 package org.jsoup.nodes;
 
+import org.jsoup.internal.LineMap;
 import org.jsoup.internal.StringUtil;
 
+import java.util.Arrays;
 import java.util.Objects;
 
-import static org.jsoup.internal.SharedConstants.*;
-
 /**
- A Range object tracks the character positions in the original input source where a Node starts or ends. If you want to
- track these positions, tracking must be enabled in the Parser with
- {@link org.jsoup.parser.Parser#setTrackPosition(boolean)}.
+ A Range tracks the source offsets where a Node starts or ends. Line and column coordinates are derived from the
+ line map retained during parsing. To track these positions, enable {@link org.jsoup.parser.Parser#setTrackPosition(boolean)}
+ before parsing.
  @see Node#sourceRange()
  @since 1.15.2
  */
 public class Range {
+    // sentinels
+    private static final LineMap UnsetLineMap  = new LineMap();
+    private static final int[] UnsetAttrRanges = new int[0];
     private static final Position UntrackedPos = new Position(-1, -1, -1);
-    private final Position start, end;
+    private static final Range Untracked       = new Range();
 
-    /** An untracked source range. */
-    static final Range Untracked = new Range(UntrackedPos, UntrackedPos);
+    private final LineMap lineMap;
+    private final int startPos;
+    private final int endPos;
 
     /**
-     Creates a new Range with start and end Positions. Called by TreeBuilder when position tracking is on.
-     * @param start the start position
-     * @param end the end position
+     Creates the untracked source range sentinel.
      */
-    public Range(Position start, Position end) {
-        this.start = start;
-        this.end = end;
+    private Range() {
+        lineMap = UnsetLineMap;
+        startPos = -1;
+        endPos = -1;
     }
 
     /**
-     Get the start position of this node.
-     * @return the start position
+     Creates a new Range from source offsets.
+     */
+    private Range(LineMap lineMap, int startPos, int endPos) {
+        this.lineMap = lineMap;
+        if (startPos < 0 || endPos < 0)
+            throw new IllegalArgumentException("Range positions must be non-negative");
+        this.startPos = startPos;
+        this.endPos = endPos;
+    }
+
+    /**
+     Deprecated parser-internal source range setup method, retained for source compatibility. The line and column values
+     in the supplied Positions are not retained; they are derived from source offsets. If either supplied Position is
+     untracked, this Range will also be untracked.
+
+     @param start the start position
+     @param end   the end position
+     @deprecated Use parser position tracking instead. Will be removed in jsoup 1.24.1.
+     */
+    @Deprecated
+    public Range(Position start, Position end) {
+        Objects.requireNonNull(start);
+        Objects.requireNonNull(end);
+        if (start.pos < -1 || end.pos < -1)
+            throw new IllegalArgumentException("Range positions must be non-negative, or -1 for untracked");
+        if (start.pos == -1 || end.pos == -1) {
+            lineMap = UnsetLineMap;
+            startPos = -1;
+            endPos = -1;
+        } else {
+            lineMap = new LineMap();
+            startPos = start.pos;
+            endPos = end.pos;
+        }
+    }
+
+    /**
+     Get the start position of this range, with 1-based line and column coordinates.
+     * @return the start position.
      */
     public Position start() {
-        return start;
+        return startPos == -1 ? UntrackedPos : position(startPos);
     }
 
     /**
-     Get the starting cursor position of this range.
-     @return the 0-based start cursor position.
+     Get the starting source offset of this range.
+     @return the 0-based start source offset.
      @since 1.17.1
      */
     public int startPos() {
-        return start.pos;
+        return startPos;
     }
 
     /**
-     Get the end position of this node.
-     * @return the end position
+     Get the end position of this range, with 1-based line and column coordinates.
+     * @return the end position.
      */
     public Position end() {
-        return end;
+        return endPos == -1 ? UntrackedPos : position(endPos);
     }
 
     /**
-     Get the ending cursor position of this range.
-     @return the 0-based ending cursor position.
+     Get the ending source offset of this range.
+     @return the 0-based ending source offset.
      @since 1.17.1
      */
     public int endPos() {
-        return end.pos;
+        return endPos;
     }
 
     /**
-     Test if this source range was tracked during parsing.
-     * @return true if this was tracked during parsing, false otherwise (and all fields will be {@code -1}).
+     Test if this range has source offsets available.
+     * @return true if this range has source offsets, false otherwise (and all fields will be {@code -1}).
      */
     public boolean isTracked() {
-        return this != Untracked;
+        return startPos != -1;
     }
 
     /**
@@ -82,21 +122,34 @@ public class Range {
      @since 1.17.1
      */
     public boolean isImplicit() {
-        if (!isTracked()) return false;
-        return start.equals(end);
+        return isTracked() && startPos == endPos;
     }
 
     /**
-     Retrieves the source range for a given Node.
+     Creates a Position from a source offset and this Range's line map.
+     */
+    private Position position(int pos) {
+        return new Position(pos, lineMap.lineNumber(pos), lineMap.columnNumber(pos));
+    }
+
+    /**
+     Retrieves the start source range for a given Node.
      * @param node the node to retrieve the position for
-     * @param start if this is the starting range. {@code false} for Element end tags.
      * @return the Range, or the Untracked (-1) position if tracking is disabled.
      */
-    static Range of(Node node, boolean start) {
-        final String key = start ? RangeKey : EndRangeKey;
-        if (!node.hasAttributes()) return Untracked;
-        Object range = node.attributes().userData(key);
-        return range != null ? (Range) range : Untracked;
+    static Range ofStart(Node node) {
+        Range.Spans rangeSpans = node.spans();
+        return rangeSpans != null ? rangeSpans.sourceRange() : Untracked;
+    }
+
+    /**
+     Retrieves the end source range for a given Element.
+     * @param element the element to retrieve the end tag position for
+     * @return the Range, or the Untracked (-1) position if tracking is disabled.
+     */
+    static Range ofEnd(Element element) {
+        Range.Spans rangeSpans = element.spans();
+        return rangeSpans != null ? rangeSpans.endSourceRange() : Untracked;
     }
 
     @Override
@@ -106,39 +159,46 @@ public class Range {
 
         Range range = (Range) o;
 
-        if (!start.equals(range.start)) return false;
-        return end.equals(range.end);
+        return startPos == range.startPos && endPos == range.endPos;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(start, end);
+        int result = startPos;
+        result = 31 * result + endPos;
+        return result;
     }
 
     /**
-     Gets a String presentation of this Range, in the format {@code line,column:pos-line,column:pos}.
+     Gets a String representation of this Range, in the format {@code line,column:pos-line,column:pos}.
      * @return a String
      */
     @Override
     public String toString() {
-        return start + "-" + end;
+        StringBuilder sb = StringUtil.borrowBuilder()
+            .append(start())
+            .append('-')
+            .append(end());
+        return StringUtil.releaseBuilder(sb);
     }
 
     /**
-     A Position object tracks the character position in the original input source where a Node starts or ends. If you want to
-     track these positions, tracking must be enabled in the Parser with
-     {@link org.jsoup.parser.Parser#setTrackPosition(boolean)}.
+     A Position describes a source offset and its line and column coordinates. Positions are available when position
+     tracking is enabled with {@link org.jsoup.parser.Parser#setTrackPosition(boolean)} before parsing.
      @see Node#sourceRange()
      */
     public static class Position {
         private final int pos, lineNumber, columnNumber;
 
         /**
-         Create a new Position object. Called by the TreeBuilder if source position tracking is on.
+         Deprecated parser-internal position setup method, retained for source compatibility. Position objects are
+         normally derived from a Range's retained source offsets.
          * @param pos position index
          * @param lineNumber line number
          * @param columnNumber column number
+         @deprecated Use parser position tracking instead. Will be removed in jsoup 1.24.1.
          */
+        @Deprecated
         public Position(int pos, int lineNumber, int columnNumber) {
             this.pos = pos;
             this.lineNumber = lineNumber;
@@ -176,7 +236,7 @@ public class Range {
          * @return true if this was tracked during parsing, false otherwise (and all fields will be {@code -1}).
          */
         public boolean isTracked() {
-            return this != UntrackedPos;
+            return pos != -1;
         }
 
         /**
@@ -185,7 +245,13 @@ public class Range {
          */
         @Override
         public String toString() {
-            return lineNumber + "," + columnNumber + ":" + pos;
+            StringBuilder sb = StringUtil.borrowBuilder()
+                .append(lineNumber)
+                .append(',')
+                .append(columnNumber)
+                .append(':')
+                .append(pos);
+            return StringUtil.releaseBuilder(sb);
         }
 
         @Override
@@ -205,35 +271,89 @@ public class Range {
     }
 
     public static class AttributeRange {
-        static final AttributeRange UntrackedAttr = new AttributeRange(Range.Untracked, Range.Untracked);
+        static final AttributeRange UntrackedAttr = new AttributeRange();
 
-        private final Range nameRange;
-        private final Range valueRange;
+        private final LineMap lineMap;
+        private final int nameStartPos, nameEndPos, valueStartPos, valueEndPos;
 
-        /** Creates a new AttributeRange. Called during parsing by Token.StartTag. */
+        /**
+         Creates the untracked attribute source range sentinel.
+         */
+        private AttributeRange() {
+            lineMap         = UnsetLineMap;
+            nameStartPos    = -1;
+            nameEndPos      = -1;
+            valueStartPos   = -1;
+            valueEndPos     = -1;
+        }
+
+        /**
+         Creates a new AttributeRange from source offsets.
+         */
+        private AttributeRange(LineMap lineMap, int nameStartPos, int nameEndPos, int valueStartPos, int valueEndPos) {
+            this.lineMap = lineMap;
+            if (nameStartPos < 0 || nameEndPos < 0 || valueStartPos < 0 || valueEndPos < 0)
+                throw new IllegalArgumentException("Attribute range positions must be non-negative");
+            this.nameStartPos = nameStartPos;
+            this.nameEndPos = nameEndPos;
+            this.valueStartPos = valueStartPos;
+            this.valueEndPos = valueEndPos;
+        }
+
+        /**
+         Deprecated parser-internal source range setup method, retained for source compatibility. Source ranges are
+         normally produced by enabling parser position tracking before parsing. If either supplied Range is untracked,
+         this AttributeRange will also be untracked.
+         @deprecated Use parser position tracking instead. Will be removed in jsoup 1.24.1.
+         */
+        @Deprecated
         public AttributeRange(Range nameRange, Range valueRange) {
-            this.nameRange = nameRange;
-            this.valueRange = valueRange;
+            Objects.requireNonNull(nameRange);
+            Objects.requireNonNull(valueRange);
+            if (!nameRange.isTracked() || !valueRange.isTracked()) {
+                lineMap         = UnsetLineMap;
+                nameStartPos    = -1;
+                nameEndPos      = -1;
+                valueStartPos   = -1;
+                valueEndPos     = -1;
+            } else {
+                lineMap         = nameRange.lineMap;
+                nameStartPos    = nameRange.startPos;
+                nameEndPos      = nameRange.endPos;
+                valueStartPos   = valueRange.startPos;
+                valueEndPos     = valueRange.endPos;
+            }
         }
 
         /** Get the source range for the attribute's name. */
         public Range nameRange() {
-            return nameRange;
+            return isTracked() ? new Range(lineMap, nameStartPos, nameEndPos) : Range.Untracked;
         }
 
         /** Get the source range for the attribute's value. */
         public Range valueRange() {
-            return valueRange;
+            return isTracked() ? new Range(lineMap, valueStartPos, valueEndPos) : Range.Untracked;
         }
 
-        /** Get a String presentation of this Attribute range, in the form
-         {@code line,column:pos-line,column:pos=line,column:pos-line,column:pos} (name start - name end = val start - val end).
-         . */
-        @Override public String toString() {
+        /**
+         Tests if this attribute range has tracked name and value offsets.
+         * @return true if the attribute's name and value ranges were tracked; false otherwise.
+         @since 1.23.1
+         */
+        public boolean isTracked() {
+            return nameStartPos != -1;
+        }
+
+        /**
+         Get a String representation of this Attribute range, in the form
+         {@code line,column:pos-line,column:pos=line,column:pos-line,column:pos} (name start - name end = val start - val end)
+         */
+        @Override
+        public String toString() {
             StringBuilder sb = StringUtil.borrowBuilder()
-                .append(nameRange)
-                .append('=')
-                .append(valueRange);
+                    .append(nameRange())
+                    .append('=')
+                    .append(valueRange());
             return StringUtil.releaseBuilder(sb);
         }
 
@@ -243,12 +363,210 @@ public class Range {
 
             AttributeRange that = (AttributeRange) o;
 
-            if (!nameRange.equals(that.nameRange)) return false;
-            return valueRange.equals(that.valueRange);
+            if (nameStartPos    != that.nameStartPos) return false;
+            if (nameEndPos      != that.nameEndPos) return false;
+            if (valueStartPos   != that.valueStartPos) return false;
+            return valueEndPos  == that.valueEndPos;
         }
 
         @Override public int hashCode() {
-            return Objects.hash(nameRange, valueRange);
+            int result = nameStartPos;
+            result = 31 * result + nameEndPos;
+            result = 31 * result + valueStartPos;
+            result = 31 * result + valueEndPos;
+            return result;
+        }
+    }
+
+    /**
+     Internal range span storage attached to a Node or Attributes object.
+     <p>Unset records use {@code -1}; once written, a node, end-tag, or attribute range record is complete.</p>
+     */
+    static final class Spans {
+        private static final int AttrRangeWidth = 4;
+
+        private LineMap lineMap     = UnsetLineMap;
+        private int nodeStartPos    = -1;
+        private int nodeEndPos      = -1;
+        private int endTagStartPos  = -1;
+        private int endTagEndPos    = -1;
+        private int[] attrRanges    = UnsetAttrRanges;
+
+        /**
+         Gets the node start source range.
+         */
+        private Range sourceRange() {
+            return range(nodeStartPos, nodeEndPos);
+        }
+
+        /**
+         Gets the element end tag source range.
+         */
+        private Range endSourceRange() {
+            return range(endTagStartPos, endTagEndPos);
+        }
+
+        /**
+         Sets the node start source range.
+         */
+        void sourceRange(LineMap lineMap, int startPos, int endPos) {
+            useLineMap(lineMap);
+            nodeStartPos = startPos;
+            nodeEndPos = endPos;
+        }
+
+        /**
+         Sets the element end tag source range.
+         */
+        void endSourceRange(LineMap lineMap, int startPos, int endPos) {
+            useLineMap(lineMap);
+            endTagStartPos = startPos;
+            endTagEndPos = endPos;
+        }
+
+        /**
+         Gets the source ranges for an attribute slot.
+         */
+        Range.AttributeRange attributeRange(int index) {
+            if (index < 0)
+                return Range.AttributeRange.UntrackedAttr;
+
+            int[] ranges = attrRanges;
+            int nameIndex = attrNameStartIndex(index);
+            int valueIndex = attrValueStartIndex(index);
+            int valueEndIndex = valueIndex + 1;
+            if (valueEndIndex >= ranges.length)
+                return Range.AttributeRange.UntrackedAttr;
+
+            int nameStart = ranges[nameIndex];
+            int nameEnd = ranges[nameIndex + 1];
+            int valueStart = ranges[valueIndex];
+            int valueEnd = ranges[valueEndIndex];
+            if (nameStart == -1)
+                return Range.AttributeRange.UntrackedAttr;
+
+            return new Range.AttributeRange(lineMap, nameStart, nameEnd, valueStart, valueEnd);
+        }
+
+        /**
+         Sets the source ranges for an attribute slot.
+         */
+        void attributeRange(int index, Range.AttributeRange range) {
+            attributeRange(
+                index,
+                range.lineMap,
+                range.nameStartPos,
+                range.nameEndPos,
+                range.valueStartPos,
+                range.valueEndPos
+            );
+        }
+
+        /**
+         Sets source range offsets for an attribute slot.
+         */
+        void attributeRange(int index, LineMap lineMap, int nameStart, int nameEnd, int valueStart, int valueEnd) {
+            if (nameStart < 0 || nameEnd < 0 || valueStart < 0 || valueEnd < 0)
+                throw new IllegalArgumentException("Attribute range positions must be non-negative");
+            useLineMap(lineMap);
+            int nameIndex = attrNameStartIndex(index);
+            int valueIndex = attrValueStartIndex(index);
+            ensureAttributeCapacity(valueIndex + 2);
+            attrRanges[nameIndex] = nameStart;
+            attrRanges[nameIndex + 1] = nameEnd;
+            attrRanges[valueIndex] = valueStart;
+            attrRanges[valueIndex + 1] = valueEnd;
+        }
+
+        /**
+         Retains the first line map and rejects mixed-source ranges.
+         */
+        private void useLineMap(LineMap lineMap) {
+            if (this.lineMap == UnsetLineMap) {
+                this.lineMap = lineMap;
+            } else if (this.lineMap != lineMap) {
+                throw new IllegalArgumentException("Source ranges must come from the same parse");
+            }
+        }
+
+        /**
+         Removes an attribute slot and shifts following source ranges.
+         */
+        void removeAttributeRange(int index) {
+            if (index < 0) return;
+            int[] ranges = attrRanges;
+            int removeIndex = attrNameStartIndex(index);
+            if (removeIndex >= ranges.length) return;
+
+            int nextIndex = removeIndex + AttrRangeWidth;
+            int shifted = ranges.length - nextIndex;
+            if (shifted > 0)
+                System.arraycopy(ranges, nextIndex, ranges, removeIndex, shifted);
+            Arrays.fill(ranges, ranges.length - AttrRangeWidth, ranges.length, -1);
+        }
+
+        /**
+         Returns a copy whose source range arrays can mutate independently.
+         */
+        Spans copy() {
+            Spans copy = new Spans();
+            copy.lineMap = lineMap;
+            copy.nodeStartPos = nodeStartPos;
+            copy.nodeEndPos = nodeEndPos;
+            copy.endTagStartPos = endTagStartPos;
+            copy.endTagEndPos = endTagEndPos;
+            copy.attrRanges = attrRanges.length == 0 ? UnsetAttrRanges : attrRanges.clone();
+            return copy;
+        }
+
+        /**
+         Grows attribute range storage to hold the requested slot count.
+         */
+        private void ensureAttributeCapacity(int minLength) {
+            if (attrRanges.length >= minLength) return;
+            int oldLength = attrRanges.length;
+            attrRanges = Arrays.copyOf(attrRanges, minLength);
+            Arrays.fill(attrRanges, oldLength, attrRanges.length, -1);
+        }
+
+        /**
+         Creates a Range from stored offsets.
+         */
+        private Range range(int startPos, int endPos) {
+            if (startPos == -1)
+                return Range.Untracked;
+            return new Range(lineMap, startPos, endPos);
+        }
+
+        /**
+         Maps an attribute slot to its stored name range start slot.
+         */
+        private static int attrNameStartIndex(int index) {
+            return index * AttrRangeWidth;
+        }
+
+        /**
+         Maps an attribute slot to its stored value range start slot.
+         */
+        private static int attrValueStartIndex(int index) {
+            return index * AttrRangeWidth + 2;
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Spans spans = (Spans) o;
+            return nodeStartPos == spans.nodeStartPos &&
+                nodeEndPos == spans.nodeEndPos &&
+                endTagStartPos == spans.endTagStartPos &&
+                endTagEndPos == spans.endTagEndPos &&
+                Arrays.equals(attrRanges, spans.attrRanges);
+        }
+
+        @Override public int hashCode() {
+            int result = Objects.hash(nodeStartPos, nodeEndPos, endTagStartPos, endTagEndPos);
+            result = 31 * result + Arrays.hashCode(attrRanges);
+            return result;
         }
     }
 }

--- a/src/main/java/org/jsoup/parser/CharacterReader.java
+++ b/src/main/java/org/jsoup/parser/CharacterReader.java
@@ -1,6 +1,7 @@
 package org.jsoup.parser;
 
 import org.jsoup.helper.Validate;
+import org.jsoup.internal.LineMap;
 import org.jsoup.internal.SoftPool;
 import org.jsoup.internal.StringUtil;
 import org.jspecify.annotations.Nullable;
@@ -9,9 +10,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Locale;
 
 /**
@@ -41,8 +40,7 @@ public final class CharacterReader implements AutoCloseable {
 
     private static final SoftPool<char[]> BufferPool = new SoftPool<>(() -> new char[BufferSize]); // recycled char buffer
 
-    @Nullable private ArrayList<Integer> newlinePositions = null; // optionally track the pos() position of newlines - scans during bufferUp()
-    private int lineNumberOffset = 1; // line numbers start at 1; += newlinePosition[indexof(pos)]
+    @Nullable private LineMap lineMap = null; // optionally maps source offsets to line and column positions
 
     public CharacterReader(Reader input, int sz) {
         this(input); // sz is no longer used
@@ -74,6 +72,7 @@ public final class CharacterReader implements AutoCloseable {
             charBuf = null;
             StringPool.release(stringCache); // conversely, we don't clear the string cache, so we can reuse the contents
             stringCache = null;
+            lineMap = null;
         }
     }
 
@@ -165,12 +164,12 @@ public final class CharacterReader implements AutoCloseable {
      @since 1.14.3
      */
     public void trackNewlines(boolean track) {
-        if (track && newlinePositions == null) {
-            newlinePositions = new ArrayList<>(BufferSize / 80); // rough guess of likely count
+        if (track && lineMap == null) {
+            lineMap = new LineMap();
             scanBufferForNewlines(); // first pass when enabled; subsequently called during bufferUp
         }
         else if (!track)
-            newlinePositions = null;
+            lineMap = null;
     }
 
     /**
@@ -179,7 +178,15 @@ public final class CharacterReader implements AutoCloseable {
      @since 1.14.3
      */
     public boolean isTrackNewlines() {
-        return newlinePositions != null;
+        return lineMap != null;
+    }
+
+    /**
+     Get the line map enabled by {@link #trackNewlines(boolean)}.
+     */
+    LineMap lineMap() {
+        assert lineMap != null;
+        return lineMap;
     }
 
     /**
@@ -193,15 +200,10 @@ public final class CharacterReader implements AutoCloseable {
     }
 
     int lineNumber(int pos) {
-        // note that this impl needs to be called before the next buffer up or line numberoffset will be wrong. if that
-        // causes issues, can remove the reset of newlinepositions during buffer, at the cost of a larger tracking array
         if (!isTrackNewlines())
             return 1;
 
-        int i = lineNumIndex(pos);
-        if (i == -1)
-            return lineNumberOffset; // first line
-        return i + lineNumberOffset + 1;
+        return lineMap().lineNumber(pos);
     }
 
     /**
@@ -218,10 +220,7 @@ public final class CharacterReader implements AutoCloseable {
         if (!isTrackNewlines())
             return pos + 1;
 
-        int i = lineNumIndex(pos);
-        if (i == -1)
-          return pos + 1;
-        return pos - newlinePositions.get(i) + 1;
+        return lineMap().columnNumber(pos);
     }
 
     /**
@@ -235,33 +234,18 @@ public final class CharacterReader implements AutoCloseable {
         return lineNumber() + ":" + columnNumber();
     }
 
-    private int lineNumIndex(int pos) {
-        if (!isTrackNewlines()) return 0;
-        int i = Collections.binarySearch(newlinePositions, pos);
-        if (i < -1) i = Math.abs(i) - 2;
-        return i;
-    }
-
     /**
-     Scans the buffer for newline position, and tracks their location in newlinePositions.
+     Scans the buffer for newline positions and records line starts.
      */
     private void scanBufferForNewlines() {
         if (!isTrackNewlines())
             return;
 
-        if (newlinePositions.size() > 0) {
-            // work out the line number that we have read up to (as we have likely scanned past this point)
-            int index = lineNumIndex(consumed);
-            if (index == -1) index = 0; // first line
-            int linePos = newlinePositions.get(index);
-            lineNumberOffset += index; // the num lines we've read up to
-            newlinePositions.clear();
-            newlinePositions.add(linePos); // roll the last read pos to first, for cursor num after buffer
-        }
-
         for (int i = bufPos; i < bufLength; i++) {
-            if (charBuf[i] == '\n')
-                newlinePositions.add(1 + consumed + i);
+            if (charBuf[i] == '\n') {
+                int lineStart = 1 + consumed + i;
+                lineMap().addLineStart(lineStart);
+            }
         }
     }
 

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -315,6 +315,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
             if (dupes > 0) {
                 error("Dropped duplicate attribute(s) in tag [%s]", startTag.normalName);
             }
+            startTag.finaliseAttributeRanges(forcePreserveCase ? ParseSettings.preserveCase : settings);
         }
 
         Tag tag = tagFor(startTag.name(), startTag.normalName, namespace,

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -8,6 +8,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.DocumentType;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
+import org.jsoup.nodes.NodeInternals;
 import org.jsoup.nodes.Range;
 import org.jspecify.annotations.Nullable;
 
@@ -1863,14 +1864,13 @@ enum HtmlTreeBuilderState {
 
     private static void mergeAttributes(Token.StartTag source, Element dest) {
         if (!source.hasAttributes()) return;
+        source.finaliseAttributeRanges(source.treeBuilder.settings);
         for (Attribute attr : source.attributes) { // only iterates public attributes
             Attributes destAttrs = dest.attributes();
             if (!destAttrs.hasKey(attr.getKey())) {
-                Range.AttributeRange range = attr.sourceRange(); // need to grab range before its parent changes
+                Range.AttributeRange range = attr.sourceRange(); // grab before its parent changes
                 destAttrs.put(attr);
-                if (source.trackSource) { // copy the attribute range
-                    destAttrs.sourceRange(attr.getKey(), range);
-                }
+                NodeInternals.attributeRange(destAttrs, attr.getKey(), range);
             }
         }
     }

--- a/src/main/java/org/jsoup/parser/Token.java
+++ b/src/main/java/org/jsoup/parser/Token.java
@@ -1,10 +1,13 @@
 package org.jsoup.parser;
 
 import org.jsoup.helper.Validate;
-import org.jsoup.internal.Normalizer;
 import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.NodeInternals;
 import org.jsoup.nodes.Range;
 import org.jspecify.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Parse tokens for the Tokeniser.
@@ -121,7 +124,11 @@ abstract class Token {
         // attribute source range tracking
         final TreeBuilder treeBuilder;
         final boolean trackSource;
+        private static final int AttrRangeWidth = 4;
         int attrNameStart, attrNameEnd, attrValStart, attrValEnd;
+        private @Nullable String @Nullable [] attrRangeNames;
+        private int @Nullable [] attrRangePositions;
+        private int attrRangeCount;
 
         Tag(TokenType type, TreeBuilder treeBuilder) {
             super(type);
@@ -136,6 +143,9 @@ abstract class Token {
             normalName = null;
             selfClosing = false;
             attributes = null;
+            if (attrRangeNames != null)
+                Arrays.fill(attrRangeNames, 0, attrRangeCount, null);
+            attrRangeCount = 0;
             resetPendingAttr();
             return this;
         }
@@ -180,28 +190,80 @@ abstract class Token {
         }
 
         private void trackAttributeRange(String name) {
-            if (trackSource && isStartTag()) {
-                final StartTag start = asStartTag();
-                final CharacterReader r = start.treeBuilder.reader;
-                final boolean preserve = start.treeBuilder.settings.preserveAttributeCase();
-
-                assert attributes != null;
-                if (!preserve) name = Normalizer.lowerCase(name);
-                if (attributes.sourceRange(name).nameRange().isTracked()) return; // dedupe ranges as we go; actual attributes get deduped later for error count
-
+            if (treeBuilder.trackSourceRange && isStartTag()) {
                 // if there's no value (e.g. boolean), make it an implicit range at current
                 if (!attrValue.hasData()) attrValStart = attrValEnd = attrNameEnd;
 
-                Range.AttributeRange range = new Range.AttributeRange(
-                    new Range(
-                        new Range.Position(attrNameStart, r.lineNumber(attrNameStart), r.columnNumber(attrNameStart)),
-                        new Range.Position(attrNameEnd, r.lineNumber(attrNameEnd), r.columnNumber(attrNameEnd))),
-                    new Range(
-                        new Range.Position(attrValStart, r.lineNumber(attrValStart), r.columnNumber(attrValStart)),
-                        new Range.Position(attrValEnd, r.lineNumber(attrValEnd), r.columnNumber(attrValEnd)))
-                );
-                attributes.sourceRange(name, range);
+                addAttributeRange(name, attrNameStart, attrNameEnd, attrValStart, attrValEnd);
             }
+        }
+
+        /**
+         Stages an attribute range until the attributes are normalized and deduplicated.
+         */
+        private void addAttributeRange(String name, int nameStart, int nameEnd, int valueStart, int valueEnd) {
+            ensureAttributeRangeCapacity(attrRangeCount + 1);
+            assert attrRangeNames != null;
+            assert attrRangePositions != null;
+            attrRangeNames[attrRangeCount] = name;
+            int rangeIndex = attrRangeIndex(attrRangeCount);
+            attrRangePositions[rangeIndex] = nameStart;
+            attrRangePositions[rangeIndex + 1] = nameEnd;
+            attrRangePositions[rangeIndex + 2] = valueStart;
+            attrRangePositions[rangeIndex + 3] = valueEnd;
+            attrRangeCount++;
+        }
+
+        /**
+         Grows parser-local attribute range staging arrays.
+         */
+        private void ensureAttributeRangeCapacity(int minSize) {
+            if (attrRangeNames != null && attrRangeNames.length >= minSize)
+                return;
+            int size = attrRangeNames == null ? 3 : attrRangeNames.length * 2;
+            if (size < minSize)
+                size = minSize;
+            attrRangeNames = attrRangeNames == null ? new String[size] : Arrays.copyOf(attrRangeNames, size);
+            attrRangePositions = attrRangePositions == null ?
+                new int[size * AttrRangeWidth] :
+                Arrays.copyOf(attrRangePositions, size * AttrRangeWidth);
+        }
+
+        /**
+         Attaches staged attribute ranges after parser normalization and deduplication have settled attribute slots.
+         */
+        final void finaliseAttributeRanges(ParseSettings settings) {
+            if (!treeBuilder.trackSourceRange || attrRangeCount == 0 || attributes == null)
+                return;
+            assert attrRangeNames != null;
+            assert attrRangePositions != null;
+            int count = attrRangeCount;
+            attrRangeCount = 0;
+            for (int i = 0; i < count; i++) {
+                String stagedName = Objects.requireNonNull(attrRangeNames[i]);
+                String rangeName = settings.normalizeAttribute(stagedName);
+                Range.AttributeRange existing = attributes.sourceRange(rangeName);
+                if (!existing.isTracked()) {
+                    int rangeIndex = attrRangeIndex(i);
+                    NodeInternals.attributeRange(
+                        attributes,
+                        rangeName,
+                        treeBuilder.lineMap(),
+                        attrRangePositions[rangeIndex],
+                        attrRangePositions[rangeIndex + 1],
+                        attrRangePositions[rangeIndex + 2],
+                        attrRangePositions[rangeIndex + 3]
+                    );
+                }
+                attrRangeNames[i] = null;
+            }
+        }
+
+        /**
+         Maps a staged attribute range to its first source offset slot.
+         */
+        private static int attrRangeIndex(int index) {
+            return index * AttrRangeWidth;
         }
 
         final boolean hasAttributes() {

--- a/src/main/java/org/jsoup/parser/TreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilder.java
@@ -1,12 +1,12 @@
 package org.jsoup.parser;
 
 import org.jsoup.helper.Validate;
-import org.jsoup.internal.SharedConstants;
+import org.jsoup.internal.LineMap;
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
-import org.jsoup.nodes.Range;
+import org.jsoup.nodes.NodeInternals;
 import org.jsoup.select.NodeVisitor;
 import org.jspecify.annotations.Nullable;
 
@@ -35,7 +35,8 @@ abstract class TreeBuilder {
     private final Token.EndTag end  = new Token.EndTag(this);
     abstract ParseSettings defaultSettings();
 
-    boolean trackSourceRange;  // optionally tracks the source range of nodes and attributes
+    boolean trackSourceRange; // optionally tracks source ranges of nodes and attributes
+    @Nullable LineMap lineMap; // shared line map for retained source ranges
 
     void initialiseParse(Reader input, String baseUri, Parser parser) {
         Validate.notNullParam(input, "input");
@@ -48,7 +49,8 @@ abstract class TreeBuilder {
         settings = parser.settings();
         reader = new CharacterReader(input);
         trackSourceRange = parser.isTrackPosition();
-        reader.trackNewlines(parser.isTrackErrors() || trackSourceRange); // when tracking errors or source ranges, enable newline tracking for better legibility
+        reader.trackNewlines(parser.isTrackErrors() || trackSourceRange);
+        lineMap = trackSourceRange ? reader.lineMap() : null;
         if (parser.isTrackErrors()) parser.getErrors().clear();
         tokeniser = new Tokeniser(this);
         stack = new ArrayList<>(32);
@@ -62,8 +64,10 @@ abstract class TreeBuilder {
     void completeParse() {
         // tidy up - as the Parser and Treebuilder are retained in document for settings / fragments
         if (reader == null) return;
+        if (lineMap != null) lineMap.complete();
         reader.close();
         reader = null;
+        lineMap = null;
         tokeniser = null;
         stack = null;
     }
@@ -323,11 +327,17 @@ abstract class TreeBuilder {
             }
         }
 
-        Range.Position startPosition = new Range.Position
-            (startPos, reader.lineNumber(startPos), reader.columnNumber(startPos));
-        Range.Position endPosition = new Range.Position
-            (endPos, reader.lineNumber(endPos), reader.columnNumber(endPos));
-        Range range = new Range(startPosition, endPosition);
-        node.attributes().userData(isStart ? SharedConstants.RangeKey : SharedConstants.EndRangeKey, range);
+        if (isStart)
+            NodeInternals.sourceRange(node, lineMap(), startPos, endPos);
+        else if (node instanceof Element)
+            NodeInternals.endSourceRange((Element) node, lineMap(), startPos, endPos);
+    }
+
+    /**
+     Internal method, used by parser tokens to attach source ranges to Nodes and Attributes.
+     */
+    LineMap lineMap() {
+        assert lineMap != null;
+        return lineMap;
     }
 }

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -154,6 +154,7 @@ public class XmlTreeBuilder extends TreeBuilder {
             attributes.deduplicate(settings);
             processNamespaces(attributes, namespaces);
             applyNamespacesToAttributes(attributes, namespaces);
+            startTag.finaliseAttributeRanges(settings);
         }
 
         enforceStackDepthLimit();

--- a/src/main/java/org/jsoup/safety/Cleaner.java
+++ b/src/main/java/org/jsoup/safety/Cleaner.java
@@ -7,6 +7,8 @@ import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
+import org.jsoup.nodes.NodeInternals;
+import org.jsoup.nodes.Range;
 import org.jsoup.nodes.TextNode;
 import org.jsoup.parser.ParseErrorList;
 import org.jsoup.parser.Parser;
@@ -199,7 +201,9 @@ public class Cleaner {
                     if (value.isEmpty()) // could not be made abs; leave as-is to allow custom unknown protocols
                         value = sourceAttr.getValue();
                 }
+                Range.AttributeRange range = sourceAttrs.sourceRange(key);
                 destAttrs.put(key, value);
+                NodeInternals.attributeRange(destAttrs, key, range);
             } else
                 numDiscarded++;
         }

--- a/src/test/java/org/jsoup/nodes/AttributesTest.java
+++ b/src/test/java/org/jsoup/nodes/AttributesTest.java
@@ -1,6 +1,7 @@
 package org.jsoup.nodes;
 
 import org.jsoup.Jsoup;
+import org.jsoup.parser.Parser;
 import org.junit.jupiter.api.Test;
 
 import java.util.ConcurrentModificationException;
@@ -301,6 +302,37 @@ public class AttributesTest {
         assertEquals(2, a.asList().size()); // excluded from lists
     }
 
+    @SuppressWarnings("deprecation")
+    @Test public void sourceRangesUseVisibleAttributeSlots() {
+        Element source = Jsoup.parse("<p one=1 two=2>", Parser.htmlParser().setTrackPosition(true)).expectFirst("p");
+        Range.AttributeRange oneRange = source.attributes().sourceRange("one");
+        Range.AttributeRange twoRange = source.attributes().sourceRange("two");
+
+        Attributes a = new Attributes();
+        a.put(Attributes.internalKey("before"), "x");
+        a.put("one", "1");
+        a.put(Attributes.internalKey("middle"), "y");
+        a.put("two", "2");
+
+        a.sourceRange("one", oneRange);
+        a.sourceRange("two", twoRange);
+
+        assertEquals(oneRange, a.sourceRange("one"));
+        assertEquals(twoRange, a.sourceRange("two"));
+
+        a.remove(Attributes.internalKey("before"));
+        assertEquals(oneRange, a.sourceRange("one"));
+        assertEquals(twoRange, a.sourceRange("two"));
+
+        a.remove(Attributes.internalKey("middle"));
+        assertEquals(oneRange, a.sourceRange("one"));
+        assertEquals(twoRange, a.sourceRange("two"));
+
+        a.remove("one");
+        assertFalse(a.sourceRange("one").isTracked());
+        assertEquals(twoRange, a.sourceRange("two"));
+    }
+
     @Test public void testBooleans() {
         // want unknown=null, and known like async=null, async="", and async=async to collapse
         String html = "<a foo bar=\"\" async=async qux=qux defer=deferring ismap inert=\"\">";
@@ -431,4 +463,5 @@ public class AttributesTest {
         assertEquals(2, attrs.size); // we keep the internals
         assertTrue(attrs.isEmpty());
     }
+
 }

--- a/src/test/java/org/jsoup/parser/PositionTest.java
+++ b/src/test/java/org/jsoup/parser/PositionTest.java
@@ -4,6 +4,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
 import org.jsoup.integration.TestServer;
 import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.CDataNode;
 import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.DataNode;
@@ -41,6 +42,124 @@ class PositionTest {
         assertFalse(xmlParser.isTrackPosition());
         xmlParser.setTrackPosition(true);
         assertTrue(xmlParser.isTrackPosition());
+    }
+
+    @Test void parserTrackPositionCopies() {
+        Parser parser = Parser.htmlParser();
+        parser.setTrackPosition(true);
+
+        Parser clone = parser.clone();
+        assertTrue(clone.isTrackPosition());
+        Parser instance = parser.newInstance();
+        assertTrue(instance.isTrackPosition());
+
+        parser.setTrackPosition(false);
+        assertFalse(parser.isTrackPosition());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test void manualRangeConstructionUsesOffsetsAsIdentity() {
+        Range range = new Range(new Range.Position(10, 3, 4), new Range.Position(20, 3, 14));
+        Range sameOffsets = new Range(new Range.Position(10, 99, 100), new Range.Position(20, 99, 110));
+
+        assertEquals(10, range.startPos());
+        assertEquals(20, range.endPos());
+        assertEquals(range, sameOffsets);
+        assertEquals(range.hashCode(), sameOffsets.hashCode());
+
+        // Manual ranges do not have a parse LineMap, so line and column are derived from offsets on one line.
+        assertEquals(1, range.start().lineNumber());
+        assertEquals(11, range.start().columnNumber());
+        assertEquals(1, range.end().lineNumber());
+        assertEquals(21, range.end().columnNumber());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test void manualUntrackedRangeConstructionStaysUntracked() {
+        Range range = new Range(new Range.Position(-1, -1, -1), new Range.Position(-1, -1, -1));
+
+        assertFalse(range.isTracked());
+        assertEquals(-1, range.startPos());
+        assertEquals(-1, range.endPos());
+        assertFalse(range.start().isTracked());
+        assertFalse(range.end().isTracked());
+
+        Range.AttributeRange attrRange = new Range.AttributeRange(range, range);
+        assertFalse(attrRange.isTracked());
+        assertFalse(attrRange.nameRange().isTracked());
+        assertFalse(attrRange.valueRange().isTracked());
+    }
+
+    @Test void trackedLeafPositionsSurviveAttributeExpansion() {
+        Parser parser = Parser.htmlParser().setTrackPosition(true);
+        Document doc = Jsoup.parse("<p>One</p><!--x-->", parser);
+
+        Element p = doc.expectFirst("p");
+        TextNode text = (TextNode) p.firstChild();
+        assertNotNull(text);
+        Comment comment = (Comment) p.nextSibling();
+        assertNotNull(comment);
+
+        assertTrue(p.sourceRange().isTracked());
+        assertTrue(p.endSourceRange().isTracked());
+
+        Range textRange = text.sourceRange();
+        assertTrue(textRange.isTracked());
+        assertEquals(0, text.attributesSize());
+        assertEquals("One", text.getWholeText());
+
+        text.attributes();
+        assertEquals("One", text.getWholeText());
+        assertEquals(textRange, text.sourceRange());
+
+        assertTrue(comment.sourceRange().isTracked());
+        assertEquals(0, comment.attributesSize());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test void attributeRangeSetterAcceptsRangesFromSameParse() {
+        Document doc = Jsoup.parse("<p one=1 two=2>", Parser.htmlParser().setTrackPosition(true));
+        Element p = doc.expectFirst("p");
+        Range.AttributeRange oneRange = p.attributes().sourceRange("one");
+        Range.AttributeRange twoRange = p.attributes().sourceRange("two");
+
+        Attributes attrs = new Attributes();
+        attrs.put("one", "1");
+        attrs.put("two", "2");
+        attrs.sourceRange("one", oneRange);
+        attrs.sourceRange("two", twoRange);
+
+        assertEquals(oneRange, attrs.sourceRange("one"));
+        assertEquals(twoRange, attrs.sourceRange("two"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test void attributeRangeSetterRejectsRangesFromDifferentSources() {
+        Document doc = Jsoup.parse("<div>\n <p one=1>Text</p>\n</div>", Parser.htmlParser().setTrackPosition(true));
+        Element p = doc.expectFirst("p");
+        String originalNodeRange = p.sourceRange().toString();
+        String originalAttrRange = p.attributes().sourceRange("one").toString();
+
+        Document other = Jsoup.parse("<a href=x>", Parser.htmlParser().setTrackPosition(true));
+        Range.AttributeRange otherRange = other.expectFirst("a").attributes().sourceRange("href");
+        IllegalArgumentException copied = assertThrows(
+            IllegalArgumentException.class,
+            () -> p.attributes().sourceRange("one", otherRange)
+        );
+        assertEquals("Source ranges must come from the same parse", copied.getMessage());
+        assertEquals(originalNodeRange, p.sourceRange().toString());
+        assertEquals(originalAttrRange, p.attributes().sourceRange("one").toString());
+
+        Range manualName = new Range(new Range.Position(0, 1, 1), new Range.Position(1, 1, 2));
+        Range manualValue = new Range(new Range.Position(2, 1, 3), new Range.Position(3, 1, 4));
+        Range.AttributeRange manualRange = new Range.AttributeRange(manualName, manualValue);
+        IllegalArgumentException manual = assertThrows(
+            IllegalArgumentException.class,
+            () -> p.attributes().sourceRange("one", manualRange)
+        );
+        assertEquals("Source ranges must come from the same parse", manual.getMessage());
+        assertEquals(originalNodeRange, p.sourceRange().toString());
+        assertEquals(originalAttrRange, p.attributes().sourceRange("one").toString());
     }
 
     @Test void tracksPosition() {
@@ -345,7 +464,7 @@ class PositionTest {
             Range.AttributeRange attrRange = attr.sourceRange();
             assertTrue(attrRange.nameRange().isTracked());
             assertTrue(attrRange.valueRange().isTracked());
-            assertSame(attrRange, div.attributes().sourceRange(attr.getKey()));
+            assertEquals(attrRange, div.attributes().sourceRange(attr.getKey()));
 
             assertFalse(attrRange.nameRange().isImplicit());
             if (attr.getValue().isEmpty())
@@ -370,7 +489,7 @@ class PositionTest {
             Range.AttributeRange attrRange = attr.sourceRange();
             assertTrue(attrRange.nameRange().isTracked());
             assertTrue(attrRange.valueRange().isTracked());
-            assertSame(attrRange, div.attributes().sourceRange(attr.getKey()));
+            assertEquals(attrRange, div.attributes().sourceRange(attr.getKey()));
             assertFalse(attrRange.nameRange().isImplicit());
             if (attr.getValue().isEmpty())
                 assertTrue(attrRange.valueRange().isImplicit());
@@ -385,6 +504,19 @@ class PositionTest {
         assertEquals("4,1:30-4,6:35=5,1:37-5,4:40", foo.toString());
 
         assertEquals("one:5-8=10-21; id:24-26=27-28; class:30-35=37-40; attr5:41-46=46-46; ", track.toString());
+    }
+
+    @Test void tracksForeignAttributesWithPreservedCase() {
+        String html = "<svg viewBox=2><foreignObject Foo=bar></foreignObject></svg>";
+        Document doc = Jsoup.parse(html, TrackingHtmlParser);
+
+        Element svg = doc.expectFirst("svg");
+        assertEquals("1,6:5-1,13:12=1,14:13-1,15:14", svg.attributes().sourceRange("viewBox").toString());
+        assertFalse(svg.attributes().sourceRange("viewbox").nameRange().isTracked());
+
+        Element foreignObject = doc.expectFirst("foreignObject");
+        assertEquals("1,31:30-1,34:33=1,35:34-1,38:37", foreignObject.attributes().sourceRange("Foo").toString());
+        assertFalse(foreignObject.attributes().sourceRange("foo").nameRange().isTracked());
     }
 
     @Test void trackAttributePositionInFirstElement() {
@@ -587,6 +719,25 @@ class PositionTest {
         Attribute attr2 = p.attribute("CLASSY");
         assertEquals("CLASSY=\"Tree\"", attr2.html());
         assertEquals(expectedRange, attr2.sourceRange().toString());
+    }
+
+    @Test void removeAttributeMaintainsFollowingRanges() {
+        String html = "<p one=1 two=2 three=3>One</p>";
+        Document doc = Jsoup.parse(html, TrackingHtmlParser);
+        Element p = doc.expectFirst("p");
+
+        String twoRange = "1,10:9-1,13:12=1,14:13-1,15:14";
+        String threeRange = "1,16:15-1,21:20=1,22:21-1,23:22";
+        assertEquals(twoRange, p.attributes().sourceRange("two").toString());
+        assertEquals(threeRange, p.attributes().sourceRange("three").toString());
+
+        p.removeAttr("one");
+        assertEquals(twoRange, p.attributes().sourceRange("two").toString());
+        assertEquals(threeRange, p.attributes().sourceRange("three").toString());
+
+        p.removeAttr("two");
+        assertFalse(p.attributes().sourceRange("two").isTracked());
+        assertEquals(threeRange, p.attributes().sourceRange("three").toString());
     }
 
     @Test void movedAttributesHaveRange() {

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -507,7 +507,7 @@ public class CleanerTest {
         assertEquals("<p>test\n <br /></p>", result.body().html());
     }
 
-    @Test void preservesSourcePositionViaUserData() {
+    @Test void preservesSourcePosition() {
         Document orig = Jsoup.parse("<script>xss</script>\n <p id=1>Hello</p>", Parser.htmlParser().setTrackPosition(true));
         Element p = orig.expectFirst("p");
         Range origRange = p.sourceRange();


### PR DESCRIPTION
I've refactored how jsoup retains source ranges, so that enabling parser position tracking has a much smaller retained-memory cost.

The issue was mostly in how the data was stored: source ranges were being kept in node and attribute user data. That meant that the range track data took the same relatively heavy path as normal user data: leaf nodes could be expanded into `Attributes` just to hold range data, and attribute ranges would be backed by adding user data hash maps. On documents with a lot of attributes, that adds up quickly.

This PR keeps the public range-reading API intact, but changes the internal storage model:

- `Range` now stores source offsets, and derives `Position` line / column values from a parse-level line map.
- `LineMap` records newline offsets once per parse, instead of retaining line and column numbers in every range position.
- `Range.Spans` is the compact internal record for node start ranges, element end ranges, and attribute ranges.
- `LeafNode` keeps its compact value storage, and wraps the value in a TrackedValue when it also needs retained source range data, vs setting up extra Attributes
- Attribute ranges are stored by directly in internal attribute slots, avoiding per-attribute user data maps.
- The old parser-internal setup methods are retained for source compatibility, but deprecated and guarded so ranges from different parses cannot be mixed into the same stored span.

This also simplifies the parser data path and lowers GC. During parsing we now pass primitive source offsets into the retained span storage, instead of constructing `Range` and `Position` objects as intermediate storage. `Position` objects are created lazily when user code asks for `range.start()` or `range.end()`, so retained documents do not carry that object graph and normal parse flow does less short-lived allocation.

Retained DOM footprint, on JDK 21.0.10:

| Fixture | Input | # Nodes | # Attrs | Retained DOM | 1.22.2 tracked | 1.23.1 tracked | Saving |
|---|---:|---:|---:|---:|---:|---:|---:|
| tiny | 274 B | 23 | 5 | 30.2 KB | 40.0 KB | 32.1 KB | 19.7% |
| small | 3.3 KB | 112 | 31 | 41.7 KB | 88.8 KB | 50.7 KB | 42.9% |
| medium | 8.6 KB | 397 | 121 | 73.4 KB | 244.4 KB | 103.9 KB | 57.5% |
| large | 496.3 KB | 18,497 | 6,152 | 1.9 MB | 9.6 MB | 3.3 MB | 65.4% |
| x-large | 2.3 MB | 26,364 | 23,244 | 5.2 MB | 19.4 MB | 7.3 MB | 62.5% |

The saving column compares tracked DOM retained size in 1.22.2 against tracked DOM retained size with this change. Retained DOM is shown as the no-source-tracking baseline.

