### PR TITLE
Refactor `classNames` scanner and add `classList`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 * Reduced retained memory when parsing with source position tracking enabled (`Parser#setTrackPosition(true)`). Source ranges are now stored in compact parser-owned span records instead of node and attribute user data, and `Position` objects are created lazily when source ranges are read. This cuts tracked DOM retained size by about 50-60% on representative benchmark documents, while keeping `Node#sourceRange()`, `Element#endSourceRange()`, and `Attribute#sourceRange()` behavior intact. [#2498](https://github.com/jhy/jsoup/pull/2498)
+* Added `Element#classList()`, an immutable snapshot of an element's class names in attribute order. Use `hasClass()` when you just need to test for one class, `classList()` when you want to read or iterate classes without needing a mutable result, and `classNames()` when you want the existing mutable, deduplicated set that can be written back with `classNames(Set)`. The class APIs now share an HTML-whitespace scanner, which also makes `classNames()` faster and lighter on allocation, especially when walking many elements without class names. [#2500](https://github.com/jhy/jsoup/pull/2500)
 
 ### Build Changes
 * Cleaned up the Maven build for the multi-release JAR so Java 8 and Java 11+ sources compile as separate source sets. This avoids spurious Java 8 compiler warnings from newer-language overlay sources, keeps long-running parser checks behind an explicit profile, and preserves the same published artifacts and runtime behavior.

--- a/src/main/java/org/jsoup/nodes/Element.java
+++ b/src/main/java/org/jsoup/nodes/Element.java
@@ -20,7 +20,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -50,7 +49,6 @@ import static org.jsoup.select.Selector.evaluatorOf;
 public class Element extends Node implements Iterable<Element> {
     private static final List<Element> EmptyChildren = Collections.emptyList();
     private static final NodeList EmptyNodeList = new NodeList(0);
-    private static final Pattern ClassSplit = Pattern.compile("\\s+");
     static final String BaseUriKey = Attributes.internalKey("baseUri");
     Tag tag;
     NodeList childNodes;
@@ -1781,17 +1779,90 @@ public class Element extends Node implements Iterable<Element> {
     }
 
     /**
-     * Get each of the element's class names. E.g. on element {@code <div class="header gray">},
-     * returns a set of two elements {@code "header", "gray"}. Note that modifications to this set are not pushed to
-     * the backing {@code class} attribute; use the {@link #classNames(java.util.Set)} method to persist them.
-     * @return set of classnames, empty if no class attribute
+     Get each of the element's class names. E.g. on element {@code <div class="header gray">},
+     returns a set of two elements {@code "header", "gray"}.
+     <p>Note that modifications to this set are not pushed to the backing {@code class} attribute; use
+     {@link #classNames(Set)} to persist them.</p>
+     <p>Use {@link #classList()} for a more efficient, read-only list that preserves duplicate class names.</p>
+
+     @return set of class names, empty if no class attribute
+     @see #classNames(Set)
+     @see #hasClass(String) 
+     @see #classList()
      */
     public Set<String> classNames() {
-    	String[] names = ClassSplit.split(className());
-    	Set<String> classNames = new LinkedHashSet<>(Arrays.asList(names));
-    	classNames.remove(""); // if classNames() was empty, would include an empty class
+        Set<String> classNames = new LinkedHashSet<>(4);
+        if (attributes == null) return classNames;
 
+        String classAttr = attributes.getIgnoreCase("class");
+        int len = classAttr.length();
+        for (int i = 0; i < len; ) {
+            int start = nextClassStart(classAttr, i, len);
+            if (start == len) break;
+
+            int end = nextClassEnd(classAttr, start, len);
+            classNames.add(classToken(classAttr, start, end));
+            i = end;
+        }
         return classNames;
+    }
+
+    /**
+     Get each of the element's class names, in attribute order. E.g. on element
+     {@code <div class="header gray">}, returns a list of two elements {@code "header", "gray"}.
+     <p>This immutable snapshot preserves duplicate class names, and is more memory efficient than
+     {@link #classNames()} when a read-only result is sufficient, particularly for elements without class names.
+     Use {@link #classNames()} for a mutable set of unique class names.</p>
+
+     @return immutable list of class names, empty if no class attribute
+     @see #classNames()
+     @see #hasClass(String)
+     @since 1.23.1
+     */
+    public List<String> classList() {
+        if (attributes == null) return Collections.emptyList();
+
+        String attr = attributes.getIgnoreCase("class");
+        int len = attr.length();
+        int start = nextClassStart(attr, 0, len);
+        if (start == len) return Collections.emptyList();
+
+        int end = nextClassEnd(attr, start, len);
+        String first = classToken(attr, start, end);
+        start = nextClassStart(attr, end, len);
+        if (start == len) return Collections.singletonList(first);
+
+        List<String> classes = new ArrayList<>(4);
+        classes.add(first);
+        do {
+            end = nextClassEnd(attr, start, len);
+            classes.add(classToken(attr, start, end));
+            start = nextClassStart(attr, end, len);
+        } while (start < len);
+        return Collections.unmodifiableList(classes);
+    }
+
+    /**
+     Find the next class token start.
+     */
+    private static int nextClassStart(String classAttr, int offset, int len) {
+        while (offset < len && StringUtil.isWhitespace(classAttr.charAt(offset))) offset++;
+        return offset;
+    }
+
+    /**
+     Find the next class token end.
+     */
+    private static int nextClassEnd(String classAttr, int offset, int len) {
+        while (offset < len && !StringUtil.isWhitespace(classAttr.charAt(offset))) offset++;
+        return offset;
+    }
+
+    /**
+     Returns the class token while preserving the original string for a single unpadded class.
+     */
+    private static String classToken(String classAttr, int start, int end) {
+        return start == 0 && end == classAttr.length() ? classAttr : classAttr.substring(start, end);
     }
 
     /**
@@ -1816,46 +1887,25 @@ public class Element extends Node implements Iterable<Element> {
      */
     // performance sensitive
     public boolean hasClass(String className) {
-        if (attributes == null)
-            return false;
+        if (attributes == null) return false;
 
         final String classAttr = attributes.getIgnoreCase("class");
         final int len = classAttr.length();
         final int wantLen = className.length();
 
-        if (len == 0 || len < wantLen) {
-            return false;
-        }
+        if (len == 0 || len < wantLen) return false;
 
-        // if both lengths are equal, only need compare the className with the attribute
-        if (len == wantLen) {
-            return className.equalsIgnoreCase(classAttr);
-        }
+        // if both lengths are equal, only need to compare the className with the attribute
+        if (len == wantLen) return className.equalsIgnoreCase(classAttr);
 
-        // otherwise, scan for whitespace and compare regions (with no string or arraylist allocations)
-        boolean inClass = false;
-        int start = 0;
-        for (int i = 0; i < len; i++) {
-            if (Character.isWhitespace(classAttr.charAt(i))) {
-                if (inClass) {
-                    // white space ends a class name, compare it with the requested one, ignore case
-                    if (i - start == wantLen && classAttr.regionMatches(true, start, className, 0, wantLen)) {
-                        return true;
-                    }
-                    inClass = false;
-                }
-            } else {
-                if (!inClass) {
-                    // we're in a class name : keep the start of the substring
-                    inClass = true;
-                    start = i;
-                }
-            }
-        }
+        // otherwise, scan for whitespace and compare regions (with no string or list allocations)
+        for (int i = 0; i < len; ) {
+            int start = nextClassStart(classAttr, i, len);
+            if (start == len) return false;
 
-        // check the last entry
-        if (inClass && len - start == wantLen) {
-            return classAttr.regionMatches(true, start, className, 0, wantLen);
+            int end = nextClassEnd(classAttr, start, len);
+            if (end - start == wantLen && classAttr.regionMatches(true, start, className, 0, wantLen)) return true;
+            i = end;
         }
 
         return false;

--- a/src/test/java/org/jsoup/nodes/ElementTest.java
+++ b/src/test/java/org/jsoup/nodes/ElementTest.java
@@ -468,6 +468,27 @@ public class ElementTest {
     }
 
     @Test
+    public void hasClassUsesHtmlWhitespace() {
+        // Verifies hasClass() uses the same HTML ASCII whitespace splitter as classNames().
+        Element el = new Element("div");
+
+        el.attr("class", "alpha\tbeta\n\rgamma\fdelta");
+        assertTrue(el.hasClass("BETA"));
+        assertTrue(el.hasClass("gamma"));
+        assertTrue(el.hasClass("delta"));
+
+        el.attr("class", "alpha\u000Bbeta gamma");
+        assertTrue(el.hasClass("alpha\u000Bbeta"));
+        assertFalse(el.hasClass("beta"));
+        assertTrue(el.hasClass("gamma"));
+
+        el.attr("class", "alpha\u00A0beta gamma");
+        assertTrue(el.hasClass("alpha\u00A0beta"));
+        assertFalse(el.hasClass("beta"));
+        assertTrue(el.hasClass("gamma"));
+    }
+
+    @Test
     public void testClassUpdates() {
         Document doc = Jsoup.parse("<div class='mellow yellow'></div>");
         Element div = doc.select("div").first();
@@ -1476,6 +1497,74 @@ public class ElementTest {
         assertEquals("c1", arr2[0]);
         assertEquals("c2", arr2[1]);
         assertEquals("c3", arr2[2]);
+    }
+
+    @Test
+    public void classNamesHandlesRoughWhitespaceAndDuplicates() {
+        // Verifies classNames() uses HTML ASCII whitespace while handling rough class attributes.
+        assertClassNames(null);
+        assertClassNames("");
+        assertClassNames(" \t\n\r\f ");
+        assertClassNames("alpha", "alpha");
+        assertClassNames("  alpha  ", "alpha");
+        assertClassNames("alpha beta gamma", "alpha", "beta", "gamma");
+        assertClassNames("alpha  beta    gamma", "alpha", "beta", "gamma");
+        assertClassNames("alpha\tbeta\n\rgamma", "alpha", "beta", "gamma");
+        assertClassNames("alpha\r\nbeta\r\n\r\ngamma", "alpha", "beta", "gamma");
+        assertClassNames("alpha\fbeta\f\f gamma", "alpha", "beta", "gamma");
+        assertClassNames("alpha\u000Bbeta gamma", "alpha\u000Bbeta", "gamma");
+        assertClassNames("alpha beta alpha gamma beta", "alpha", "beta", "gamma");
+        assertClassNames("alpha\u00A0beta gamma", "alpha\u00A0beta", "gamma");
+    }
+
+    @Test
+    public void classListReturnsRawTokens() {
+        // Verifies classList() uses HTML ASCII whitespace while preserving duplicate tokens.
+        assertClassList(null);
+        assertClassList("");
+        assertClassList(" \t\n\r\f ");
+        assertClassList("alpha", "alpha");
+        assertClassList("  alpha  ", "alpha");
+        assertClassList("alpha beta gamma", "alpha", "beta", "gamma");
+        assertClassList("alpha  beta    gamma", "alpha", "beta", "gamma");
+        assertClassList("alpha\tbeta\n\rgamma", "alpha", "beta", "gamma");
+        assertClassList("alpha\r\nbeta\r\n\r\ngamma", "alpha", "beta", "gamma");
+        assertClassList("alpha\fbeta\f\f gamma", "alpha", "beta", "gamma");
+        assertClassList("alpha\u000Bbeta gamma", "alpha\u000Bbeta", "gamma");
+        assertClassList("alpha beta alpha gamma beta", "alpha", "beta", "alpha", "gamma", "beta");
+        assertClassList("alpha\u00A0beta gamma", "alpha\u00A0beta", "gamma");
+    }
+
+    @Test
+    public void classListIsImmutable() {
+        // Checks classList() returns immutable snapshots for empty, single, and multi-token results.
+        Element empty = new Element("div");
+        Element single = new Element("div").attr("class", "alpha");
+        Element multiple = new Element("div").attr("class", "alpha beta");
+
+        assertThrows(UnsupportedOperationException.class, () -> empty.classList().add("gamma"));
+        assertThrows(UnsupportedOperationException.class, () -> single.classList().add("gamma"));
+        assertThrows(UnsupportedOperationException.class, () -> multiple.classList().add("gamma"));
+    }
+
+    /**
+     Checks classNames() output order for a single raw class attribute value.
+     */
+    private static void assertClassNames(String classAttr, String... expected) {
+        Element div = new Element("div");
+        if (classAttr != null)
+            div.attr("class", classAttr);
+        assertArrayEquals(expected, div.classNames().toArray());
+    }
+
+    /**
+     Checks classList() output order for a single raw class attribute value.
+     */
+    private static void assertClassList(String classAttr, String... expected) {
+        Element div = new Element("div");
+        if (classAttr != null)
+            div.attr("class", classAttr);
+        assertArrayEquals(expected, div.classList().toArray());
     }
 
     @Test


### PR DESCRIPTION
Improve throughput and allocation behavior in `classNames()` by replacing the regex split path with a small HTML-whitespace scanner.

Add `classList()` as an immutable snapshot API for callers that only need to read class names, with a more efficient empty result path for elements without classes.

Align `classNames()`, `classList()`, and `hasClass()` on the HTML whitespace definition for class attributes.

## Benchmarks

`classNames()` Throughput:

| Fixture | Scope | 1.22.2 | New| Gain |
|---|---|---:|---:|---:|
| tiny | all elements | 36.0M ops/s | 270.6M ops/s | 652.1% |
| small | all elements | 39.1M ops/s | 153.3M ops/s | 291.6% |
| medium | all elements | 28.3M ops/s | 144.5M ops/s | 411.3% |
| large | all elements | 30.1M ops/s | 63.2M ops/s | 110.3% |
| x-large | all elements | 11.7M ops/s | 22.1M ops/s | 88.9% |
| small | classed elements | 35.1M ops/s | 54.6M ops/s | 55.3% |
| medium | classed elements | 18.3M ops/s | 43.6M ops/s | 137.8% |
| large | classed elements | 21.2M ops/s | 26.2M ops/s | 23.6% |
| x-large | classed elements | 9.7M ops/s | 15.2M ops/s | 56.8% |

`classNames()` Allocation:

| Fixture | Scope | 1.22.2 | New | Saving |
|---|---|---:|---:|---:|
| tiny | all elements | 376 B/op | 80.0 B/op | 78.7% |
| small | all elements | 352 B/op | 89.7 B/op | 74.5% |
| medium | all elements | 460 B/op | 93.1 B/op | 79.8% |
| large | all elements | 376 B/op | 104 B/op | 72.3% |
| x-large | all elements | 544 B/op | 203 B/op | 62.7% |
| small | classed elements | 376 B/op | 152 B/op | 59.6% |
| medium | classed elements | 511 B/op | 171 B/op | 66.6% |
| large | classed elements | 376 B/op | 152 B/op | 59.6% |
| x-large | classed elements | 560 B/op | 261 B/op | 53.4% |

`classList()` Baseline:

| Fixture | Scope | classList() throughput | classList() allocation |
|---|---|---:|---:|
| tiny | all elements | 1,355.8M ops/s | ~0 B/op |
| small | all elements | 285.3M ops/s | 3.2 B/op |
| medium | all elements | 215.6M ops/s | 6.4 B/op |
| large | all elements | 112.4M ops/s | 8.1 B/op |
| x-large | all elements | 26.1M ops/s | 79.0 B/op |
| small | classed elements | 87.0M ops/s | 24.0 B/op |
| medium | classed elements | 61.0M ops/s | 44.8 B/op |
| large | classed elements | 40.2M ops/s | 24.0 B/op |
| x-large | classed elements | 18.6M ops/s | 117 B/op |

Fixture Class Histogram:

| Fixture | Input | Elements | [class] elements | 0 classes | 1 class | 2 classes | 3 classes | 4+ classes | Avg classes / [class] |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| tiny | 274 B | 11 | 0 | 11 | 0 | 0 | 0 | 0 | 0.00 |
| small | 3.3 KB | 45 | 6 | 39 | 6 | 0 | 0 | 0 | 1.00 |
| medium | 8.6 KB | 160 | 22 | 138 | 19 | 3 | 0 | 0 | 1.14 |
| large | 496.3 KB | 6,208 | 2,145 | 4,063 | 2,145 | 0 | 0 | 0 | 1.00 |
| x-large | 2.3 MB | 10,310 | 7,347 | 2,963 | 3,435 | 1,594 | 1,245 | 1,073 | 2.20 |

(Single threaded performance, relative comparison)