### PR TITLE
Move hot-path consumers back to direct scans.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * Added `Element#classList()`, an immutable snapshot of an element's class names in attribute order. Use `hasClass()` when you just need to test for one class, `classList()` when you want to read or iterate classes without needing a mutable result, and `classNames()` when you want the existing mutable, deduplicated set that can be written back with `classNames(Set)`. The class APIs now share an HTML-whitespace scanner, which also makes `classNames()` faster and lighter on allocation, especially when walking many elements without class names. [#2500](https://github.com/jhy/jsoup/pull/2500)
 * Aligned HTML parser scope classification with the current HTML spec for `select`, `foreignObject`, and `template`. [#2501](https://github.com/jhy/jsoup/issues/2501)
 * Simplified the HTML tree builder's scope, implied-end-tag, and special-element checks by caching parser-only options on Tag. That improves HTML parser throughput by about 10% on small inputs and up to about 30% on larger inputs in the benchmark fixtures. [#2502](https://github.com/jhy/jsoup/issues/2502)
+* Improved HTML parser throughput stability by making hot tokeniser scan paths compile more predictably. [#2507](https://github.com/jhy/jsoup/pull/2507)
 
 ### Bug Fixes
 * Fixed HTML parsing of mixed-case RCDATA end tags after tag-shaped text. For example, `<title><p>Foo</TiTLE>` and `<textarea><img src=x></TeXtArEa>` now keep the tag-shaped content as text instead of promoting it to markup. [#2503](https://github.com/jhy/jsoup/issues/2503)

--- a/src/main/java/org/jsoup/parser/CharacterReader.java
+++ b/src/main/java/org/jsoup/parser/CharacterReader.java
@@ -410,41 +410,108 @@ public final class CharacterReader implements AutoCloseable {
     }
 
     /**
-     * Read characters until the first of any delimiters is found.
-     * @param chars delimiters to scan for
-     * @return characters read up to the matched delimiter.
+     Read characters until the first of any delimiters is found.
+     @param chars delimiters to scan for
+     @return characters read up to the matched delimiter.
      */
     public String consumeToAny(final char... chars) {
-        return consumeMatching(c -> { // seeks until we see one of the terminating chars
+        bufferUp();
+        int pos = bufPos;
+        final int start = pos;
+        final int remaining = bufLength;
+        final char[] val = charBuf;
+
+        scan:
+        while (pos < remaining) {
+            char c = val[pos];
             for (char seek : chars)
-                if (c == seek) return false;
-            return true;
-        });
+                if (c == seek) break scan;
+            pos++;
+        }
+
+        return consumeRange(start, pos);
+    }
+
+    /**
+     Read characters until either delimiter is found.
+     */
+    String consumeToAny(char c1, char c2) {
+        // monomorhpic to allow JIT to avoid virtual dispatch of e.g. consumeMatching(CharPredicate func)
+        bufferUp();
+        int pos = bufPos;
+        final int start = pos;
+        final int remaining = bufLength;
+        final char[] val = charBuf;
+
+        while (pos < remaining) {
+            char c = val[pos];
+            if (c == c1 || c == c2) break;
+            pos++;
+        }
+
+        return consumeRange(start, pos);
+    }
+
+    /**
+     Read characters until any delimiter is found.
+     */
+    String consumeToAny(char c1, char c2, char c3) {
+        bufferUp();
+        int pos = bufPos;
+        final int start = pos;
+        final int remaining = bufLength;
+        final char[] val = charBuf;
+
+        while (pos < remaining) {
+            char c = val[pos];
+            if (c == c1 || c == c2 || c == c3) break;
+            pos++;
+        }
+
+        return consumeRange(start, pos);
     }
 
     String consumeToAnySorted(final char... chars) {
-        return consumeMatching(c -> Arrays.binarySearch(chars, c) < 0); // matches until a hit
+        bufferUp();
+        int pos = bufPos;
+        final int start = pos;
+        final int remaining = bufLength;
+        final char[] val = charBuf;
+
+        while (pos < remaining && Arrays.binarySearch(chars, val[pos]) < 0) {
+            pos++;
+        }
+
+        return consumeRange(start, pos);
     }
 
     String consumeData() {
         // consumes until &, <, null
-        return consumeMatching(c -> c != '&' && c != '<' && c != TokeniserState.nullChar);
+        return consumeToAny('&', '<', TokeniserState.nullChar);
     }
 
     String consumeAttributeQuoted(final boolean single) {
         // null, " or ', &
-        return consumeMatching(c -> c != TokeniserState.nullChar && c != '&' && (single ? c != '\'' : c != '"'));
+        char quote = single ? '\'' : '"';
+        return consumeToAny(TokeniserState.nullChar, '&', quote);
     }
 
     String consumeRawData() {
         // <, null
-        return consumeMatching(c -> c != '<' && c != TokeniserState.nullChar);
+        return consumeToAny('<', TokeniserState.nullChar);
     }
 
     String consumeTagName() {
         // '\t', '\n', '\r', '\f', ' ', '/', '>'
         // NOTE: out of spec; does not stop and append on nullChar but eats
-        return consumeMatching(c -> {
+        bufferUp();
+        int pos = bufPos;
+        final int start = pos;
+        final int remaining = bufLength;
+        final char[] val = charBuf;
+
+        while (pos < remaining) {
+            char c = val[pos];
             switch (c) {
                 case '\t':
                 case '\n':
@@ -453,10 +520,12 @@ public final class CharacterReader implements AutoCloseable {
                 case ' ':
                 case '/':
                 case '>':
-                    return false;
+                    return consumeRange(start, pos);
             }
-            return true;
-        });
+            pos++;
+        }
+
+        return consumeRange(start, pos);
     }
 
     String consumeToEnd() {
@@ -491,6 +560,14 @@ public final class CharacterReader implements AutoCloseable {
 
     String consumeDigitSequence() {
         return consumeMatching(c -> c >= '0' && c <= '9');
+    }
+
+    /**
+     Complete a scan by moving the reader and returning the matched range.
+     */
+    private String consumeRange(int start, int pos) {
+        bufPos = pos;
+        return pos > start ? cacheString(charBuf, stringCache, start, pos - start) : "";
     }
 
     boolean matches(char c) {


### PR DESCRIPTION
Make the parser-hot `CharacterReader` scanners use direct delimiter loops instead of routing through `consumeMatching(CharPredicate)`.

The lambda predicates looked cleaner, but would not always get a good JIT and could stay in virtual dispatch. That led to a wide variance in throughput.

This keeps the generic predicate scanner for lower-traffic cases, but gives the main HTML tokeniser scanners monomorphic loops that the JIT can compile more predictably.

| Fixture | Baseline avg ops/s | Baseline min | Baseline max | Baseline spread | New avg ops/s | New min | New max | New spread |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| tiny | 447,238 | 375,236 | 497,448 | 27.3% | 471,773 | 460,019 | 478,158 | 3.8% |
| small | 58,630 | 58,031 | 59,325 | 2.2% | 85,310 | 81,470 | 86,786 | 6.2% |
| medium | 20,764 | 19,626 | 27,966 | 40.2% | 27,648 | 27,524 | 27,836 | 1.1% |
| large | 597 | 592 | 607 | 2.5% | 598 | 591 | 606 | 2.5% |
| x-large | 184 | 182 | 186 | 2.4% | 182 | 175 | 184 | 5.2% |

The spread really seemed to be dependent on the contents of the fixture more than the size.