### PR TITLE
Validate the inputStream argument in KeyVal.inputStream

### DIFF
--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -1390,7 +1390,7 @@ public class HttpConnection implements Connection {
 
         @Override
         public KeyVal inputStream(InputStream inputStream) {
-            Validate.notNullParam(value, "inputStream");
+            Validate.notNullParam(inputStream, "inputStream");
             this.stream = inputStream;
             return this;
         }

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -250,6 +250,10 @@ public class HttpConnectionTest {
         assertEquals("one", kv.key());
         assertEquals("two", kv.value());
         assertFalse(kv.hasInputStream());
+
+        // inputStream(null) must be rejected: it validates the argument, not the value field
+        Connection.KeyVal withNull = HttpConnection.KeyVal.create("one", "two");
+        assertThrows(ValidationException.class, () -> withNull.inputStream(null));
     }
 
     @Test public void requestBody() {


### PR DESCRIPTION
`HttpConnection.KeyVal.inputStream(InputStream)` calls `Validate.notNullParam(value, "inputStream")` — it validates the unrelated `value` field instead of the `inputStream` argument. So `inputStream(null)` is silently accepted (a null stream is stored), while a `KeyVal` whose `value` is null would fail with a misleading "The parameter 'inputStream' must not be null."

Validate the argument that's actually used. Extended the existing `inputStream()` test.

## Verifying this change

The added `HttpConnectionTest#inputStream` case fails before this change and passes after:

Before the fix:

```
$ mvn test -Dtest=HttpConnectionTest
[INFO] Running org.jsoup.helper.HttpConnectionTest
[ERROR] Tests run: 42, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE!
org.opentest4j.AssertionFailedError: Expected org.jsoup.helper.ValidationException to be thrown, but nothing was thrown.
	at org.jsoup.helper.HttpConnectionTest.inputStream(HttpConnectionTest.java:256)
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=HttpConnectionTest
[INFO] Running org.jsoup.helper.HttpConnectionTest
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

