### PR TITLE
`noscript` is an island

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 * Aligned HTML parser scope classification with the current HTML spec for `select`, `foreignObject`, and `template`. [#2501](https://github.com/jhy/jsoup/issues/2501)
 * Simplified the HTML tree builder's scope, implied-end-tag, and special-element checks by caching parser-only options on Tag. That improves HTML parser throughput by about 10% on small inputs and up to about 30% on larger inputs in the benchmark fixtures. [#2502](https://github.com/jhy/jsoup/issues/2502)
 * Improved HTML parser throughput stability by making hot tokeniser scan paths compile more predictably. [#2507](https://github.com/jhy/jsoup/pull/2507)
-* `<noscript>` fallback markup is now parsed into an inspectable DOM subtree in both the document head and body. The fallback acts as a contained parsing island, so malformed markup cannot disrupt the surrounding document structure, while normal HTML tokenization still applies within it. This also improves round-trip serialization.
+* `<noscript>` fallback markup is now parsed into an inspectable DOM subtree in both the document head and body. The fallback acts as a contained parsing island, so malformed markup cannot disrupt the surrounding document structure, while normal HTML tokenization still applies within it. This also improves round-trip serialization. [#2537](https://github.com/jhy/jsoup/pull/2537)
 
 ### Bug Fixes
 * Fixed HTML parsing of mixed-case RCDATA end tags after tag-shaped text. For example, `<title><p>Foo</TiTLE>` and `<textarea><img src=x></TeXtArEa>` now keep the tag-shaped content as text instead of promoting it to markup. [#2503](https://github.com/jhy/jsoup/issues/2503)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 * Aligned HTML parser scope classification with the current HTML spec for `select`, `foreignObject`, and `template`. [#2501](https://github.com/jhy/jsoup/issues/2501)
 * Simplified the HTML tree builder's scope, implied-end-tag, and special-element checks by caching parser-only options on Tag. That improves HTML parser throughput by about 10% on small inputs and up to about 30% on larger inputs in the benchmark fixtures. [#2502](https://github.com/jhy/jsoup/issues/2502)
 * Improved HTML parser throughput stability by making hot tokeniser scan paths compile more predictably. [#2507](https://github.com/jhy/jsoup/pull/2507)
+* `<noscript>` fallback markup is now parsed into an inspectable DOM subtree in both the document head and body. The fallback acts as a contained parsing island, so malformed markup cannot disrupt the surrounding document structure, while normal HTML tokenization still applies within it. This also improves round-trip serialization.
 
 ### Bug Fixes
 * Fixed HTML parsing of mixed-case RCDATA end tags after tag-shaped text. For example, `<title><p>Foo</TiTLE>` and `<textarea><img src=x></TeXtArEa>` now keep the tag-shaped content as text instead of promoting it to markup. [#2503](https://github.com/jhy/jsoup/issues/2503)

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -47,6 +47,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     private @Nullable Element contextElement; // fragment parse root; name only copy of context. could be null even if fragment parsing
     ArrayList<Element> formattingElements; // active (open) formatting elements
     private ArrayList<HtmlTreeBuilderState> tmplInsertMode; // stack of Template Insertion modes
+    private @Nullable NoscriptState noscriptState; // active noscript island state
     private List<Token.Character> pendingTableCharacters; // chars in table to be shifted out
     private Token.EndTag emptyEnd; // reused empty end tag
 
@@ -76,6 +77,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
         contextElement = null;
         formattingElements = new ArrayList<>();
         tmplInsertMode = new ArrayList<>();
+        noscriptState = null;
         pendingTableCharacters = new ArrayList<>();
         emptyEnd = new Token.EndTag(this);
         framesetOk = true;
@@ -128,6 +130,8 @@ public class HtmlTreeBuilder extends TreeBuilder {
                 }
                 formSearch = formSearch.parent();
             }
+
+            if (contextName.equals("noscript")) enterNoscript(contextElement);
         }
     }
 
@@ -146,8 +150,84 @@ public class HtmlTreeBuilder extends TreeBuilder {
 
     @Override
     protected boolean process(Token token) {
+        if (noscriptState != null && state != HtmlTreeBuilderState.Text)
+            return processNoscriptToken(token);
         HtmlTreeBuilderState dispatch = useCurrentOrForeignInsert(token) ? this.state : ForeignContent;
         return dispatch.process(token, this);
+    }
+
+    /**
+     Handles tokens in a noscript island as plain contained markup. This diverges from the spec intentionally so that
+     content is available in the DOM and round-trip serializable, but errant content won't change the parser's context
+     (e.g. an `a` won't kick out of InHead).
+     */
+    private boolean processNoscriptToken(Token token) {
+        switch (token.type) {
+            case StartTag:
+                return insertNoscriptStartTag(token.asStartTag());
+            case EndTag:
+                return closeNoscriptEndTag(token.asEndTag());
+            case Comment:
+                insertCommentNode(token.asComment());
+                return true;
+            case Character:
+                Token.Character character = token.asCharacter();
+                insertCharacterNode(character);
+                if (!StringUtil.isBlank(character.getData()))
+                    framesetOk(false);
+                return true;
+            case Doctype:
+                error(state);
+                return false;
+            case EOF:
+                error(state);
+                endNoscript();
+                return process(token);
+            default:
+                Validate.wtf("Unexpected state: " + token.type); // XmlDecl only in XmlTreeBuilder
+                return false;
+        }
+    }
+
+    /**
+     Inserts a start tag inside a noscript island as plain markup.
+     */
+    private boolean insertNoscriptStartTag(Token.StartTag start) {
+        TokeniserState textState = tagFor(start).textState();
+        Element el = insertElementFor(start);
+        if (textState != null) { // plaintext is intentionally not TagSet-driven and remains plain fallback markup.
+            if (start.isSelfClosing()) {
+                if (currentElement() == el)
+                    pop();
+            } else {
+                tokeniser.transition(textState);
+                markInsertionMode();
+                transition(HtmlTreeBuilderState.Text);
+            }
+        }
+
+        framesetOk(false);
+        return true;
+    }
+
+    /**
+     Closes an island element if it matches above the current noscript boundary.
+     */
+    private boolean closeNoscriptEndTag(Token.EndTag end) {
+        String name = end.normalName();
+        NoscriptState island = Validate.expectNotNull(noscriptState, "Bug: noscript end tag processed with no island state");
+        if (name.equals("noscript") && island.boundary != contextElement) {
+            endNoscript();
+            return true;
+        }
+        if (!inNoscriptScope(name)) {
+            error(state);
+            return false;
+        }
+        if (!currentElementIs(name))
+            error(state);
+        popStackToClose(name);
+        return true;
     }
 
     boolean useCurrentOrForeignInsert(Token token) {
@@ -488,6 +568,8 @@ public class HtmlTreeBuilder extends TreeBuilder {
             if (templateModeSize() > 0)
                 popTemplateMode();
             resetInsertionMode();
+        } else if (noscriptState != null && element == noscriptState.boundary) {
+            restoreNoscriptState();
         }
     }
 
@@ -771,8 +853,81 @@ public class HtmlTreeBuilder extends TreeBuilder {
         return formElement;
     }
 
-    void setFormElement(FormElement formElement) {
+    void setFormElement(@Nullable FormElement formElement) {
         this.formElement = formElement;
+    }
+
+    private static final class NoscriptState {
+        final Element boundary;
+        final @Nullable FormElement savedFormElement;
+
+        /**
+         Captures parser state isolated by the active noscript island.
+        */
+        NoscriptState(Element boundary, @Nullable FormElement formElement) {
+            this.boundary = boundary;
+            this.savedFormElement = formElement;
+        }
+    }
+
+    /** Starts a noscript island, preserving parser-global state for restoration on close. */
+    void startNoscript(Token.StartTag startTag) {
+        Element boundary = insertElementFor(startTag);
+        enterNoscript(boundary);
+    }
+
+    /** Enters a noscript island around the provided boundary element. */
+    private void enterNoscript(Element boundary) {
+        noscriptState = new NoscriptState(boundary, formElement);
+        // Fallback form elements should not leak through the parser form pointer.
+        setFormElement(null);
+    }
+
+    /** Tests if the named element is above the current noscript boundary. */
+    private boolean inNoscriptScope(String name) {
+        NoscriptState state = noscriptState;
+        if (state == null)
+            return false;
+        for (int pos = stack.size() - 1; pos >= 0; pos--) {
+            Element el = stack.get(pos);
+            if (el == state.boundary)
+                return false;
+            if (el.nameIs(name))
+                return true;
+        }
+        return false;
+    }
+
+    /** Closes the active noscript subtree and restores isolated parser state. */
+    private void endNoscript() {
+        NoscriptState state = Validate.expectNotNull(noscriptState, "Bug: noscript fallback closed with no island state");
+        int boundary = noscriptBoundaryIndex(state);
+        if (boundary == -1) {
+            error(this.state);
+            restoreNoscriptState();
+            return;
+        }
+        if (stack.get(stack.size() - 1) != state.boundary)
+            error(this.state);
+        while (stack.size() > boundary)
+            pop();
+        restoreNoscriptState();
+    }
+
+    /** Finds the active noscript boundary on the stack by identity. */
+    private int noscriptBoundaryIndex(NoscriptState state) {
+        for (int pos = stack.size() - 1; pos >= 0; pos--) {
+            if (stack.get(pos) == state.boundary)
+                return pos;
+        }
+        return -1;
+    }
+
+    /** Restores parser-global state from the active noscript island. */
+    private void restoreNoscriptState() {
+        NoscriptState state = Validate.expectNotNull(noscriptState, "Bug: no noscript island state to restore");
+        noscriptState = null;
+        setFormElement(state.savedFormElement);
     }
 
     void resetPendingTableCharacters() {

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -137,9 +137,7 @@ enum HtmlTreeBuilderState {
                     } else if (inSorted(name, InHeadRaw)) {
                         HandleTextState(start, tb, tb.tagFor(start).textState());
                     } else if (name.equals("noscript")) {
-                        // else if noscript && scripting flag = true: rawtext (jsoup doesn't run script, to handle as noscript)
-                        tb.insertElementFor(start);
-                        tb.transition(InHeadNoscript);
+                        tb.startNoscript(start);
                     } else if (name.equals("script")) {
                         // skips some script rules as won't execute them
                         tb.tokeniser.transition(TokeniserState.ScriptData);
@@ -193,38 +191,6 @@ enum HtmlTreeBuilderState {
         private boolean anythingElse(Token t, TreeBuilder tb) {
             tb.processEndTag("head");
             return tb.process(t);
-        }
-    },
-    InHeadNoscript {
-        @Override boolean process(Token t, HtmlTreeBuilder tb) {
-            if (t.isDoctype()) {
-                tb.error(this);
-            } else if (t.isStartTag() && t.asStartTag().normalName().equals("html")) {
-                return tb.process(t, InBody);
-            } else if (t.isEndTag() && t.asEndTag().normalName().equals("noscript")) {
-                tb.pop();
-                tb.transition(InHead);
-            } else if (isWhitespace(t) || t.isComment() || (t.isStartTag() && inSorted(t.asStartTag().normalName(),
-                    InHeadNoScriptHead))) {
-                return tb.process(t, InHead);
-            } else if (t.isEndTag() && t.asEndTag().normalName().equals("br")) {
-                return anythingElse(t, tb);
-            } else if ((t.isStartTag() && inSorted(t.asStartTag().normalName(), InHeadNoscriptIgnore)) || t.isEndTag()) {
-                tb.error(this);
-                return false;
-            } else {
-                return anythingElse(t, tb);
-            }
-            return true;
-        }
-
-        private boolean anythingElse(Token t, HtmlTreeBuilder tb) {
-            // note that this deviates from spec, which is to pop out of noscript and reprocess in head:
-            // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inheadnoscript
-            // allows content to be inserted as data
-            tb.error(this);
-            tb.insertCharacterNode(new Token.Character().data(t.toString()));
-            return true;
         }
     },
     AfterHead {
@@ -492,8 +458,11 @@ enum HtmlTreeBuilderState {
                     HandleTextState(startTag, tb, tb.tagFor(startTag).textState());
                     break;
                 case "noembed":
-                    // also handle noscript if script enabled
                     HandleTextState(startTag, tb, tb.tagFor(startTag).textState());
+                    break;
+                case "noscript":
+                    tb.reconstructFormattingElements();
+                    tb.startNoscript(startTag);
                     break;
                 case "select":
                     tb.reconstructFormattingElements();
@@ -1056,6 +1025,8 @@ enum HtmlTreeBuilderState {
                     }
                 } else if (inSorted(name, InTableToHead)) {
                     return tb.process(t, InHead);
+                } else if (name.equals("noscript")) {
+                    tb.startNoscript(startTag);
                 } else if (name.equals("input")) {
                     if (!(startTag.hasAttributes() && startTag.attributes.get("type").equalsIgnoreCase("hidden"))) {
                         return anythingElse(t, tb);
@@ -1484,6 +1455,8 @@ enum HtmlTreeBuilderState {
                         return tb.process(start);
                     } else if (name.equals("script") || name.equals("template")) {
                         return tb.process(t, InHead);
+                    } else if (name.equals("noscript")) {
+                        tb.startNoscript(start);
                     } else {
                         return anythingElse(t, tb);
                     }
@@ -1902,7 +1875,6 @@ enum HtmlTreeBuilderState {
         static final String[] InHeadEnd = new String[]{"body", "br", "html"};
         static final String[] AfterHeadBody = new String[]{"body", "br", "html"};
         static final String[] BeforeHtmlToHead = new String[]{"body", "br", "head", "html", };
-        static final String[] InHeadNoScriptHead = new String[]{"basefont", "bgsound", "link", "meta", "noframes", "style"};
         static final String[] InBodyStartToHead = new String[]{"base", "basefont", "bgsound", "command", "link", "meta", "noframes", "script", "style", "template", "title"};
         static final String[] InBodyStartPClosers = new String[]{"address", "article", "aside", "blockquote", "center", "details", "dir", "div", "dl",
             "fieldset", "figcaption", "figure", "footer", "header", "hgroup", "menu", "nav", "ol",
@@ -1935,7 +1907,6 @@ enum HtmlTreeBuilderState {
         static final String[] InSelectEnd = new String[]{"input", "keygen", "textarea"};
         static final String[] InSelectTableEnd = new String[]{"caption", "table", "tbody", "td", "tfoot", "th", "thead", "tr"};
         static final String[] InTableEndIgnore = new String[]{"tbody", "tfoot", "thead"};
-        static final String[] InHeadNoscriptIgnore = new String[]{"head", "noscript"};
         static final String[] InCaptionIgnore = new String[]{"body", "col", "colgroup", "html", "tbody", "td", "tfoot", "th", "thead", "tr"};
         static final String[] InTemplateToHead = new String[] {"base", "basefont", "bgsound", "link", "meta", "noframes", "script", "style", "template", "title"};
         static final String[] InTemplateToTable = new String[] {"caption", "colgroup", "tbody", "tfoot", "thead"};

--- a/src/test/java/org/jsoup/nodes/DocumentTest.java
+++ b/src/test/java/org/jsoup/nodes/DocumentTest.java
@@ -76,7 +76,8 @@ public class DocumentTest {
 
     @Test public void testNormalisesStructure() {
         Document doc = Jsoup.parse("<html><head><script>one</script><noscript><p>two</p></noscript></head><body><p>three</p></body><p>four</p></html>");
-        assertEquals("<html><head><script>one</script><noscript>&lt;p&gt;two</noscript></head><body><p>three</p><p>four</p></body></html>", TextUtil.stripNewlines(doc.html()));
+        assertEquals("<html><head><script>one</script><noscript><p>two</p></noscript></head><body><p>three</p><p>four</p></body></html>", TextUtil.stripNewlines(doc.html()));
+        // ^ noscript content gets round-tripped correctly
     }
 
     @Test public void accessorsWillNormalizeStructure() {

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -658,10 +658,200 @@ public class HtmlParserTest {
         assertEquals("<span>Hello <div>there</div> <span>now</span></span>", TextUtil.stripNewlines(doc.body().html()));
     }
 
-    @Test public void testNoImagesInNoScriptInHead() {
-        // jsoup used to allow, but against spec if parsing with noscript
+    @Test public void parsesImageInNoscriptFallbackInHead() {
         Document doc = Jsoup.parse("<html><head><noscript><img src='foo'></noscript></head><body><p>Hello</p></body></html>");
-        assertEquals("<html><head><noscript>&lt;img src=\"foo\"&gt;</noscript></head><body><p>Hello</p></body></html>", TextUtil.stripNewlines(doc.html()));
+        assertEquals("<html><head><noscript><img src=\"foo\"></noscript></head><body><p>Hello</p></body></html>", TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void parsesNoscriptFallbackAsContainedDomInHead() {
+        Document doc = Jsoup.parse("<head><noscript><p>head</p><img src=x><title>N</title></noscript><title>After</title></head><body>B</body>");
+        assertEquals("<html><head><noscript><p>head</p><img src=\"x\"><title>N</title></noscript><title>After</title></head><body>B</body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptFallbackDoesNotCloseOuterHead() {
+        Document doc = Jsoup.parse("<head><noscript></head><p>x</p></noscript><title>T</title></head><body>B</body>");
+        assertEquals("<html><head><noscript><p>x</p></noscript><title>T</title></head><body>B</body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void parsesNoscriptFallbackAsPlainMarkupIsland() {
+        Document doc = Jsoup.parse("<body><noscript><p>one<p>two<ul><li>a<li>b</ul></noscript>B</body>");
+        assertEquals("<html><head></head><body><noscript><p>one<p>two<ul><li>a<li>b</li></li></ul></p></p></noscript>B</body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void encodedNoscriptFallbackRemainsText() {
+        Document doc = Jsoup.parse("<body><noscript>&lt;p&gt;x&lt;/p&gt;</noscript></body>");
+        assertEquals("<html><head></head><body><noscript>&lt;p&gt;x&lt;/p&gt;</noscript></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptFallbackUsesTextTokenization() {
+        Document doc = Jsoup.parse("<noscript><script><p>x</p></script><title><i>t</i></title><title /></noscript><p>after</p>");
+        Element script = doc.expectFirst("noscript script");
+        Elements titles = doc.select("noscript title");
+
+        assertEquals("<p>x</p>", script.data());
+        assertNull(script.selectFirst("p"));
+        assertEquals("&lt;i&gt;t&lt;/i&gt;", titles.get(0).html());
+        assertEquals("", titles.get(1).html());
+        assertEquals("after", doc.expectFirst("body > p").text());
+
+        Parser parser = Parser.htmlParser();
+        parser.tagSet().valueOf("x-data", Parser.NamespaceHtml).set(Tag.Data);
+        Document custom = Jsoup.parse("<noscript><x-data><p>x</p></x-data></noscript>", "", parser);
+        Element data = custom.expectFirst("x-data");
+        assertEquals("<p>x</p>", data.data());
+        assertNull(data.selectFirst("p"));
+    }
+
+    @Test public void unclosedTextElementUsesHtmlTokenizationInsideNoscript() {
+        // script-data tokenization owns the apparent noscript end tag through EOF (effectively same as spec; unclosed rcdata will eat remaining content)
+        Document doc = Jsoup.parse("<body><noscript><script>bad</noscript><p>after</p>");
+        Element script = doc.expectFirst("noscript > script");
+
+        assertEquals("bad</noscript><p>after</p>", script.data());
+        assertNull(doc.selectFirst("p"));
+    }
+
+    @Test public void noscriptFallbackDoesNotEnterPlaintextMode() {
+        Document doc = Jsoup.parse("<noscript><plaintext><p>x</p></noscript><p>after</p>");
+        assertEquals("<html><head><noscript><plaintext><p>x</p></plaintext></noscript></head><body><p>after</p></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptFallbackHonoursTagSetVoids() {
+        Parser parser = Parser.htmlParser();
+        parser.tagSet().valueOf("fallback", Parser.NamespaceHtml).set(Tag.Void);
+
+        Document doc = Jsoup.parse("<noscript><fallback><p>x</p></noscript>", "", parser);
+        assertEquals("<html><head><noscript><fallback><p>x</p></noscript></head><body></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void doesNotEnterTableOrSelectModesInsideNoscript() {
+        Document table = Jsoup.parse("<table><noscript><tr><td>x</td></tr></noscript></table>");
+        assertEquals("<html><head></head><body><table><noscript><tr><td>x</td></tr></noscript></table></body></html>",
+            TextUtil.stripNewlines(table.html()));
+
+        Document select = Jsoup.parse("<select><noscript><option>x</option></noscript></select>");
+        assertEquals("<html><head></head><body><select><noscript><option>x</option></noscript></select></body></html>",
+            TextUtil.stripNewlines(select.html()));
+    }
+
+    @Test public void noscriptFragmentContextUsesIslandParsing() {
+        Document doc = Jsoup.parse("<noscript></noscript>");
+        Element noscript = doc.expectFirst("noscript");
+        noscript.html("<table><tr><td>x</td></tr></table>");
+
+        assertEquals("<table><tr><td>x</td></tr></table>", TextUtil.stripNewlines(noscript.html()));
+    }
+
+    @Test public void noscriptFragmentContextCannotBeClosedByInput() {
+        // a synthetic fragment context is not part of the input, so its end tag cannot close the island:
+        Document doc = Jsoup.parse("<noscript></noscript>");
+        Element noscript = doc.expectFirst("noscript");
+        noscript.html("<p>one</noscript><table><tr><td>x</td></tr></table>");
+
+        assertEquals("<p>one<table><tr><td>x</td></tr></table></p>", TextUtil.stripNewlines(noscript.html()));
+    }
+
+    @Test public void nestedNoscriptCanCloseWithinFragmentContext() {
+        // input-created noscript still closes normally above the synthetic context boundary:
+        Document doc = Jsoup.parse("<noscript></noscript>");
+        Element noscript = doc.expectFirst("noscript");
+        noscript.html("<noscript><b>x</b></noscript><table><tr><td>y</td></tr></table>");
+
+        assertEquals("<noscript><b>x</b></noscript><table><tr><td>y</td></tr></table>",
+            TextUtil.stripNewlines(noscript.html()));
+    }
+
+    @Test public void treatsForeignContentAsPlainHtmlInsideNoscript() {
+        Document doc = Jsoup.parse("<body><noscript><svg><path d='M0 0'></path><foreignObject><p>x</p></foreignObject></svg><p>y</p></noscript></body>");
+        assertEquals("<html><head></head><body><noscript><svg><path d=\"M0 0\"></path><foreignobject><p>x</p></foreignobject></svg><p>y</p></noscript></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptFallbackEndTagInsideCommentIsNotAClose() {
+        Document doc = Jsoup.parse("<noscript><!-- </noscript> --><p>x</p></noscript>");
+        assertEquals("<html><head><noscript><!-- </noscript> --><p>x</p></noscript></head><body></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptFallbackEndTagInsideAttributeIsNotAClose() {
+        Document doc = Jsoup.parse("<noscript><div data='</noscript>'>x</div></noscript>");
+        assertEquals("<html><head><noscript><div data=\"&lt;/noscript&gt;\">x</div></noscript></head><body></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptReconstructsFormattingElementsInBody() {
+        Document doc = Jsoup.parse("<p><b>one</p><noscript>two</noscript>");
+        assertEquals("<p><b>one</b></p><b><noscript>two</noscript></b>",
+            TextUtil.stripNewlines(doc.body().html()));
+    }
+
+    @Test public void noscriptFallbackContentBlocksFrameset() {
+        Document doc = Jsoup.parse("<head></head><noscript><p>x</p></noscript><frameset><frame src=x></frameset>");
+        assertEquals("<html><head></head><body><noscript><p>x</p></noscript></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void emptyNoscriptFallbackDoesNotBlockFrameset() {
+        Document doc = Jsoup.parse("<head></head><noscript><!--x--></noscript><frameset><frame src=x></frameset>");
+        assertEquals("<html><head></head><frameset><frame src=\"x\"></frameset></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptFallbackDoesNotMutateOuterFormattingElement() {
+        Document doc = Jsoup.parse("<a href=1><noscript><a href=2>x</a></noscript>y</a>");
+        assertEquals("<a href=\"1\"><noscript><a href=\"2\">x</a></noscript>y</a>",
+            TextUtil.stripNewlines(doc.body().html()));
+    }
+
+    @Test public void noscriptFallbackTemplateDoesNotTrapParser() {
+        Document doc = Jsoup.parse("<body><noscript><template><b>x</noscript><p>after</p>");
+        assertEquals("<noscript><template><b>x</b></template></noscript><p>after</p>",
+            TextUtil.stripNewlines(doc.body().html()));
+    }
+
+    @Test public void nestedNoscriptStartDoesNotCreateNestedIsland() {
+        Document doc = Jsoup.parse("<noscript><noscript></noscript><p>body</p>");
+        assertEquals("<html><head><noscript><noscript></noscript></noscript></head><body><p>body</p></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptFallbackDoesNotResetToOuterInsertionMode() {
+        Document doc = Jsoup.parse("<head><noscript><select></select><p>x</p></noscript><title>T</title></head>");
+        assertEquals("<html><head><noscript><select></select><p>x</p></noscript><title>T</title></head><body></body></html>",
+            TextUtil.stripNewlines(doc.html()));
+    }
+
+    @Test public void noscriptFallbackDoesNotLeakFormPointer() {
+        Document doc = Jsoup.parse("<head><noscript><form id=a><p>x</p></noscript></head><body><form id=b><input name=y></form></body>");
+        assertNotNull(doc.selectFirst("noscript form#a"));
+        assertNotNull(doc.selectFirst("body form#b"));
+    }
+
+    @Test public void nestedNoscriptFallbackDoesNotReparseRecursively() {
+        StringBuilder html = new StringBuilder("<noscript>");
+        for (int i = 0; i < 2000; i++)
+            html.append("<noscript>");
+        html.append("</noscript>");
+
+        Parser parser = Parser.htmlParser().setMaxDepth(32);
+        Document doc = assertDoesNotThrow(() -> Jsoup.parse(html.toString(), "", parser));
+        assertEquals(2001, doc.select("noscript").size());
+    }
+
+    @Test public void noscriptFallbackUsesOuterParserBookkeeping() {
+        Parser parser = Parser.htmlParser().setTrackErrors(10);
+        Document doc = Jsoup.parse("<body>\n<noscript><x-noscript a=1 a=2>One</x-noscript></noscript>", "", parser);
+
+        assertNotNull(doc.selectFirst("x-noscript"));
+        assertNotNull(parser.tagSet().get("x-noscript", Parser.NamespaceHtml));
+        assertEquals(1, parser.getErrors().size());
+        assertErrorsContain("<2:31>: Dropped duplicate attribute(s) in tag [x-noscript]", parser.getErrors());
     }
 
     @Test public void testUnclosedNoscriptInHead() {

--- a/src/test/java/org/jsoup/parser/HtmlTreeBuilderStateTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlTreeBuilderStateTest.java
@@ -45,7 +45,7 @@ public class HtmlTreeBuilderStateTest {
     public void ensureArraysAreSorted() {
         List<Object[]> constants = findConstantArrays(Constants.class);
         ensureSorted(constants);
-        assertEquals(39, constants.size());
+        assertEquals(37, constants.size());
     }
 
     @Test public void ensureTagSearchesAreKnownTags() {

--- a/src/test/java/org/jsoup/parser/PositionTest.java
+++ b/src/test/java/org/jsoup/parser/PositionTest.java
@@ -338,6 +338,22 @@ class PositionTest {
         assertEquals("2,9:15-4,8:33", data.sourceRange().toString());
     }
 
+    @Test void tracksNoscriptFallbackContent() {
+        String html = "<head>\n<noscript><p a=1>One\nTwo</p></noscript>\n</head>";
+        Document doc = Jsoup.parse(html, TrackingHtmlParser);
+
+        Element noscript = doc.expectFirst("noscript");
+        Element p = noscript.expectFirst("p");
+        TextNode text = (TextNode) p.firstChild();
+
+        assertEquals("2,1:7-2,11:17", noscript.sourceRange().toString());
+        assertTrue(noscript.endSourceRange().isTracked());
+        assertEquals("2,11:17-2,18:24", p.sourceRange().toString());
+        assertEquals("3,4:31-3,8:35", p.endSourceRange().toString());
+        assertEquals("2,14:20-2,15:21=2,16:22-2,17:23", p.attributes().sourceRange("a").toString());
+        assertEquals("2,18:24-3,4:31", text.sourceRange().toString());
+    }
+
     @Test void tracksExplicitAndImplicitBodyHtml() {
         // Tests that </body></html> tokens are tracked when present
         String htmlSans = "<body><a>Link</a>";

--- a/src/test/java/org/jsoup/parser/StreamParserTest.java
+++ b/src/test/java/org/jsoup/parser/StreamParserTest.java
@@ -484,4 +484,17 @@ class StreamParserTest {
         }
     }
 
+    @Test
+    void emitsNoscriptFallbackElements() {
+        String html = "<body><noscript><p>one</p><p>two</p></noscript><p>after</p>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            StringBuilder seen = new StringBuilder();
+            parser.stream().forEachOrdered(el -> {
+                if (el.normalName().equals("p"))
+                    trackSeen(el, seen);
+            });
+            assertEquals("p[one]+;p[two];p[after];", seen.toString());
+        }
+    }
+
 }

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -428,6 +428,20 @@ public class CleanerTest {
         assertEquals(0, cleanDoc.body().childNodeSize());
     }
 
+    @Test public void dropsScriptInsideNoscriptFallback() {
+        String[] inputs = {
+            "<noscript><script alert='xss'></noscript>",
+            "<noscript><script>alert(1)</script></noscript>",
+            "<noscript><script><p>x</p></script></noscript>"
+        };
+
+        for (String dirty : inputs) {
+            assertEquals("", Jsoup.clean(dirty, Safelist.basic()));
+            assertEquals("", Jsoup.clean(dirty, Safelist.relaxed()));
+            assertFalse(Jsoup.isValid(dirty, Safelist.relaxed()));
+        }
+    }
+
     @Test public void cleansInternationalText() {
         assertEquals("привет", Jsoup.clean("привет", Safelist.none()));
     }


### PR DESCRIPTION
This changes how jsoup parses `<noscript>` content.

The HTML specification defines two behaviours depending on whether scripting is enabled, but neither is especially useful for jsoup.

When scripting is enabled, the contents are parsed as text, making fallback markup opaque to callers:

```html
<noscript><img src="//example.com/1x1.gif"></noscript>
```

When scripting is disabled, the contents are parsed as normal HTML.
That makes the elements inspectable, but their parsing rules can affect the surrounding document.
For example, an element that is not permitted in the document head can move the parser into the body, causing subsequent head content to be misplaced.

Historically, jsoup used a mixture of these behaviours: `<noscript>` content in the head was treated as text, while content in the body was parsed into the DOM.

This change instead treats `<noscript>` as a parsing island.
Its fallback markup is parsed into an inspectable DOM subtree, while malformed or context-sensitive markup inside it cannot disrupt the structure outside the `<noscript>` element.

This gives callers a representation closer to the source markup without requiring them to account for the specification’s scripting modes.
The result also round-trip serializes without allowing parsing state from the fallback content to escape into the surrounding document.

This is an intentional deviation from the HTML specification.
Callers with site-specific `<noscript>` handling, or code that works around jsoup’s previous head/body behaviour, should review how the resulting DOM is used.

Relevant specification sections:

- [The `noscript` element](https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element)
- [HTML parsing and tokenization](https://html.spec.whatwg.org/multipage/parsing.html#tokenization)