### PR TITLE
Improve content-type matching to handle case-insensitivity and correctly support structured `+xml` suffixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)
-* Fixed HTTP response content-type matching to handle media types case-insensitively and recognize structured `+xml` suffixes, including vendor-specific media types.
+* Fixed HTTP response content-type matching to handle media types case-insensitively and recognize structured `+xml` suffixes, including vendor-specific media types. [#2550](https://github.com/jhy/jsoup/pull/2550)
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)
+* Fixed HTTP response content-type matching to handle media types case-insensitively and recognize structured `+xml` suffixes, including vendor-specific media types.
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -849,10 +849,9 @@ public class HttpConnection implements Connection {
         private int numRedirects = 0;
         private final HttpConnection.Request req;
 
-        /*
-         * Matches XML content types (like text/xml, image/svg+xml, application/xhtml+xml;charset=UTF8, etc)
-         */
-        private static final Pattern xmlContentTypeRxp = Pattern.compile("(\\w+)/\\w*\\+?xml.*");
+        // matches XML content types: */xml, */xml-*, and */*+xml
+        private static final Pattern xmlContentTypeRxp = Pattern.compile(
+            "^[^/;]+/(?:xml(?:-[^/;]+)?|[^/;]+\\+xml)(?:\\s*;.*)?$", Pattern.CASE_INSENSITIVE);
 
         /**
          <b>Internal only! </b>Creates a dummy HttpConnection.Response, useful for testing. All actual responses
@@ -960,16 +959,19 @@ public class HttpConnection implements Connection {
 
                 // check that we can handle the returned content type; if not, abort before fetching it
                 String contentType = res.contentType();
+                boolean isText = contentType != null && contentType.regionMatches(true, 0, "text/", 0, 5);
+                boolean isXml = contentType != null && xmlContentTypeRxp.matcher(contentType).matches();
+
                 if (contentType != null
                         && !req.ignoreContentType()
-                        && !contentType.startsWith("text/")
-                        && !xmlContentTypeRxp.matcher(contentType).matches()
+                        && !isText
+                        && !isXml
                         )
-                    throw new UnsupportedMimeTypeException("Unhandled content type. Must be text/*, */xml, or */*+xml",
+                    throw new UnsupportedMimeTypeException("Unhandled content type. Must be a text or XML media type",
                             contentType, req.url().toString());
 
                 // switch to the XML parser if content type is xml and not parser not explicitly set
-                if (contentType != null && xmlContentTypeRxp.matcher(contentType).matches()) {
+                if (isXml) {
                     if (!req.parserDefined) req.parser(Parser.xmlParser());
                 }
 

--- a/src/test/java/org/jsoup/integration/ConnectTest.java
+++ b/src/test/java/org/jsoup/integration/ConnectTest.java
@@ -798,15 +798,40 @@ public class ConnectTest {
         Connection con = Jsoup.connect(origin().file.url("/htmltests/thumb.jpg"));
         con.data(FileRoute.ContentTypeParam, "image/jpeg");
 
-        boolean threw = false;
-        try {
-            con.execute();
-            Document doc = con.response().parse();
-        } catch (UnsupportedMimeTypeException e) {
-            threw = true;
-            assertEquals("Unhandled content type. Must be text/*, */xml, or */*+xml", e.getMessage());
-        }
-        assertTrue(threw);
+        UnsupportedMimeTypeException exception = assertThrows(UnsupportedMimeTypeException.class, con::execute);
+        assertEquals("Unhandled content type. Must be a text or XML media type", exception.getMessage());
+    }
+
+    @Test public void textContentTypesAreMatchedCaseInsensitively() throws IOException {
+        String contentType = "Text/HTML; charset=UTF-8";
+        Connection con = Jsoup.connect(origin().file.url("/htmltests/medium.html"))
+            .data(FileRoute.ContentTypeParam, contentType);
+
+        Document doc = con.get();
+
+        assertEquals("Medium HTML", doc.title());
+        assertEquals(contentType, con.response().contentType());
+    }
+
+    @Test public void xmlSuffixAllowsRegisteredSubtypeCharacters() throws IOException {
+        String contentType = "Application/Vnd.Example+XML; charset=UTF-8";
+        Connection con = Jsoup.connect(origin().file.url("/htmltests/xml-test.xml"))
+            .data(FileRoute.ContentTypeParam, contentType);
+
+        Document doc = con.get();
+
+        assertInstanceOf(XmlTreeBuilder.class, doc.parser().getTreeBuilder());
+        assertEquals(contentType, con.response().contentType());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"application/notxml", "application/xmlish", "application/foo+xmlish"})
+    public void rejectsXmlLikeContentTypes(String contentType) {
+        Connection con = Jsoup.connect(origin().file.url("/htmltests/xml-test.xml"))
+            .data(FileRoute.ContentTypeParam, contentType);
+
+        UnsupportedMimeTypeException exception = assertThrows(UnsupportedMimeTypeException.class, con::execute);
+        assertEquals("Unhandled content type. Must be a text or XML media type", exception.getMessage());
     }
 
     @Test public void testParseRss() throws IOException {
@@ -934,7 +959,16 @@ public class ConnectTest {
 
     @Test
     public void fetchHandlesXml() throws IOException {
-        String[] types = {"text/xml", "application/xml", "application/rss+xml", "application/xhtml+xml"};
+        String[] types = {
+            "text/xml",
+            "application/xml",
+            "image/xml",
+            "application/xml-external-parsed-entity",
+            "text/xml-external-parsed-entity",
+            "application/xml-dtd",
+            "application/rss+xml",
+            "application/xhtml+xml"
+        };
         for (String type : types) {
             fetchHandlesXml(type);
         }


### PR DESCRIPTION
HTTP media type names are case-insensitive, but jsoup previously rejected responses such as `Text/HTML; charset=UTF-8`.

The XML matcher also rejected structured media types containing registered subtype characters, such as `application/vnd.example+xml`, while incorrectly treating values such as `application/notxml` and `application/xmlish` as XML.

This updates the matching to support case-insensitive text and XML types, exact and legacy `xml-*` types, and structured `+xml` suffixes.