### PR TITLE
Make progressive StreamParser selections emission-aware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 1.23.2 (pending)
 
+### Improvements
+* Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery.
+
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## 1.23.2 (pending)
 
 ### Improvements
-* Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery.
+* Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery. [#2551](https://github.com/jhy/jsoup/pull/2551)
 
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)

--- a/src/main/java/org/jsoup/parser/StreamParser.java
+++ b/src/main/java/org/jsoup/parser/StreamParser.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UncheckedIOException;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -166,9 +167,11 @@ public class StreamParser implements Closeable {
      Closes the input and releases resources including the underlying parser and reader.
      <p>The parser will also be closed when the input is fully read.</p>
      <p>The parser can be reused with another call to {@link #parse(Reader, String)}.</p>
-     */
+    */
     @Override public void close() {
-        treeBuilder.completeParse(); // closes the reader, frees resources
+        it.deferOpenElements();
+        stopped = true;
+        treeBuilder.closeParse(); // closes the reader, frees resources
     }
 
     /**
@@ -207,7 +210,7 @@ public class StreamParser implements Closeable {
 
     /**
      Finds the first Element that matches the provided query. If the parsed Document does not already have a match, the
-     input will be parsed until the first match is found, or the input is completely read.
+     input will be parsed until the first match is ready for stream emission, or the input is completely read.
      @param query the {@link org.jsoup.select.Selector} query.
      @return the first matching {@link Element}, or {@code null} if there's no match
      @throws IOException if an I/O error occurs
@@ -235,8 +238,8 @@ public class StreamParser implements Closeable {
 
     /**
      Finds the first Element that matches the provided query. If the parsed Document does not already have a match, the
-     input will be parsed until the first match is found, or the input is completely read.
-     <p>By providing a compiled evaluator vs a CSS selector, this method may be more efficient when executing the same
+     input will be parsed until the first match is ready for stream emission, or the input is completely read.
+     <p>By providing a compiled evaluator vs. a CSS selector, this method may be more efficient when executing the same
      query against multiple documents.</p>
      @param eval the {@link org.jsoup.select.Selector} evaluator.
      @return the first matching {@link Element}, or {@code null} if there's no match
@@ -246,11 +249,26 @@ public class StreamParser implements Closeable {
     public @Nullable Element selectFirst(Evaluator eval) throws IOException {
         final Document doc = document();
 
-        // run the query on the existing (partial) doc first, as there may be a hit already parsed
+        // a ready match can be returned without advancing the iterator
         Element first = doc.selectFirst(eval);
-        if (first != null) return first;
+        if (first != null && it.isPending(first)) {
+            if (!it.awaitReady(first)) return null;
+            first = doc.selectFirst(eval);
+        }
+        if (first != null && !it.isPending(first)) return first;
 
-        return selectNext(eval);
+        // use the iterator for linear progress
+        Element emitted = selectNext(eval);
+        if (emitted == null) {
+            if (!treeBuilder.isComplete()) return null;
+            return doc.selectFirst(eval);
+        }
+
+        // reconcile the iterator's child-first emission order with document order
+        while ((first = doc.selectFirst(eval)) != null && it.isPending(first)) {
+            if (!it.awaitReady(first)) return null;
+        }
+        return first != null ? first : emitted;
     }
 
     /**
@@ -305,16 +323,54 @@ public class StreamParser implements Closeable {
     }
 
     final class ElementIterator implements Iterator<Element>, NodeVisitor {
-        // listeners add to a next emit queue, as a single token read step may yield multiple elements
-        final private Queue<Element> emitQueue = new LinkedList<>();
+        final private Queue<Element> emitQueue = new LinkedList<>(); // ready elements waiting for iterator delivery, in emission order
+        final private HashSet<Element> deferredEls = new HashSet<>(); // off-stack elements not yet ready for emission
         private @Nullable Element current;  // most recently emitted
         private @Nullable Element next;     // element waiting to be picked up
         private @Nullable Element tail;     // The last tailed element (</html>), on hold for final pop
 
         void reset() {
             emitQueue.clear();
+            deferredEls.clear();
             current = next = tail = null;
             stopped = false;
+        }
+
+        /** Defers open Elements before an early close releases the tree-builder stack. */
+        void deferOpenElements() {
+            treeBuilder.copyOpenElementsTo(deferredEls);
+        }
+
+        /** Tests whether an Element has reached its iterator emission point. */
+        boolean isReady(Element element) {
+            return current == element || next == element || emitQueue.contains(element);
+        }
+
+        /** Tests whether an Element still needs parser advancement before selection. */
+        boolean isPending(Element element) {
+            // the document is pending until EOF; other pending elements are open or explicitly deferred
+            return !treeBuilder.isComplete() &&
+                (element == treeBuilder.doc || treeBuilder.isOpen(element) || deferredEls.contains(element));
+        }
+
+        /** Advances parsing until an Element is ready; returns false if parsing was stopped. */
+        boolean awaitReady(Element element) throws IOException {
+            try {
+                while (isPending(element) && !stopped) {
+                    if (!hasNext()) break;
+                    if (isPending(element)) next(); // hasNext may have buffered the target itself
+                }
+                return !isPending(element);
+            } catch (UncheckedIOException e) {
+                // preserve the checked I/O contract when iterator advancement reads input
+                throw e.getCause();
+            }
+        }
+
+        /** Marks an Element ready and queues it for iterator emission. */
+        void queueForEmission(Element element) {
+            deferredEls.remove(element);
+            emitQueue.add(element);
         }
 
         // Iterator Interface:
@@ -355,11 +411,11 @@ public class StreamParser implements Closeable {
                     return;
                 }
             }
-            stop();
             close();
 
             // send the final element out:
             if (tail != null) {
+                deferredEls.remove(tail);
                 next = tail;
                 tail = null;
             }
@@ -375,15 +431,20 @@ public class StreamParser implements Closeable {
             if (node instanceof Element) {
                 Element prev = node.previousElementSibling();
                 // We prefer to wait until an element has a next sibling before emitting it; otherwise, get it in tail
-                if (prev != null) emitQueue.add(prev);
+                if (prev != null) {
+                    queueForEmission(prev);
+                    if (tail == prev) tail = null; // queueing marks it ready
+                }
             }
         }
 
         @Override public void tail(Node node, int depth) {
             if (node instanceof Element) {
                 tail = (Element) node; // kept for final hit
+                if (!isReady(tail)) deferredEls.add(tail);
                 Element lastChild = tail.lastElementChild(); // won't get a nextsib, so emit that:
-                if (lastChild != null) emitQueue.add(lastChild);
+                if (lastChild != null) queueForEmission(lastChild);
+                if (tail == treeBuilder.doc) deferredEls.clear(); // completed document makes stale recovery state irrelevant
             }
         }
     }

--- a/src/main/java/org/jsoup/parser/TreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilder.java
@@ -12,6 +12,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static org.jsoup.parser.Parser.NamespaceHtml;
@@ -24,7 +25,7 @@ abstract class TreeBuilder {
     CharacterReader reader;
     Tokeniser tokeniser;
     Document doc; // current doc we are building into
-    ArrayList<Element> stack; // the stack of open elements
+    final ArrayList<Element> stack = new ArrayList<>(); // open elements; reused and trimmed between parses
     String baseUri; // current base uri, for creating new elements
     Token currentToken; // currentToken is used for error and source position tracking. Null at start of fragment parse
     ParseSettings settings;
@@ -37,6 +38,7 @@ abstract class TreeBuilder {
 
     boolean trackSourceRange; // optionally tracks source ranges of nodes and attributes
     @Nullable LineMap lineMap; // shared line map for retained source ranges
+    private boolean parseComplete; // true only after EOF has closed the document
 
     void initialiseParse(Reader input, String baseUri, Parser parser) {
         Validate.notNullParam(input, "input");
@@ -53,7 +55,9 @@ abstract class TreeBuilder {
         lineMap = trackSourceRange ? reader.lineMap() : null;
         if (parser.isTrackErrors()) parser.getErrors().clear();
         tokeniser = new Tokeniser(this);
-        stack = new ArrayList<>(32);
+        stack.clear();
+        stack.ensureCapacity(32);
+        parseComplete = false;
         tagSet = parser.tagSet();
         start = new Token.StartTag(this);
         currentToken = start; // init current token to the virtual start token.
@@ -61,7 +65,8 @@ abstract class TreeBuilder {
         onNodeInserted(doc);
     }
 
-    void completeParse() {
+    /** Closes the current input and releases parse resources without changing whether EOF was reached. */
+    void closeParse() {
         // tidy up - as the Parser and Treebuilder are retained in document for settings / fragments
         if (reader == null) return;
         if (lineMap != null) lineMap.complete();
@@ -69,7 +74,8 @@ abstract class TreeBuilder {
         reader = null;
         lineMap = null;
         tokeniser = null;
-        stack = null;
+        stack.clear();
+        stack.trimToSize();
     }
 
     Document parse(Reader input, String baseUri, Parser parser) {
@@ -104,17 +110,17 @@ abstract class TreeBuilder {
 
     void runParser() {
         do {} while (stepParser()); // run until stepParser sees EOF
-        completeParse();
+        closeParse();
     }
 
     boolean stepParser() {
+        if (parseComplete) return false;
+
         // if we have reached the end already, step by popping off the stack, to hit nodeRemoved callbacks:
         if (currentToken.type == Token.TokenType.EOF) {
-            if (stack == null) {
-                return false;
-            } if (stack.isEmpty()) {
+            if (stack.isEmpty()) {
                 onNodeClosed(doc); // the root doc is not on the stack, so let this final step close it
-                stack = null;
+                parseComplete = true;
                 return true;
             }
             pop();
@@ -125,6 +131,21 @@ abstract class TreeBuilder {
         process(token);
         token.reset();
         return true;
+    }
+
+    /** Return if we have reached EOF and completed the document tree. */
+    boolean isComplete() {
+        return parseComplete;
+    }
+
+    /** Check if the given Element is currently on the stack of open elements. */
+    boolean isOpen(Element element) {
+        return stack.contains(element);
+    }
+
+    /** Copies the currently open elements before a caller-initiated close clears the parser stack. */
+    void copyOpenElementsTo(Collection<? super Element> elements) {
+        elements.addAll(stack);
     }
 
     abstract boolean process(Token token);

--- a/src/test/java/org/jsoup/parser/HtmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlTreeBuilderTest.java
@@ -6,7 +6,10 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.jsoup.parser.Parser.NamespaceHtml;
@@ -50,6 +53,33 @@ public class HtmlTreeBuilderTest {
 
         // would need to rework this if/when that annotation moves from the method to the class / package.
         assertTrue(seen);
+    }
+
+    @Test void tracksParseLifecycle() throws IOException {
+        Parser parser = Parser.htmlParser();
+        TreeBuilder treeBuilder = parser.getTreeBuilder();
+        assertFalse(treeBuilder.isComplete());
+
+        try (StreamParser streamParser = new StreamParser(parser).parse("<title>One</title><p id=hit>Full</p>", "")) {
+            streamParser.expectFirst("title");
+            Element open = streamParser.document().expectFirst("#hit");
+            assertTrue(treeBuilder.isOpen(open));
+
+            List<Element> openElements = new ArrayList<>();
+            treeBuilder.copyOpenElementsTo(openElements);
+            assertTrue(openElements.contains(open));
+
+            // closing before EOF releases the open stack without marking the document complete
+            streamParser.close();
+            assertTrue(treeBuilder.stack.isEmpty());
+            assertFalse(treeBuilder.isComplete());
+
+            streamParser.parse("<p>Complete</p>", "");
+            assertFalse(treeBuilder.isComplete());
+            streamParser.complete();
+            assertTrue(treeBuilder.stack.isEmpty());
+            assertTrue(treeBuilder.isComplete());
+        }
     }
 
     @Test void isSpecial() {

--- a/src/test/java/org/jsoup/parser/StreamParserTest.java
+++ b/src/test/java/org/jsoup/parser/StreamParserTest.java
@@ -5,10 +5,13 @@ import org.jsoup.Jsoup;
 import org.jsoup.helper.DataUtil;
 import org.jsoup.integration.ParseTest;
 import org.jsoup.integration.TestServer;
+import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
+import org.jsoup.select.Evaluator;
 import org.jsoup.select.Elements;
+import org.jsoup.select.Selector;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -17,11 +20,13 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -93,7 +98,7 @@ class StreamParserTest {
 
     @Test void canStopAndCompleteAndReuse() throws IOException {
         StreamParser parser = new StreamParser(Parser.htmlParser());
-        String html1 = "<p>One<p>Two";
+        String html1 = "<p id=one>One<p id=two>Two";
         parser.parse(html1, "");
 
         Element p = parser.expectFirst("p");
@@ -106,6 +111,7 @@ class StreamParserTest {
 
         Element p2 = parser.selectNext("p");
         assertNull(p2);
+        assertNull(parser.selectFirst("p + p")); // a stopped parse exposes only complete matches
 
         Document completed = parser.complete();
         Elements ps = completed.select("p");
@@ -113,10 +119,27 @@ class StreamParserTest {
         assertEquals("One", ps.get(0).text());
         assertEquals("Two", ps.get(1).text());
 
+        // complete() makes the whole document selectable, even though stop() still suppresses iterator emission
+        Element completedP2 = parser.selectFirst("#two");
+        assertSame(ps.get(1), completedP2);
+
         // can reuse
         parser.parse("<div>DIV", "");
         Element div = parser.expectFirst("div");
         assertEquals("DIV", div.text());
+    }
+
+    @Test void closeKeepsOpenMatchesUnavailable() throws IOException {
+        String html = "<title>One</title><p id=hit>Full</p>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            Element title = parser.expectFirst("title");
+            parser.stop();
+            parser.close();
+
+            // completed matches remain selectable while an open match stays unavailable after close
+            assertSame(title, parser.selectFirst("title"));
+            assertNull(parser.selectFirst("#hit"));
+        }
     }
 
     static void trackSeen(Element el, StringBuilder actual) {
@@ -155,8 +178,221 @@ class StreamParserTest {
         Element p2 = parser.expectNext("p");
         assertEquals("P Two", p2.text());
 
+        Element p1Again = parser.selectFirst("#1");
+        assertSame(p1, p1Again); // can reselect an earlier element after later elements were emitted
+
         Element pNone = parser.selectNext("p");
         assertNull(pNone);
+    }
+
+    @Test void selectFirstWaitsForLookaheadElement() throws IOException {
+        String html = "<title>One</title><p id=hit>Full</p><p>After</p>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            parser.expectFirst("title");
+
+            // the second selection advances the provisional paragraph before returning it
+            Element hit = parser.expectFirst("#hit");
+            assertEquals("Full", hit.text());
+            Element next = hit.nextElementSibling();
+            assertNotNull(next);
+            assertEquals("p", next.normalName());
+        }
+    }
+
+    @Test void selectFirstWaitsForOpenQueuedElement() throws IOException {
+        String html = "<form><em id=hit></form>x</em>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            // form-stack correction must not expose the formatting element before its later text is parsed
+            Element hit = parser.expectFirst("#hit");
+            assertEquals("x", hit.text());
+        }
+    }
+
+    @Test void selectFirstCompletesDocumentRoot() throws IOException {
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse("<p>Full</p>", "")) {
+            // the document root becomes selectable with the same complete contents as its final iterator emission
+            Element root = parser.expectFirst("*");
+            assertSame(parser.document(), root);
+            assertEquals("Full", root.text());
+        }
+    }
+
+    @Test void selectFirstKeepsDocumentOrderForNestedMatches() throws IOException {
+        String html = "<title>One</title><div id=outer class=hit><div id=inner class=hit>Inner</div>Tail</div><p>After</p>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            parser.expectFirst("title");
+
+            Element hit = parser.expectFirst(".hit");
+            assertEquals("outer", hit.id());
+            assertEquals("Inner Tail", hit.text());
+        }
+    }
+
+    @Test void selectFirstKeepsDocumentOrderWhenParsingToMatch() throws IOException {
+        String html = "<div id=outer class=hit><div id=inner class=hit>Inner</div></div><p>After</p>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            // the document-first outer match wins over the child emitted first by the iterator
+            Element hit = parser.expectFirst(".hit");
+            assertEquals("outer", hit.id());
+            assertEquals("Inner", hit.text());
+        }
+    }
+
+    @Test void selectFirstKeepsDocumentOrderAfterTransientMatch() throws IOException {
+        String html = "<title>One</title><p>Full</p><div id=outer class=hit><div id=inner class=hit>Inner</div></div>" +
+            "<p>After</p><aside id=unread>Unread</aside>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            parser.expectFirst("title");
+
+            // the replacement outer match wins after the provisional empty paragraph stops matching
+            Element hit = parser.expectFirst("p:empty, .hit");
+            assertEquals("outer", hit.id());
+            assertEquals("Inner", hit.text());
+            assertNull(parser.document().selectFirst("#unread")); // later input remains unparsed
+        }
+    }
+
+    @Test void selectFirstRechecksLookaheadMatchAfterEmission() throws IOException {
+        String html = "<title>One</title><p id=filled>Full</p><p id=empty></p><p>After</p>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            parser.expectFirst("title");
+
+            Element hit = parser.expectFirst("p:empty");
+            assertEquals("empty", hit.id());
+        }
+    }
+
+    @Test void selectFirstDoesNotRescanTransientLookaheads() throws IOException {
+        int paragraphCount = 200;
+        StringBuilder html = new StringBuilder("<title>One</title>");
+        for (int i = 0; i < paragraphCount; i++)
+            html.append("<p>Filled</p>");
+        html.append("<p id=empty></p><div>After</div>");
+
+        Evaluator emptyParagraph = Selector.evaluatorOf("p:empty");
+        AtomicInteger evaluations = new AtomicInteger();
+        Evaluator countingEvaluator = new Evaluator() {
+            @Override public boolean matches(Element root, Element element) {
+                evaluations.incrementAndGet();
+                return emptyParagraph.matches(root, element);
+            }
+        };
+
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html.toString(), "")) {
+            parser.expectFirst("title");
+
+            Element hit = parser.selectFirst(countingEvaluator);
+            assertNotNull(hit);
+            assertEquals("empty", hit.id());
+            // make sure transient p:empty matches are not rescanned quadratically
+            assertTrue(evaluations.get() < paragraphCount * 3, "evaluations: " + evaluations.get());
+        }
+    }
+
+    @Test void selectFirstFindsFosterParentedElementThatIsNotEmitted() throws IOException {
+        String html = "<table><b id=hit>T<div>T";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            parser.expectNext("head");
+            parser.expectNext("div");
+
+            // the completed tree makes the foster-parented match selectable
+            Element hit = parser.expectFirst("#hit");
+            assertEquals("b", hit.normalName());
+            assertEquals("T T", hit.text());
+        }
+    }
+
+    @Test void selectFirstRechecksCompletedDocumentAfterIteratorFallback() throws IOException {
+        String html = "<p id=pre>pre</p><table><b id=hit>T<div>T";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            parser.expectFirst("#pre");
+
+            // the completed document supplies a foster-parented match that was not emitted by the iterator
+            Element hit = parser.expectFirst("#hit");
+            assertEquals("b", hit.normalName());
+            assertEquals("T T", hit.text());
+        }
+    }
+
+    @Test void selectFirstDoesNotConsumeBufferedMatch() throws IOException {
+        String html = "<p>One</p><p>Two</p>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            Iterator<Element> iterator = parser.iterator();
+            assertTrue(iterator.hasNext());
+
+            // the complete head buffered by hasNext() remains the iterator's next element after selection
+            Element head = parser.expectFirst("head");
+            assertSame(head, iterator.next());
+        }
+    }
+
+    @Test void selectFirstDoesNotConsumeQueuedMatch() throws IOException {
+        String html = "<div><p><span>One</div><aside>After";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            parser.expectNext("head");
+            Iterator<Element> iterator = parser.iterator();
+            assertTrue(iterator.hasNext());
+            Element span = parser.document().selectFirst("span");
+            assertNotNull(span);
+            Element paragraph = parser.document().selectFirst("p");
+            assertNotNull(paragraph);
+
+            // the ready span remains next in iterator order after selecting the queued paragraph
+            Element selected = parser.expectFirst("p");
+            assertSame(paragraph, selected);
+            assertSame(span, iterator.next());
+        }
+    }
+
+    @Test void selectFirstWaitsForVoidElementEmission() throws IOException {
+        String html = "<title>One</title><img id=hit><p>After</p>";
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(html, "")) {
+            parser.expectFirst("title");
+
+            Element hit = parser.expectFirst("#hit");
+            Element next = hit.nextElementSibling();
+            assertNotNull(next);
+            assertEquals("p", next.normalName());
+        }
+    }
+
+    @Test void selectFirstWaitsForFragmentLookahead() throws IOException {
+        String html = "<tr id=one><td>One</td><tr id=two><td>Two</td>";
+        Element context = new Element("table");
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parseFragment(html, context, "")) {
+            parser.expectFirst("td");
+
+            Element row = parser.expectFirst("#two");
+            assertEquals("Two", row.text());
+        }
+    }
+
+    @Test void selectFirstUnwrapsReaderExceptionWhileCompletingLookahead() throws IOException {
+        String prefix = "<title>One</title><p id=hit>";
+        // selection preserves its checked IOException contract while advancing the pending match
+        String initialBuffer = prefix + StringUtil.padding(CharacterReader.BufferSize - prefix.length(), -1);
+        IOException expected = new IOException("read failed");
+        Reader reader = new Reader() {
+            boolean firstRead = true;
+
+            @Override public int read(char[] buffer, int offset, int length) throws IOException {
+                if (firstRead) {
+                    firstRead = false;
+                    initialBuffer.getChars(0, initialBuffer.length(), buffer, offset);
+                    return initialBuffer.length();
+                }
+                throw expected;
+            }
+
+            @Override public void close() { }
+        };
+
+        try (StreamParser parser = new StreamParser(Parser.htmlParser()).parse(reader, "")) {
+            parser.expectFirst("title");
+
+            IOException actual = assertThrows(IOException.class, () -> parser.selectFirst("#hit"));
+            assertSame(expected, actual);
+        }
     }
 
     @Test void canRemoveFromDom() {


### PR DESCRIPTION
`StreamParser` progressively builds a DOM and emits elements as they become ready, allowing large inputs to be processed without first parsing the whole document.

`selectFirst(...)` searches the document built so far. If it does not find a match there, it continues by running the parser until a matching element reaches its normal stream-emission point.

Given:

```html
<title>One</title><p id=hit>Full</p><p>Next</p>
```

calling `selectFirst("#hit")` directly already returned the complete paragraph:

```html
<p id="hit">Full</p>
```

Consecutive selections, however, could return an incomplete result:

```java
Element title = parser.selectFirst("title");
Element hit = parser.selectFirst("#hit");
```

Emitting `title` advances the parser far enough to create the following paragraph as lookahead, but not to parse its contents. The second selection found that paragraph in the progressive document and treated its presence as readiness, returning:

```html
<p id="hit"></p>
```

`selectFirst(...)` now advances the provisional match to that emission point and returns:

```html
<p id="hit">Full</p>
```

Consecutive selections may consume slightly more input before returning, but callers receive the match with its parsed contents without switching to `selectNext(...)` or completing the document. Later input remains unparsed until needed.

---

As background: HTML parsing does not construct the DOM in simple start-tag order.

The tree builder creates and closes implicit elements, foster-parents malformed table content, reconstructs formatting elements, and can change node parentage as input arrives. StreamParser’s iterator accommodates this by emitting children before their parents and, where applicable, retaining an element until its next sibling is known.

Consequently, `selectFirst(...)` cannot simply return the first match currently present in the progressive document. It also cannot just return the first iterator match because iterator emission order is not always document order.

Selectors such as `:empty` add another wrinkle because an element can match provisionally and stop matching as its contents arrive.

---

Readiness is now derived from TreeBuilder’s explicit open-element and completion state together with StreamParser’s iterator state.

`selectFirst(...)` now follows three stages:

1. Search the progressive document and advance an existing provisional match if necessary.
2. Use the iterator to make linear progress until a ready match is emitted.
3. Reconcile the emitted match with the progressive document, waiting on the current document-first pending candidate where necessary.

Pathological malformed input can cause HTML recovery algorithms to reparent an open descendant beneath an element that previously appeared ready. Proving that a subtree can never change would require parsing the entire remaining input, defeating StreamParser’s purpose.

This change therefore retains StreamParser’s normal emission point as its practical readiness boundary. It improves progressive selection without turning `selectFirst(...)` into an implicit full-document parse.
