### PR TITLE
Form encode CR and LF in multipart field names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)
 * Fixed HTTP response content-type matching to handle media types case-insensitively and recognize structured `+xml` suffixes, including vendor-specific media types. [#2550](https://github.com/jhy/jsoup/pull/2550)
-* Corrected multipart form encoding to percent-escape CR and LF in field names and filenames, matching the HTML form submission specification. Multipart file content-types containing CR or LF are now rejected with a `ValidationException`.
+* Corrected multipart form encoding to percent-escape CR and LF in field names and filenames, matching the HTML form submission specification. Multipart file content-types containing CR or LF are now rejected with a `ValidationException`. [#2555](https://github.com/jhy/jsoup/pull/2555)
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)
 * Fixed HTTP response content-type matching to handle media types case-insensitively and recognize structured `+xml` suffixes, including vendor-specific media types. [#2550](https://github.com/jhy/jsoup/pull/2550)
+* Corrected multipart form encoding to percent-escape CR and LF in field names and filenames, matching the HTML form submission specification. Multipart file content-types containing CR or LF are now rejected with a `ValidationException`.
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -116,8 +116,16 @@ public class HttpConnection implements Connection {
         req = new Request(copy);
     }
 
+    /** Encodes a multipart field name or filename so it stays within its quoted header value. */
     static String encodeMimeName(String val) {
-        return val.replace("\"", "%22");
+        return val.replace("\"", "%22").replace("\r", "%0D").replace("\n", "%0A");
+    }
+
+    /** Validates that a multipart content-type cannot introduce another header line. */
+    private static void validateMimeContentType(String contentType) {
+        Validate.notEmptyParam(contentType, "contentType");
+        Validate.isFalse(contentType.indexOf('\r') != -1 || contentType.indexOf('\n') != -1,
+            "The 'contentType' parameter must not contain CR or LF.");
     }
 
     @Override
@@ -1330,6 +1338,8 @@ public class HttpConnection implements Connection {
                         w.write(encodeMimeName(keyVal.value()));
                         w.write("\"\r\nContent-Type: ");
                         String contentType = keyVal.contentType();
+                        if (contentType != null)
+                            validateMimeContentType(contentType);
                         w.write(contentType != null ? contentType : DefaultUploadType);
                         w.write("\r\n\r\n");
                         w.flush();
@@ -1453,7 +1463,7 @@ public class HttpConnection implements Connection {
 
         @Override
         public Connection.KeyVal contentType(String contentType) {
-            Validate.notEmpty(contentType);
+            validateMimeContentType(contentType);
             this.contentType = contentType;
             return this;
         }

--- a/src/test/java/org/jsoup/helper/HttpConnectionTest.java
+++ b/src/test/java/org/jsoup/helper/HttpConnectionTest.java
@@ -475,4 +475,15 @@ public class HttpConnectionTest {
         assertEquals(input, fixHeaderEncoding(input));
         assertEquals(input, fixHeaderEncoding(mojibake(input)));
     }
+
+    @Test void mimeNameEscapesQuotesAndNewlines() {
+        assertEquals("field%22name%0D%0Afile", HttpConnection.encodeMimeName("field\"name\r\nfile"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/plain\rX-Test: yes", "text/plain\nX-Test: yes"})
+    void mimeContentTypeRejectsNewlines(String contentType) {
+        assertThrows(ValidationException.class, () ->
+                HttpConnection.KeyVal.create("file", "file.txt").contentType(contentType));
+    }
 }


### PR DESCRIPTION
Corrected multipart form encoding to percent-escape CR and LF in field names and filenames, matching the HTML form submission specification. Multipart file content-types containing CR or LF are now rejected with a `ValidationException`.