### PR TITLE
Optimize XML namespace scope tracking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 * Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery. [#2551](https://github.com/jhy/jsoup/pull/2551)
+* Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope.
 
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 * Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery. [#2551](https://github.com/jhy/jsoup/pull/2551)
-* Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope.
+* Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope. [#2556](https://github.com/jhy/jsoup/pull/2556)
 
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -37,7 +37,31 @@ import static org.jsoup.parser.Parser.NamespaceXml;
 public class XmlTreeBuilder extends TreeBuilder {
     static final String XmlnsKey = "xmlns";
     static final String XmlnsPrefix = "xmlns:";
-    private final ArrayDeque<HashMap<String, String>> namespacesStack = new ArrayDeque<>(); // stack of namespaces, prefix => urn
+    private static final NamespaceChange ScopeMarker = new NamespaceChange("", null);
+    final HashMap<String, String> namespaceBindings = new HashMap<>();
+    final ArrayDeque<NamespaceChange> namespaceChanges = new ArrayDeque<>();
+
+    /**
+     Tracks namespace binding changes within element scopes. Each scope starts with a shared marker, followed by a
+     change record for each namespace declaration. When the scope closes, the change records are applied in reverse to
+     restore the parent bindings.
+     */
+    private static final class NamespaceChange {
+        private final String prefix;
+        private final @Nullable String previousValue;
+
+        /** Creates a namespace change; a null previous value means the prefix was previously unbound. */
+        private NamespaceChange(String prefix, @Nullable String previousValue) {
+            this.prefix = prefix;
+            this.previousValue = previousValue;
+        }
+
+        /** Restores the binding that was active before this change. */
+        private void restore(Map<String, String> namespaceBindings) {
+            if (previousValue == null) namespaceBindings.remove(prefix);
+            else namespaceBindings.put(prefix, previousValue);
+        }
+    }
 
     @Override ParseSettings defaultSettings() {
         return ParseSettings.preserveCase;
@@ -51,11 +75,10 @@ public class XmlTreeBuilder extends TreeBuilder {
             .escapeMode(Entities.EscapeMode.xhtml)
             .prettyPrint(false); // as XML, we don't understand what whitespace is significant or not
 
-        namespacesStack.clear();
-        HashMap<String, String> ns = new HashMap<>();
-        ns.put("xml", NamespaceXml);
-        ns.put("", NamespaceXml);
-        namespacesStack.push(ns);
+        namespaceBindings.clear();
+        namespaceChanges.clear();
+        namespaceBindings.put("xml", NamespaceXml);
+        namespaceBindings.put("", NamespaceXml);
     }
 
     @Override
@@ -67,15 +90,13 @@ public class XmlTreeBuilder extends TreeBuilder {
         TokeniserState textState = context.tag().textState();
         if (textState != null) tokeniser.transition(textState);
 
-        // reconstitute the namespace stack by traversing the element and its parents (top down)
+        // establish the fragment's base namespace scope from the context and its ancestors, top down
         Elements chain = context.parents();
         chain.add(0, context);
         for (int i = chain.size() - 1; i >= 0; i--) {
             Element el = chain.get(i);
-            HashMap<String, String> namespaces = new HashMap<>(namespacesStack.peek());
-            namespacesStack.push(namespaces);
             if (el.attributesSize() > 0) {
-                processNamespaces(el.attributes(), namespaces);
+                applyNamespaceDeclarations(el.attributes());
             }
         }
     }
@@ -144,23 +165,23 @@ public class XmlTreeBuilder extends TreeBuilder {
     }
 
     void insertElementFor(Token.StartTag startTag) {
-        // handle namespace for tag
-        HashMap<String, String> namespaces = new HashMap<>(namespacesStack.peek());
-        namespacesStack.push(namespaces);
-
         Attributes attributes = startTag.attributes;
         if (attributes != null) {
             settings.normalizeAttributes(attributes);
             attributes.deduplicate(settings);
-            processNamespaces(attributes, namespaces);
-            applyNamespacesToAttributes(attributes, namespaces);
-            startTag.finaliseAttributeRanges(settings);
         }
 
         enforceStackDepthLimit();
+        namespaceChanges.push(ScopeMarker);
+
+        if (attributes != null) {
+            applyNamespaceDeclarations(attributes);
+            applyNamespacesToAttributes(attributes);
+            startTag.finaliseAttributeRanges(settings);
+        }
 
         String tagName = startTag.tagName.value();
-        String ns = resolveNamespace(tagName, namespaces);
+        String ns = resolveNamespace(tagName);
         Tag tag = tagFor(tagName, startTag.normalName, ns, settings);
         Element el = new Element(tag, null, attributes);
         currentElement().appendChild(el);
@@ -177,28 +198,34 @@ public class XmlTreeBuilder extends TreeBuilder {
         }
     }
 
-    private static void processNamespaces(Attributes attributes, HashMap<String, String> namespaces) {
-        // process attributes for namespaces (xmlns, xmlns:)
+    /** Applies namespace declarations and records changes within an element scope. */
+    private void applyNamespaceDeclarations(Attributes attributes) {
         for (Attribute attr : attributes) {
             String key = attr.getKey();
             String value = attr.getValue();
+            String prefix;
             if (key.equals(XmlnsKey)) {
-                namespaces.put("", value); // new default for this level
+                prefix = ""; // new default for this level
             } else if (key.startsWith(XmlnsPrefix)) {
-                String nsPrefix = key.substring(XmlnsPrefix.length());
-                namespaces.put(nsPrefix, value);
+                prefix = key.substring(XmlnsPrefix.length());
+            } else {
+                continue;
             }
+
+            String previousValue = namespaceBindings.put(prefix, value);
+            if (!namespaceChanges.isEmpty()) namespaceChanges.push(new NamespaceChange(prefix, previousValue));
         }
     }
 
-    private static void applyNamespacesToAttributes(Attributes attributes, HashMap<String, String> namespaces) {
-        // second pass, apply namespace to attributes. Collects them first then adds (as userData is an attribute)
+    /** Applies resolved namespace URIs to prefixed attributes. */
+    private void applyNamespacesToAttributes(Attributes attributes) {
+        // collect first, then add, as userData is stored as an attribute
         Map<String, String> attrPrefix = new HashMap<>();
         for (Attribute attr: attributes) {
             String prefix = attr.prefix();
             if (!prefix.isEmpty()) {
                 if (prefix.equals(XmlnsKey)) continue;
-                String ns = namespaces.get(prefix);
+                String ns = namespaceBindings.get(prefix);
                 if (ns != null) attrPrefix.put(SharedConstants.XmlnsAttr + prefix, ns);
             }
         }
@@ -206,15 +233,25 @@ public class XmlTreeBuilder extends TreeBuilder {
             attributes.userData(entry.getKey(), entry.getValue());
     }
 
-    private static String resolveNamespace(String tagName, HashMap<String, String> namespaces) {
-        String ns = namespaces.get("");
+    /** Resolves the namespace URI for a qualified tag name. */
+    private String resolveNamespace(String tagName) {
+        String ns = namespaceBindings.get("");
         int pos = tagName.indexOf(':');
         if (pos > 0) {
             String prefix = tagName.substring(0, pos);
-            if (namespaces.containsKey(prefix))
-                ns = namespaces.get(prefix);
+            if (namespaceBindings.containsKey(prefix))
+                ns = namespaceBindings.get(prefix);
         }
         return ns;
+    }
+
+    @Override
+    Element pop() {
+        NamespaceChange change;
+        while ((change = namespaceChanges.pop()) != ScopeMarker) {
+            change.restore(namespaceBindings);
+        }
+        return super.pop();
     }
 
     void insertLeafNode(LeafNode node) {
@@ -248,12 +285,6 @@ public class XmlTreeBuilder extends TreeBuilder {
         XmlDeclaration decl = new XmlDeclaration(token.name(), token.isDeclaration);
         if (token.attributes != null) decl.attributes().addAll(token.attributes);
         insertLeafNode(decl);
-    }
-
-    @Override
-    Element pop() {
-        namespacesStack.pop();
-        return super.pop();
     }
 
     /**

--- a/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -663,12 +664,21 @@ public class XmlTreeBuilderTest {
         assertEquals("", other.namespace());
     }
 
+    @Test void restoresNamespaceBindingsAfterNestedOverride() {
+        String xml = "<root xmlns:p='/one'><p:a/><inner xmlns:p='/two'><p:b/></inner><p:c/></root>";
+        Document doc = Jsoup.parse(xml, Parser.xmlParser());
+
+        assertEquals("/one", doc.expectFirst("p|a").tag().namespace());
+        assertEquals("/two", doc.expectFirst("p|b").tag().namespace());
+        assertEquals("/one", doc.expectFirst("p|c").tag().namespace());
+    }
+
     @Test void elementsViaAppendHtmlAreNamespaced() {
-        // tests that when elements / attributes are added via a fragment parse, they inherit the namespace stack, and can still override
+        // fragment parsing inherits the context namespace scope and may override it locally
         String xml = "<out xmlns='/out'><bk:book xmlns:bk='/books' xmlns:edi='/edi'><bk:title>Test</bk:title><li edi:foo='bar'></bk:book></out>";
         Document doc = Jsoup.parse(xml, Parser.xmlParser());
 
-        // insert some parsed xml, inherit bk and edi, and with an inner node override bk
+        // inherit bk and edi, then override bk within a nested scope
         Element book = doc.expectFirst("bk|book");
         book.append("<bk:content edi:foo=qux>Content</bk:content>");
 
@@ -680,14 +690,17 @@ public class XmlTreeBuilderTest {
         assertEquals("/books", content.tag().namespace());
         assertEquals("/edi", content.attribute("edi:foo").namespace());
 
-        content.append("<data>Data</data><html xmlns='/html' xmlns:bk='/update'><p>Foo</p><bk:news>News</bk:news></html>");
-        // p should be in /html, news in /update
+        content.append("<data>Data</data><html xmlns='/html' xmlns:bk='/update'><p>Foo</p><bk:news>News</bk:news></html><bk:after edi:foo='after'/>");
+        // p uses the local default, news uses the local bk, and after returns to the inherited bk
         Element p = content.expectFirst("p");
         assertEquals("/html", p.tag().namespace());
         Element news = content.expectFirst("bk|news");
         assertEquals("/update", news.tag().namespace());
         Element data = content.expectFirst("data");
         assertEquals("/out", data.tag().namespace());
+        Element after = content.expectFirst("bk|after");
+        assertEquals("/books", after.tag().namespace());
+        assertEquals("/edi", after.attribute("edi:foo").namespace());
     }
 
     @Test void selfClosingOK() {
@@ -717,6 +730,37 @@ public class XmlTreeBuilderTest {
         assertEquals(parser.getMaxDepth(), depth(target));
     }
 
+    @Test void namespaceScopeTracksDepthPruning() {
+        Parser parser = Parser.xmlParser().setMaxDepth(3);
+        Document doc = Jsoup.parse("<a><b><x xmlns:p='/pruned'><p:y/></x></b></a>", "", parser);
+        Element y = doc.expectFirst("p|y");
+
+        assertEquals(NamespaceXml, y.tag().namespace());
+        assertEquals("b", y.parent().normalName());
+
+        doc = Jsoup.parse("<a><b><x><q:y xmlns:q='/incoming'/></x></b></a>", "", parser);
+        y = doc.expectFirst("q|y");
+        assertEquals("/incoming", y.tag().namespace());
+    }
+
+    @Test void namespaceTrackingRetainsLinearState() {
+        int depth = 1_000;
+        XmlTreeBuilder treeBuilder = new XmlTreeBuilder();
+        Parser parser = new Parser(treeBuilder);
+        treeBuilder.initialiseParse(new StringReader(deeplyNamespacedXml(depth)), "", parser);
+
+        try {
+            while (treeBuilder.stack.size() < depth) {
+                assertTrue(treeBuilder.stepParser());
+            }
+
+            assertEquals(depth + 2, treeBuilder.namespaceBindings.size()); // declarations plus the two initial bindings
+            assertEquals(depth * 2, treeBuilder.namespaceChanges.size()); // one marker and binding change per element
+        } finally {
+            treeBuilder.closeParse();
+        }
+    }
+
     private static String deepXml(int depth) {
         StringBuilder xml = new StringBuilder("<root>");
         for (int i = 0; i < depth; i++) {
@@ -727,6 +771,17 @@ public class XmlTreeBuilderTest {
             xml.append("</n>");
         }
         xml.append("</root>");
+        return xml.toString();
+    }
+
+    private static String deeplyNamespacedXml(int depth) {
+        StringBuilder xml = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            xml.append("<n xmlns:p").append(i).append("='urn:").append(i).append("'>");
+        }
+        for (int i = 0; i < depth; i++) {
+            xml.append("</n>");
+        }
         return xml.toString();
     }
 


### PR DESCRIPTION
Previously, XmlTreeBuilder copied the complete in-scope namespace map for every start tag. As nested declarations grew that map, parsing retained progressively larger copies and spent increasing time recreating them.

This keeps one current bindings map instead, recording only the bindings changed by each element and restoring their parent values when it closes. This makes namespace scope tracking linear in time and retained state while preserving namespace resolution and fragment inheritance.