### PR TITLE
Place trailing comments per spec and clarify open elements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)
 * Fixed HTTP response content-type matching to handle media types case-insensitively and recognize structured `+xml` suffixes, including vendor-specific media types. [#2550](https://github.com/jhy/jsoup/pull/2550)
 * Corrected multipart form encoding to percent-escape CR and LF in field names and filenames, matching the HTML form submission specification. Multipart file content-types containing CR or LF are now rejected with a `ValidationException`. [#2555](https://github.com/jhy/jsoup/pull/2555)
+* Aligned trailing comment placement with the HTML specification: comments after `</body>` remain children of the `html` element, while comments after `</html>` remain children of the document.
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -465,27 +465,35 @@ public class HtmlTreeBuilder extends TreeBuilder {
         if (parser.getErrors().canAddError() && el.hasAttr("xmlns") && !el.attr("xmlns").equals(el.tag().namespace()))
             error("Invalid xmlns attribute [%s] on tag [%s]", el.attr("xmlns"), el.tagName());
 
-        if (isFosterInserts() && StringUtil.inSorted(currentElement().normalName(), InTableFoster))
+        Element target = currentElOrDoc();
+        if (isFosterInserts() && StringUtil.inSorted(target.normalName(), InTableFoster))
             insertInFosterParent(el);
         else
-            currentElement().appendChild(el);
+            target.appendChild(el);
 
         push(el);
     }
 
+    /** Inserts a comment into the current element, or the document when there is none. */
     void insertCommentNode(Token.Comment token) {
+        insertCommentNode(token, currentElOrDoc());
+    }
+
+    /** Inserts a comment into the supplied target. */
+    void insertCommentNode(Token.Comment token, Element target) {
         Comment node = new Comment(token.getData());
-        currentElement().appendChild(node);
+        target.appendChild(node);
         onNodeInserted(node);
     }
 
-    /** Inserts the provided character token into the current element. Any nulls in the data will be removed. */
+    /** Inserts the provided character token into the current element, or the document when there is none. */
     void insertCharacterNode(Token.Character characterToken) {
         insertCharacterNode(characterToken, false);
     }
 
     /**
-     Inserts the provided character token into the current element. The tokenizer will have already raised precise character errors.
+     Inserts the provided character token into the current element, or the document when there is none.
+     The tokenizer will have already raised precise character errors.
 
      @param characterToken the character token to insert
      @param replace if true, replaces any null chars in the data with the replacement char (U+FFFD). If false, removes
@@ -493,7 +501,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
      */
     void insertCharacterNode(Token.Character characterToken, boolean replace) {
         characterToken.normalizeNulls(replace);
-        Element el = currentElement(); // will be doc if no current element; allows for whitespace to be inserted into the doc root object (not on the stack)
+        Element el = currentElOrDoc();
         insertCharacterToElement(characterToken, el);
     }
 
@@ -508,7 +516,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
             node = new DataNode(data);
         else
             node = new TextNode(data);
-        el.appendChild(node); // doesn't use insertNode, because we don't foster these; and will always have a stack.
+        el.appendChild(node); // doesn't use insertNode, because we don't foster these
         onNodeInserted(node);
     }
 
@@ -961,7 +969,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
      process, then the UA must perform the above steps as if that element was not in the above list.
      */
     void generateImpliedEndTags(String excludeTag) {
-        while (currentElement().tag().hasParserOption(HtmlTagOptions.ImpliedEnd)) {
+        while (hasCurrentElement() && currentElement().tag().hasParserOption(HtmlTagOptions.ImpliedEnd)) {
             if (excludeTag != null && currentElementIs(excludeTag))
                 break;
             pop();
@@ -979,6 +987,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     void generateImpliedEndTags(boolean thorough) {
         final int option = thorough ? HtmlTagOptions.ThoroughImpliedEnd : HtmlTagOptions.ImpliedEnd;
         while (true) {
+            if (!hasCurrentElement()) break;
             Tag tag = currentElement().tag();
             if (!tag.hasParserOption(option))
                 break;
@@ -988,7 +997,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
 
     void closeElement(String name) {
         generateImpliedEndTags(name);
-        if (!name.equals(currentElement().normalName())) error(state());
+        if (!currentElementIs(name)) error(state());
         popStackToClose(name);
     }
 
@@ -1191,7 +1200,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
         return "TreeBuilder{" +
                 "currentToken=" + currentToken +
                 ", state=" + state +
-                ", currentElement=" + currentElement() +
+                ", currentElement=" + (hasCurrentElement() ? currentElement() : "none") +
                 '}';
     }
 

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -494,7 +494,7 @@ enum HtmlTreeBuilderState {
                     if (tb.inButtonScope("p")) {
                         tb.processEndTag("p");
                     }
-                    if (inSorted(tb.currentElement().normalName(), Constants.Headings)) {
+                    if (tb.hasCurrentElement() && inSorted(tb.currentElement().normalName(), Constants.Headings)) {
                         tb.error(this);
                         tb.pop();
                     }
@@ -803,7 +803,7 @@ enum HtmlTreeBuilderState {
             final String subject = endTag.normalName; // 1. Let subject be token's tag name.
 
             // 2. If the [current node] is an [HTML element] whose tag name is subject, and the [current node] is not in the [list of active formatting elements], then pop the [current node] off the [stack of open elements] and return.
-            if (tb.currentElement().normalName().equals(subject) && !tb.isInActiveFormattingElements(tb.currentElement())) {
+            if (tb.currentElementIs(subject) && !tb.isInActiveFormattingElements(tb.currentElement())) {
                 tb.pop();
                 return true;
             }
@@ -975,7 +975,7 @@ enum HtmlTreeBuilderState {
     },
     InTable {
         @Override boolean process(Token t, HtmlTreeBuilder tb) {
-            if (t.isCharacter() && inSorted(tb.currentElement().normalName(), InTableFoster)) {
+            if (t.isCharacter() && tb.hasCurrentElement() && inSorted(tb.currentElement().normalName(), InTableFoster)) {
                 tb.resetPendingTableCharacters();
                 tb.markInsertionMode();
                 tb.transition(InTableText);
@@ -1610,7 +1610,10 @@ enum HtmlTreeBuilderState {
                 else
                     tb.process(t, InBody); // will get into body
             } else if (t.isComment()) {
-                tb.insertCommentNode(t.asComment()); // into html node
+                if (html != null)
+                    tb.insertCommentNode(t.asComment(), html);
+                else
+                    tb.insertCommentNode(t.asComment()); // fragment fallback
             } else if (t.isDoctype()) {
                 tb.error(this);
                 return false;
@@ -1709,7 +1712,7 @@ enum HtmlTreeBuilderState {
     AfterAfterBody {
         @Override boolean process(Token t, HtmlTreeBuilder tb) {
             if (t.isComment()) {
-                tb.insertCommentNode(t.asComment());
+                tb.insertCommentNode(t.asComment(), tb.getDocument());
             } else if (t.isDoctype() || (t.isStartTag() && t.asStartTag().normalName().equals("html"))) {
                 return tb.process(t, InBody);
             } else if (isWhitespace(t)) {
@@ -1729,7 +1732,7 @@ enum HtmlTreeBuilderState {
     AfterAfterFrameset {
         @Override boolean process(Token t, HtmlTreeBuilder tb) {
             if (t.isComment()) {
-                tb.insertCommentNode(t.asComment());
+                tb.insertCommentNode(t.asComment(), tb.getDocument());
             } else if (t.isDoctype() || isWhitespace(t) || (t.isStartTag() && t.asStartTag().normalName().equals("html"))) {
                 return tb.process(t, InBody);
             } else if (t.isEOF()) {

--- a/src/main/java/org/jsoup/parser/Tokeniser.java
+++ b/src/main/java/org/jsoup/parser/Tokeniser.java
@@ -265,7 +265,7 @@ final class Tokeniser {
     /** Test if CDATA sections are allowed at the adjusted current node */
     boolean isCdataAllowed() {
         return syntax == Document.OutputSettings.Syntax.xml
-            || !Parser.NamespaceHtml.equals(treeBuilder.currentElement().tag().namespace());
+            || (treeBuilder.hasCurrentElement() && !Parser.NamespaceHtml.equals(treeBuilder.currentElement().tag().namespace()));
     }
 
     boolean isAppropriateEndTagToken() {

--- a/src/main/java/org/jsoup/parser/TreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilder.java
@@ -25,7 +25,7 @@ abstract class TreeBuilder {
     CharacterReader reader;
     Tokeniser tokeniser;
     Document doc; // current doc we are building into
-    final ArrayList<Element> stack = new ArrayList<>(); // open elements; reused and trimmed between parses
+    final ArrayList<Element> stack = new ArrayList<>(); // open elements only; the document is never on this stack
     String baseUri; // current base uri, for creating new elements
     Token currentToken; // currentToken is used for error and source position tracking. Null at start of fragment parse
     ParseSettings settings;
@@ -224,13 +224,26 @@ abstract class TreeBuilder {
     }
 
     /**
-     Get the current element (last on the stack). If all items have been removed, returns the document instead
-     (which might not actually be on the stack; use stack.size() == 0 to test if required.
-     @return the last element on the stack, if any; or the root document
+     Gets the current open element for tree-construction decisions.
+     The stack must not be empty; use {@link #hasCurrentElement()} when it may be.
      */
     Element currentElement() {
-        int size = stack.size();
-        return size > 0 ? stack.get(size-1) : doc;
+        return stack.get(stack.size() - 1);
+    }
+
+    /**
+     Tests if there is a current open element.
+     */
+    boolean hasCurrentElement() {
+        return !stack.isEmpty();
+    }
+
+    /**
+     Gets the current open element, or the document when there is none.
+     This fallback is for generic node attachment; state-specific placement and foster parenting use explicit targets.
+     */
+    Element currentElOrDoc() {
+        return hasCurrentElement() ? currentElement() : doc;
     }
 
     /**
@@ -239,11 +252,7 @@ abstract class TreeBuilder {
      @return true if there is a current element on the stack, and its name equals the supplied
      */
     boolean currentElementIs(String normalName) {
-        if (stack.size() == 0)
-            return false;
-        Element current = currentElement();
-        return current != null && current.normalName().equals(normalName)
-            && current.tag().namespace().equals(NamespaceHtml);
+        return currentElementIs(normalName, NamespaceHtml);
     }
 
     /**
@@ -253,10 +262,10 @@ abstract class TreeBuilder {
      @return true if there is a current element on the stack, and its name equals the supplied
      */
     boolean currentElementIs(String normalName, String namespace) {
-        if (stack.size() == 0)
+        if (!hasCurrentElement())
             return false;
         Element current = currentElement();
-        return current != null && current.normalName().equals(normalName)
+        return current.normalName().equals(normalName)
             && current.tag().namespace().equals(namespace);
     }
 

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -184,7 +184,7 @@ public class XmlTreeBuilder extends TreeBuilder {
         String ns = resolveNamespace(tagName);
         Tag tag = tagFor(tagName, startTag.normalName, ns, settings);
         Element el = new Element(tag, null, attributes);
-        currentElement().appendChild(el);
+        currentElOrDoc().appendChild(el);
         push(el);
 
         if (startTag.isSelfClosing()) {
@@ -255,7 +255,7 @@ public class XmlTreeBuilder extends TreeBuilder {
     }
 
     void insertLeafNode(LeafNode node) {
-        currentElement().appendChild(node);
+        currentElOrDoc().appendChild(node);
         onNodeInserted(node);
     }
 
@@ -267,9 +267,10 @@ public class XmlTreeBuilder extends TreeBuilder {
     void insertCharacterFor(Token.Character token) {
         final String data = token.getData();
         LeafNode node;
-        if      (token.isCData())                       node = new CDataNode(data);
-        else if (currentElement().tag().is(Tag.Data))   node = new DataNode(data);
-        else                                            node = new TextNode(data);
+        if      (token.isCData()) node = new CDataNode(data);
+        else if (currentElOrDoc().tag().is(Tag.Data))
+            node = new DataNode(data);
+        else node = new TextNode(data);
         insertLeafNode(node);
     }
 

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -727,6 +727,19 @@ public class HtmlParserTest {
         // no body, no table. No crash!
     }
 
+    @Test void placesCommentsAfterFrameset() {
+        String html = "<html><head></head><frameset><frame></frameset><!--after frameset--></html><!--after html-->";
+        Document doc = Jsoup.parse(html);
+        doc.outputSettings().prettyPrint(false);
+
+        Element htmlEl = doc.expectFirst("html");
+        Comment afterFrameset = assertInstanceOf(Comment.class, htmlEl.childNode(2));
+        Comment afterHtml = assertInstanceOf(Comment.class, doc.childNode(1));
+        assertSame(htmlEl, afterFrameset.parent());
+        assertSame(doc, afterHtml.parent());
+        assertEquals(html, doc.outerHtml());
+    }
+
     @Test public void handlesJavadocFont() {
         String h = "<TD BGCOLOR=\"#EEEEFF\" CLASS=\"NavBarCell1\">    <A HREF=\"deprecated-list.html\"><FONT CLASS=\"NavBarFont1\"><B>Deprecated</B></FONT></A>&nbsp;</TD>";
         Document doc = Jsoup.parse(h);
@@ -1804,6 +1817,21 @@ public class HtmlParserTest {
         Document doc = Jsoup.parse(html);
         doc.outputSettings().prettyPrint(false);
         assertEquals("<html><head></head><body>One<p>Hello!</p><p>There</p></body>  </html> ", doc.outerHtml());
+    }
+
+    @Test void placesCommentsAroundDocumentElement() {
+        String html = "<!--before html--><html><head></head><body>One</body><!--after body--></html><!--after html-->";
+        Document doc = Jsoup.parse(html);
+        doc.outputSettings().prettyPrint(false);
+
+        Comment beforeHtml = assertInstanceOf(Comment.class, doc.childNode(0));
+        Element htmlEl = doc.expectFirst("html");
+        Comment afterBody = assertInstanceOf(Comment.class, htmlEl.childNode(2));
+        Comment afterHtml = assertInstanceOf(Comment.class, doc.childNode(2));
+        assertSame(doc, beforeHtml.parent());
+        assertSame(htmlEl, afterBody.parent());
+        assertSame(doc, afterHtml.parent());
+        assertEquals(html, doc.outerHtml());
     }
 
     @Test public void preservesTabs() {

--- a/src/test/java/org/jsoup/parser/HtmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlTreeBuilderTest.java
@@ -64,10 +64,12 @@ public class HtmlTreeBuilderTest {
             streamParser.expectFirst("title");
             Element open = streamParser.document().expectFirst("#hit");
             assertTrue(treeBuilder.isOpen(open));
+            assertFalse(treeBuilder.isOpen(treeBuilder.doc));
 
             List<Element> openElements = new ArrayList<>();
             treeBuilder.copyOpenElementsTo(openElements);
             assertTrue(openElements.contains(open));
+            assertFalse(openElements.contains(treeBuilder.doc));
 
             // closing before EOF releases the open stack without marking the document complete
             streamParser.close();


### PR DESCRIPTION
Comments after </body> now remain under the html element, while comments after </html> are attached to the Document, matching the HTML specification.

Make currentElement() strictly represent the top of the stack of open elements, and use an explicit Document fallback only for generic node attachment.

This separates parser state from insertion placement while preserving fragment parsing and empty-stack recovery.