### PR TITLE
Prevent cyclic node mutations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Improvements
 * Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery. [#2551](https://github.com/jhy/jsoup/pull/2551)
 * Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope. [#2556](https://github.com/jhy/jsoup/pull/2556)
+* DOM mutation methods, including child insertion and replacement, now reject operations that would create a cycle, such as making a node its own child or moving an ancestor beneath a descendant. [#2552](https://github.com/jhy/jsoup/issues/2552)
 
 ### Bug Fixes
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)

--- a/src/main/java/org/jsoup/nodes/Node.java
+++ b/src/main/java/org/jsoup/nodes/Node.java
@@ -537,10 +537,36 @@ public abstract class Node implements Cloneable {
 
     protected void setParentNode(Node parentNode) {
         Validate.notNull(parentNode);
+        assert parentNode instanceof Element;
+        parentNode.validateChild(this);
+        setParentNodeUnchecked((Element) parentNode);
+    }
+
+    /** Reparents this node without cycle validation; callers must validate first. */
+    private void setParentNodeUnchecked(Element parentNode) {
         if (this.parentNode != null)
             this.parentNode.removeChild(this);
-        assert parentNode instanceof Element;
-        this.parentNode = (Element) parentNode;
+        this.parentNode = parentNode;
+    }
+
+    private static final String CycleError = "Cannot add a node here because it would create a cycle.";
+
+    /** Checks that the child is neither this node nor an ancestor of this node. */
+    private void validateChild(Node child) {
+        Validate.isFalse(child == this, CycleError);
+        if (child.childNodeSize() == 0) return;
+
+        for (Node ancestor = parentNode; ancestor != null; ancestor = ancestor.parentNode)
+            Validate.isFalse(ancestor == child, CycleError);
+    }
+
+    /** Checks every child before reparenting any of them. */
+    private void validateChildren(Node[] children) {
+        Validate.notNull(children);
+        for (Node child : children) {
+            Validate.notNull(child, "Array must not contain any null objects");
+            validateChild(child);
+        }
     }
 
     protected void replaceChild(Node out, Node in) {
@@ -548,16 +574,16 @@ public abstract class Node implements Cloneable {
         Validate.notNull(in);
         if (out == in) return; // no-op self replacement
 
-        if (in.parentNode != null)
-            in.parentNode.removeChild(in);
+        Element parent = (Element) this;
+        validateChild(in);
+        in.setParentNodeUnchecked(parent);
 
         final int index = out.siblingIndex();
         ensureChildNodes().set(index, in);
-        in.parentNode = (Element) this;
         in.setSiblingIndex(index);
         out.parentNode = null;
 
-        ((Element) this).childNodes.incrementMod(); // as mod count not changed in set(), requires explicit update, to invalidate the child element cache
+        parent.childNodes.incrementMod(); // as mod count not changed in set(), requires explicit update, to invalidate the child element cache
     }
 
     protected void removeChild(Node out) {
@@ -574,10 +600,14 @@ public abstract class Node implements Cloneable {
 
     protected void addChildren(Node... children) {
         //most used. short circuit addChildren(int), which hits reindex children and array copy
+        validateChildren(children);
+
         final List<Node> nodes = ensureChildNodes();
+        assert this instanceof Element;
+        Element parent = (Element) this;
 
         for (Node child: children) {
-            reparentChild(child);
+            child.setParentNodeUnchecked(parent);
             nodes.add(child);
             child.setSiblingIndex(nodes.size()-1);
         }
@@ -587,7 +617,11 @@ public abstract class Node implements Cloneable {
         // todo clean up all these and use the list, not the var array. just need to be careful when iterating the incoming (as we are removing as we go)
         Validate.notNull(children);
         if (children.length == 0) return;
+        validateChildren(children);
+
         final List<Node> nodes = ensureChildNodes();
+        assert this instanceof Element;
+        Element parent = (Element) this;
 
         // fast path - if used as a wrap (index=0, children = child[0].parent.children - do inplace
         final Node firstParent = children[0].parent();
@@ -606,21 +640,19 @@ public abstract class Node implements Cloneable {
                 firstParent.empty();
                 nodes.addAll(index, Arrays.asList(children));
                 i = children.length;
-                assert this instanceof Element;
                 while (i-- > 0) {
-                    children[i].parentNode = (Element) this;
+                    children[i].setParentNodeUnchecked(parent);
                 }
-                ((Element) this).invalidateChildren();
+                parent.invalidateChildren();
                 return;
             }
         }
 
-        Validate.noNullElements(children);
         for (Node child : children) {
-            reparentChild(child);
+            child.setParentNodeUnchecked(parent);
         }
         nodes.addAll(index, Arrays.asList(children));
-        ((Element) this).invalidateChildren();
+        parent.invalidateChildren();
     }
     
     protected void reparentChild(Node child) {

--- a/src/test/java/org/jsoup/nodes/NodeTest.java
+++ b/src/test/java/org/jsoup/nodes/NodeTest.java
@@ -2,6 +2,7 @@ package org.jsoup.nodes;
 
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
+import org.jsoup.helper.ValidationException;
 import org.jsoup.parser.Tag;
 import org.jsoup.select.Elements;
 import org.jsoup.select.NodeVisitor;
@@ -186,6 +187,82 @@ public class NodeTest {
 
         assertEquals("Child TwoChild ThreeChild OneChild Four",
                 TextUtil.stripNewlines(children.html()));
+    }
+
+    @Test void rejectsSelfParenting() {
+        Element element = new Element("div");
+
+        ValidationException exception = assertThrows(ValidationException.class, () -> element.appendChild(element));
+        assertEquals("Cannot add a node here because it would create a cycle.", exception.getMessage());
+        assertNull(element.parent());
+        assertEquals(0, element.childNodeSize());
+    }
+
+    @Test void rejectsAncestorAsChild() {
+        Element root = new Element("root");
+        Element child = root.appendElement("child");
+        Element descendant = child.appendElement("descendant");
+        String originalHtml = root.outerHtml();
+
+        assertThrows(ValidationException.class, () -> descendant.appendChild(root));
+        assertEquals(originalHtml, root.outerHtml());
+        assertNull(root.parent());
+        assertSame(root, child.parent());
+        assertSame(child, descendant.parent());
+    }
+
+    @Test void rejectsAncestorReplacement() {
+        Element root = new Element("root");
+        Element child = root.appendElement("child");
+        child.appendElement("descendant");
+        String originalHtml = root.outerHtml();
+
+        assertThrows(ValidationException.class, () -> child.replaceWith(root));
+        assertEquals(originalHtml, root.outerHtml());
+        assertNull(root.parent());
+        assertSame(root, child.parent());
+    }
+
+    @Test void rejectsCyclicBatchAtomically() {
+        Element source = new Element("source");
+        Element movable = source.appendElement("movable");
+        Element ancestor = new Element("ancestor");
+        Element target = ancestor.appendElement("target");
+        String sourceHtml = source.outerHtml();
+        String ancestorHtml = ancestor.outerHtml();
+
+        assertThrows(ValidationException.class, () -> target.insertChildren(0, movable, ancestor));
+        assertEquals(sourceHtml, source.outerHtml());
+        assertEquals(ancestorHtml, ancestor.outerHtml());
+        assertSame(source, movable.parent());
+        assertNull(ancestor.parent());
+        assertSame(ancestor, target.parent());
+    }
+
+    @Test void rejectsCyclicWholeSourceMove() {
+        Element source = new Element("source");
+        Element ancestor = source.appendElement("ancestor");
+        Element target = ancestor.appendElement("target");
+        String originalHtml = source.outerHtml();
+
+        assertThrows(ValidationException.class, () -> target.insertChildren(0, source.childNodes()));
+        assertEquals(originalHtml, source.outerHtml());
+        assertNull(source.parent());
+        assertSame(source, ancestor.parent());
+        assertSame(ancestor, target.parent());
+    }
+
+    @Test void allowsPopulatedSubtreeMove() {
+        Element source = new Element("source");
+        Element subtree = source.appendElement("subtree");
+        subtree.appendElement("child").text("One");
+        Element target = new Element("target");
+
+        target.appendChild(subtree);
+        assertEquals(0, source.childNodeSize());
+        assertSame(target, subtree.parent());
+        assertSame(subtree, target.childNode(0));
+        assertEquals("One", target.text());
     }
 
     @Test public void ownerDocument() {


### PR DESCRIPTION
Node insertion and replacement methods now reject changes that would place a node beneath itself or one of its descendants, creating a cycle. Bulk mutations are checked before any changes are made, so a rejected operation leaves the tree unchanged.

Fixes #2552 