### PR TITLE
Share namespace scope tracking with W3CDom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,18 @@
 ### Improvements
 * Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery. [#2551](https://github.com/jhy/jsoup/pull/2551)
 * Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope. [#2556](https://github.com/jhy/jsoup/pull/2556)
+* Improved `W3CDom` conversion performance for documents with many nested namespace declarations.
+  The W3C converter now uses the same optimized namespace tracking as the XML parser.
 * DOM mutation methods, including child insertion and replacement, now reject operations that would create a cycle, such as making a node its own child or moving an ancestor beneath a descendant. [#2552](https://github.com/jhy/jsoup/issues/2552)
 
 ### Bug Fixes
+* Fixed `W3CDom` namespace conversion in several cases:
+  * Namespace declarations and prefixed attributes now carry the correct namespace URI, so namespace-aware DOM lookups work as expected.
+  * Attributes added after parsing, or included through subtree conversion, now use inherited prefix declarations.
+  * Namespace declarations now apply regardless of attribute order, and an empty declaration shadows an inherited binding only within its scope.
+  * With namespace awareness disabled, inherited and undeclared prefixes now receive the declarations needed for XML serialization.
+  * Valid HTML names that are not XML QNames, such as `a:b:c`, are normalized.
+    Attributes that still cannot be represented are skipped, and unrepresentable elements no longer change the surrounding tree.
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)
 * Fixed HTTP response content-type matching to handle media types case-insensitively and recognize structured `+xml` suffixes, including vendor-specific media types. [#2550](https://github.com/jhy/jsoup/pull/2550)
 * Corrected multipart form encoding to percent-escape CR and LF in field names and filenames, matching the HTML form submission specification. Multipart file content-types containing CR or LF are now rejected with a `ValidationException`. [#2555](https://github.com/jhy/jsoup/pull/2555)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,18 +5,16 @@
 ### Improvements
 * Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery. [#2551](https://github.com/jhy/jsoup/pull/2551)
 * Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope. [#2556](https://github.com/jhy/jsoup/pull/2556)
-* Improved `W3CDom` conversion performance for documents with many nested namespace declarations.
-  The W3C converter now uses the same optimized namespace tracking as the XML parser.
+* Improved `W3CDom` conversion performance for documents with many nested namespace declarations. The W3C converter now uses the same optimized namespace tracking as the XML parser. [#2559](https://github.com/jhy/jsoup/pull/2559)
 * DOM mutation methods, including child insertion and replacement, now reject operations that would create a cycle, such as making a node its own child or moving an ancestor beneath a descendant. [#2552](https://github.com/jhy/jsoup/issues/2552)
 
 ### Bug Fixes
-* Fixed `W3CDom` namespace conversion in several cases:
+* Fixed `W3CDom` namespace conversion in several cases: [#2559](https://github.com/jhy/jsoup/pull/2559)
   * Namespace declarations and prefixed attributes now carry the correct namespace URI, so namespace-aware DOM lookups work as expected.
   * Attributes added after parsing, or included through subtree conversion, now use inherited prefix declarations.
   * Namespace declarations now apply regardless of attribute order, and an empty declaration shadows an inherited binding only within its scope.
   * With namespace awareness disabled, inherited and undeclared prefixes now receive the declarations needed for XML serialization.
-  * Valid HTML names that are not XML QNames, such as `a:b:c`, are normalized.
-    Attributes that still cannot be represented are skipped, and unrepresentable elements no longer change the surrounding tree.
+  * Valid HTML names that are not XML QNames, such as `a:b:c`, are normalized. Attributes that still cannot be represented are skipped, and unrepresentable elements no longer change the surrounding tree.
 * Fixed the JDK `HttpClient` implementation to accept responses without a `Content-Type` header, matching the `HttpURLConnection` implementation. [#2549](https://github.com/jhy/jsoup/pull/2549)
 * Fixed HTTP response content-type matching to handle media types case-insensitively and recognize structured `+xml` suffixes, including vendor-specific media types. [#2550](https://github.com/jhy/jsoup/pull/2550)
 * Corrected multipart form encoding to percent-escape CR and LF in field names and filenames, matching the HTML form submission specification. Multipart file content-types containing CR or LF are now rejected with a `ValidationException`. [#2555](https://github.com/jhy/jsoup/pull/2555)

--- a/src/main/java/org/jsoup/helper/W3CDom.java
+++ b/src/main/java/org/jsoup/helper/W3CDom.java
@@ -1,9 +1,9 @@
 package org.jsoup.helper;
 
-import org.jsoup.internal.Normalizer;
+import org.jsoup.internal.NamespaceBindings;
 import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Attribute;
-import org.jsoup.parser.HtmlTreeBuilder;
+import org.jsoup.nodes.Attributes;
 import org.jsoup.parser.Parser;
 import org.jsoup.select.NodeVisitor;
 import org.jsoup.select.Selector;
@@ -18,6 +18,7 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.jspecify.annotations.Nullable;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -38,6 +39,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static javax.xml.transform.OutputKeys.METHOD;
 import static org.jsoup.nodes.Document.OutputSettings.Syntax;
@@ -344,6 +347,9 @@ public class W3CDom {
      */
     protected static class W3CBuilder implements NodeVisitor {
         private final Document doc;
+        // source bindings include omitted ancestors; output bindings track declarations emitted to the W3C tree
+        private final NamespaceBindings sourceNamespaces = new NamespaceBindings();
+        private final NamespaceBindings outputNamespaces = new NamespaceBindings();
         private boolean namespaceAware = true;
         private Node dest;
         private Syntax syntax = Syntax.xml; // the syntax (to coerce attributes to). From the input doc if available.
@@ -352,6 +358,8 @@ public class W3CDom {
         public W3CBuilder(Document doc) {
             this.doc = doc;
             dest = doc;
+            sourceNamespaces.put("xml", Parser.NamespaceXml);
+            outputNamespaces.put("xml", Parser.NamespaceXml);
             contextElement = (org.jsoup.nodes.Element) doc.getUserData(ContextProperty); // Track the context jsoup Element, so we can save the corresponding w3c element
         }
 
@@ -359,8 +367,13 @@ public class W3CDom {
         public void head(org.jsoup.nodes.Node source, int depth) {
             if (source instanceof org.jsoup.nodes.Element) {
                 org.jsoup.nodes.Element sourceEl = (org.jsoup.nodes.Element) source;
+                if (depth == 0)
+                    seedSourceNamespaces(sourceEl);
+                sourceNamespaces.pushScope();
+                outputNamespaces.pushScope();
+                sourceNamespaces.applyDeclarations(sourceEl.attributes());
                 @Nullable String namespace = namespaceAware ? w3cNamespace(sourceEl) : null;
-                String tagName = Normalizer.xmlSafeTagName(sourceEl.tagName());
+                String tagName = w3cSafeName(sourceEl.tagName(), Syntax.xml);
                 try {
                     // use an empty namespace if none is present but the tag name has a prefix
                     String imputedNamespace = namespace == null && tagName.contains(":") ? "" : namespace;
@@ -399,6 +412,16 @@ public class W3CDom {
             return namespace;
         }
 
+        /** Applies declarations inherited from ancestors outside a subtree conversion. */
+        private void seedSourceNamespaces(org.jsoup.nodes.Element sourceEl) {
+            org.jsoup.select.Elements parents = sourceEl.parents();
+            for (int i = parents.size() - 1; i >= 0; i--) {
+                org.jsoup.nodes.Element parent = parents.get(i);
+                if (parent.attributesSize() > 0)
+                    sourceNamespaces.applyDeclarations(parent.attributes());
+            }
+        }
+
         private void append(Node append, org.jsoup.nodes.Node source) {
             append.setUserData(SourceProperty, source, null);
             dest.appendChild(append);
@@ -406,65 +429,136 @@ public class W3CDom {
 
         @Override
         public void tail(org.jsoup.nodes.Node source, int depth) {
-            if (source instanceof org.jsoup.nodes.Element && dest.getParentNode() instanceof Element) {
+            // head may emit an invalid element as text without descending, so only ascend from its matching output element
+            if (source instanceof org.jsoup.nodes.Element && dest.getUserData(SourceProperty) == source &&
+                dest.getParentNode() instanceof Element) {
                 dest = dest.getParentNode(); // undescend
             }
+            if (source instanceof org.jsoup.nodes.Element) {
+                sourceNamespaces.popScope();
+                outputNamespaces.popScope();
+            }
         }
 
+        /** Copies namespace declarations first so source attribute order does not affect binding resolution. */
         private void copyAttributes(org.jsoup.nodes.Element jEl, Element wEl) {
-            for (Attribute attribute : jEl.attributes()) {
-                try {
-                    setAttribute(jEl, wEl, attribute, syntax);
-                } catch (DOMException e) {
-                    if (syntax != Syntax.xml)
-                        setAttribute(jEl, wEl, attribute, Syntax.xml);
-                }
+            Attributes attributes = jEl.attributes();
+            for (Attribute attribute : attributes) {
+                if (NamespaceBindings.isDeclaration(attribute.getKey()))
+                    copyAttribute(wEl, attribute);
+            }
+            for (Attribute attribute : attributes) {
+                if (!NamespaceBindings.isDeclaration(attribute.getKey()))
+                    copyAttribute(wEl, attribute);
             }
         }
 
-        private void setAttribute(org.jsoup.nodes.Element jEl, Element wEl, Attribute attribute, Syntax syntax) throws DOMException {
-            String key = Attribute.getValidKey(attribute.getKey(), syntax);
-            if (key != null) {
-                String namespace = attribute.namespace();
-                if (namespaceAware && !namespace.isEmpty())
-                    wEl.setAttributeNS(namespace, key, attribute.getValue());
-                else
-                    wEl.setAttribute(key, attribute.getValue());
-                maybeAddUndeclaredNs(namespace, key, jEl, wEl);
+        /** Copies an attribute using the closest W3C representation. */
+        private void copyAttribute(Element wEl, Attribute attribute) {
+            // preserve DOM-compatible HTML names; otherwise normalize as XML, and skip if still unrepresentable
+            if (!trySetAttribute(wEl, attribute, syntax) && syntax != Syntax.xml)
+                trySetAttribute(wEl, attribute, Syntax.xml);
+        }
+
+        /** Tries to copy an attribute, allowing the DOM to validate its name and namespace. */
+        private boolean trySetAttribute(Element wEl, Attribute attribute, Syntax syntax) {
+            try {
+                setAttribute(wEl, attribute, syntax);
+                return true;
+            } catch (DOMException ignored) {
+                return false;
             }
         }
 
-        /**
-         Add a namespace declaration for an attribute with a prefix if it is not already present. Ensures that attributes
-         with prefixes have the corresponding namespace declared, E.g. attribute "v-bind:foo" gets another attribute
-         "xmlns:v-bind='undefined'. So that the asString() transformation pass is valid.
-         If the parser was HTML we don't have a discovered namespace but we are trying to coerce it, so walk up the
-         element stack and find it.
-         */
-        private void maybeAddUndeclaredNs(String namespace, String attrKey, org.jsoup.nodes.Element jEl, Element wEl) {
-            if (!namespaceAware || !namespace.isEmpty()) return;
-            int pos = attrKey.indexOf(':');
-            if (pos != -1) { // prefixed but no namespace defined during parse, add a fake so that w3c serialization doesn't blow up
-                String prefix = attrKey.substring(0, pos);
-                if (prefix.equals("xmlns")) return;
-                org.jsoup.nodes.Document doc = jEl.ownerDocument();
-                if (doc != null && doc.parser().getTreeBuilder() instanceof HtmlTreeBuilder) {
-                    // try walking up the stack and seeing if there is a namespace declared for this prefix (and that we didn't parse because HTML)
-                    for (org.jsoup.nodes.Element el = jEl; el != null; el = el.parent()) {
-                        String ns = el.attr("xmlns:" + prefix);
-                        if (!ns.isEmpty()) {
-                            namespace = ns;
-                            // found it, set it
-                            wEl.setAttributeNS(namespace, attrKey, jEl.attr(attrKey));
-                            return;
-                        }
-                    }
-                }
+        /** Copies an attribute with its resolved namespace and W3C-safe name. */
+        private void setAttribute(Element wEl, Attribute attribute, Syntax syntax) throws DOMException {
+            String key = w3cSafeName(attribute.getKey(), syntax);
+            if (key == null) return;
 
-                // otherwise, put in a fake one
-                wEl.setAttribute("xmlns:" + prefix, undefinedNs);
+            @Nullable String declarationPrefix = NamespaceBindings.declarationPrefix(key);
+            if (declarationPrefix != null) {
+                setNamespaceDeclaration(wEl, key, attribute.getValue());
+                outputNamespaces.put(declarationPrefix, attribute.getValue());
+                return;
+            }
+
+            int pos = key.indexOf(':');
+            if (pos == -1) { // default namespaces do not apply to unprefixed attributes
+                wEl.setAttribute(key, attribute.getValue());
+                return;
+            }
+
+            String prefix = key.substring(0, pos);
+            String sourcePrefix = attribute.prefix();
+            @Nullable String namespace;
+            if (namespaceAware) {
+                String attributeNamespace = attribute.namespace();
+                namespace = !attributeNamespace.isEmpty() ? attributeNamespace : sourceNamespaces.get(sourcePrefix);
+            } else {
+                namespace = sourceNamespaces.get(sourcePrefix);
+            }
+            if (namespace == null || namespace.isEmpty())
+                namespace = undefinedNs;
+
+            if (namespaceAware)
+                wEl.setAttributeNS(namespace, key, attribute.getValue());
+            else
+                wEl.setAttribute(key, attribute.getValue());
+            ensureOutputBinding(wEl, prefix, namespace);
+        }
+
+        /** Normalizes a name to a W3C-compatible QName, converting {@code a:b:c} to {@code a:b_c}. */
+        private @Nullable String w3cSafeName(String name, Syntax syntax) {
+            @Nullable String normalized = Attribute.getValidKey(name, syntax);
+            if (normalized == null) return null;
+            if (normalized.indexOf(':') == -1) return normalized;
+
+            Matcher parts = QNameParts.matcher(normalized);
+            if (!parts.matches()) return w3cSafeNcName(normalized.replace(':', '_'));
+            return w3cSafeNcName(parts.group(1)) + ':' + w3cSafeNcName(parts.group(2));
+        }
+
+        /** Normalizes one QName component while preserving valid XML name characters. */
+        private String w3cSafeNcName(String name) {
+            if (isValidNcName(name)) return name;
+            String safeStart = "_" + name;
+            if (isValidNcName(safeStart)) return safeStart;
+
+            String colonSafe = name.replace(':', '_');
+            @Nullable String normalized = Attribute.getValidKey(colonSafe, Syntax.xml);
+            if (normalized != null) return normalized;
+            normalized = Attribute.getValidKey("_" + colonSafe, Syntax.xml);
+            return normalized != null ? normalized : "_";
+        }
+
+        /** Tests a component against the XML NCName rules used by the output DOM. */
+        private boolean isValidNcName(String name) {
+            try {
+                // validate as a local name so reserved words such as xmlns are treated as ordinary NCName text
+                doc.createAttributeNS(undefinedNs, "p:" + name);
+                return true;
+            } catch (DOMException ignored) {
+                return false;
             }
         }
+
+        /** Declares a prefix when its output binding is not active. */
+        private void ensureOutputBinding(Element wEl, String prefix, String namespace) {
+            if (!namespace.equals(outputNamespaces.get(prefix))) {
+                setNamespaceDeclaration(wEl, "xmlns:" + prefix, namespace);
+                outputNamespaces.put(prefix, namespace);
+            }
+        }
+
+        /** Writes a namespace declaration with namespace awareness when enabled. */
+        private void setNamespaceDeclaration(Element wEl, String key, String namespace) {
+            if (namespaceAware)
+                wEl.setAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, key, namespace);
+            else
+                wEl.setAttribute(key, namespace);
+        }
+
+        private static final Pattern QNameParts = Pattern.compile("^([^:]+):(.+)$");
         private static final String undefinedNs = "undefined";
     }
 

--- a/src/main/java/org/jsoup/internal/NamespaceBindings.java
+++ b/src/main/java/org/jsoup/internal/NamespaceBindings.java
@@ -1,0 +1,103 @@
+package org.jsoup.internal;
+
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Attributes;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.HashMap;
+
+/** Tracks namespace prefix bindings across nested element scopes. Jsoup internal; API subject to change. */
+public final class NamespaceBindings {
+    private static final String XmlnsKey = "xmlns";
+    private static final String XmlnsPrefix = "xmlns:";
+    private static final NamespaceChange ScopeMarker = new NamespaceChange("", null);
+
+    private final HashMap<String, String> bindings = new HashMap<>();
+    private final ArrayDeque<NamespaceChange> changes = new ArrayDeque<>();
+
+    /** Creates an empty binding set. */
+    public NamespaceBindings() {}
+
+    /** Clears all bindings and scopes for reuse. */
+    public void clear() {
+        bindings.clear();
+        changes.clear();
+    }
+
+    /** Opens a namespace scope. */
+    public void pushScope() {
+        changes.push(ScopeMarker);
+    }
+
+    /** Closes the current scope and restores its parent bindings. */
+    public void popScope() {
+        NamespaceChange change;
+        while ((change = changes.pop()) != ScopeMarker)
+            change.restore(bindings);
+    }
+
+    /** Binds a prefix in the current scope, or at the root if no scope is open. */
+    public void put(String prefix, String namespace) {
+        String previousValue = bindings.get(prefix);
+        if (namespace.equals(previousValue)) return;
+
+        bindings.put(prefix, namespace);
+        if (!changes.isEmpty())
+            changes.push(new NamespaceChange(prefix, previousValue));
+    }
+
+    /** Returns the namespace URI bound to a prefix, or null if unbound. */
+    public @Nullable String get(String prefix) {
+        return bindings.get(prefix);
+    }
+
+    /** Applies namespace declarations from an attribute set. */
+    public void applyDeclarations(Attributes attributes) {
+        for (Attribute attribute : attributes) {
+            @Nullable String prefix = declarationPrefix(attribute.getKey());
+            if (prefix != null)
+                put(prefix, attribute.getValue());
+        }
+    }
+
+    /** Tests whether a key is an {@code xmlns} declaration. */
+    public static boolean isDeclaration(String key) {
+        return declarationPrefix(key) != null;
+    }
+
+    /** Returns the prefix declared by an {@code xmlns} key, or null if it is not a declaration. */
+    public static @Nullable String declarationPrefix(String key) {
+        if (key.equals(XmlnsKey)) return "";
+        if (key.startsWith(XmlnsPrefix)) return key.substring(XmlnsPrefix.length());
+        return null;
+    }
+
+    /** Returns the number of active bindings. */
+    int bindingCount() {
+        return bindings.size();
+    }
+
+    /** Returns the number of recorded scope markers and binding changes. */
+    int changeCount() {
+        return changes.size();
+    }
+
+    /** A previous binding recorded for scope restoration. */
+    private static final class NamespaceChange {
+        private final String prefix;
+        private final @Nullable String previousValue;
+
+        /** Records a prefix's previous binding. */
+        private NamespaceChange(String prefix, @Nullable String previousValue) {
+            this.prefix = prefix;
+            this.previousValue = previousValue;
+        }
+
+        /** Restores the previous binding. */
+        private void restore(HashMap<String, String> bindings) {
+            if (previousValue == null) bindings.remove(prefix);
+            else bindings.put(prefix, previousValue);
+        }
+    }
+}

--- a/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/XmlTreeBuilder.java
@@ -1,6 +1,7 @@
 package org.jsoup.parser;
 
 import org.jsoup.helper.Validate;
+import org.jsoup.internal.NamespaceBindings;
 import org.jsoup.internal.SharedConstants;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Attributes;
@@ -20,7 +21,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,33 +35,7 @@ import static org.jsoup.parser.Parser.NamespaceXml;
  * @author Jonathan Hedley
  */
 public class XmlTreeBuilder extends TreeBuilder {
-    static final String XmlnsKey = "xmlns";
-    static final String XmlnsPrefix = "xmlns:";
-    private static final NamespaceChange ScopeMarker = new NamespaceChange("", null);
-    final HashMap<String, String> namespaceBindings = new HashMap<>();
-    final ArrayDeque<NamespaceChange> namespaceChanges = new ArrayDeque<>();
-
-    /**
-     Tracks namespace binding changes within element scopes. Each scope starts with a shared marker, followed by a
-     change record for each namespace declaration. When the scope closes, the change records are applied in reverse to
-     restore the parent bindings.
-     */
-    private static final class NamespaceChange {
-        private final String prefix;
-        private final @Nullable String previousValue;
-
-        /** Creates a namespace change; a null previous value means the prefix was previously unbound. */
-        private NamespaceChange(String prefix, @Nullable String previousValue) {
-            this.prefix = prefix;
-            this.previousValue = previousValue;
-        }
-
-        /** Restores the binding that was active before this change. */
-        private void restore(Map<String, String> namespaceBindings) {
-            if (previousValue == null) namespaceBindings.remove(prefix);
-            else namespaceBindings.put(prefix, previousValue);
-        }
-    }
+    final NamespaceBindings namespaceBindings = new NamespaceBindings();
 
     @Override ParseSettings defaultSettings() {
         return ParseSettings.preserveCase;
@@ -76,7 +50,6 @@ public class XmlTreeBuilder extends TreeBuilder {
             .prettyPrint(false); // as XML, we don't understand what whitespace is significant or not
 
         namespaceBindings.clear();
-        namespaceChanges.clear();
         namespaceBindings.put("xml", NamespaceXml);
         namespaceBindings.put("", NamespaceXml);
     }
@@ -96,7 +69,7 @@ public class XmlTreeBuilder extends TreeBuilder {
         for (int i = chain.size() - 1; i >= 0; i--) {
             Element el = chain.get(i);
             if (el.attributesSize() > 0) {
-                applyNamespaceDeclarations(el.attributes());
+                namespaceBindings.applyDeclarations(el.attributes());
             }
         }
     }
@@ -172,10 +145,10 @@ public class XmlTreeBuilder extends TreeBuilder {
         }
 
         enforceStackDepthLimit();
-        namespaceChanges.push(ScopeMarker);
+        namespaceBindings.pushScope();
 
         if (attributes != null) {
-            applyNamespaceDeclarations(attributes);
+            namespaceBindings.applyDeclarations(attributes);
             applyNamespacesToAttributes(attributes);
             startTag.finaliseAttributeRanges(settings);
         }
@@ -198,33 +171,14 @@ public class XmlTreeBuilder extends TreeBuilder {
         }
     }
 
-    /** Applies namespace declarations and records changes within an element scope. */
-    private void applyNamespaceDeclarations(Attributes attributes) {
-        for (Attribute attr : attributes) {
-            String key = attr.getKey();
-            String value = attr.getValue();
-            String prefix;
-            if (key.equals(XmlnsKey)) {
-                prefix = ""; // new default for this level
-            } else if (key.startsWith(XmlnsPrefix)) {
-                prefix = key.substring(XmlnsPrefix.length());
-            } else {
-                continue;
-            }
-
-            String previousValue = namespaceBindings.put(prefix, value);
-            if (!namespaceChanges.isEmpty()) namespaceChanges.push(new NamespaceChange(prefix, previousValue));
-        }
-    }
-
     /** Applies resolved namespace URIs to prefixed attributes. */
     private void applyNamespacesToAttributes(Attributes attributes) {
         // collect first, then add, as userData is stored as an attribute
         Map<String, String> attrPrefix = new HashMap<>();
         for (Attribute attr: attributes) {
+            if (NamespaceBindings.isDeclaration(attr.getKey())) continue;
             String prefix = attr.prefix();
             if (!prefix.isEmpty()) {
-                if (prefix.equals(XmlnsKey)) continue;
                 String ns = namespaceBindings.get(prefix);
                 if (ns != null) attrPrefix.put(SharedConstants.XmlnsAttr + prefix, ns);
             }
@@ -239,18 +193,16 @@ public class XmlTreeBuilder extends TreeBuilder {
         int pos = tagName.indexOf(':');
         if (pos > 0) {
             String prefix = tagName.substring(0, pos);
-            if (namespaceBindings.containsKey(prefix))
-                ns = namespaceBindings.get(prefix);
+            String boundNamespace = namespaceBindings.get(prefix);
+            if (boundNamespace != null)
+                ns = boundNamespace;
         }
         return ns;
     }
 
     @Override
     Element pop() {
-        NamespaceChange change;
-        while ((change = namespaceChanges.pop()) != ScopeMarker) {
-            change.restore(namespaceBindings);
-        }
+        namespaceBindings.popScope();
         return super.pop();
     }
 

--- a/src/test/java/org/jsoup/helper/W3CDomTest.java
+++ b/src/test/java/org/jsoup/helper/W3CDomTest.java
@@ -15,6 +15,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -545,14 +546,46 @@ public class W3CDomTest {
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><html xmlns=\"http://www.w3.org/1999/xhtml\"><head/><body><div xmlns:v-bind=\"undefined\" v-bind:class=\"test\"/></body></html>", xml);
     }
 
+    @Test void serializesUndeclaredPrefixWithoutNamespaceAwareness() {
+        // prefixed DOM attributes still need a declaration for XML serialization
+        W3CDom w3CDom = new W3CDom().namespaceAware(false);
+        String html = "<html><body><div v-bind:class='test'></div></body></html>";
+        org.jsoup.nodes.Document jdoc = Jsoup.parse(html);
+        org.w3c.dom.Document w3CDoc = w3CDom.fromJsoup(jdoc);
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
+
+        assertNull(div.getAttributeNode("v-bind:class").getNamespaceURI());
+        String xml = assertDoesNotThrow(() -> w3CDom.asString(w3CDoc));
+        assertTrue(xml.contains("xmlns:v-bind=\"undefined\""));
+    }
+
+    @Test void normalizesInvalidPrefixWithoutNamespaceAwareness() {
+        // namespace declarations need a valid prefix even when the DOM is not namespace aware
+        W3CDom w3CDom = new W3CDom().namespaceAware(false);
+        org.w3c.dom.Document w3CDoc = w3CDom.fromJsoup(Jsoup.parseBodyFragment("<div 9a:b='v'></div>"));
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
+
+        assertEquals("v", div.getAttribute("_9a:b"));
+        assertEquals("undefined", div.getAttribute("xmlns:_9a"));
+        assertFalse(div.hasAttribute("xmlns:9a"));
+        String xml = w3CDom.asString(w3CDoc, W3CDom.OutputXml());
+        assertDoesNotThrow(() -> parseXml(xml, true));
+    }
+
     @Test void declaredNamespaceIsUsed() {
         W3CDom w3CDom = new W3CDom();
         String html = "<html xmlns:v-bind=\"http://example.com\"><body><div v-bind:class='test'></div></body></html>";
         org.jsoup.nodes.Document jdoc = Jsoup.parse(html);
         org.w3c.dom.Document w3CDoc = w3CDom.fromJsoup(jdoc);
+        org.w3c.dom.Element root = w3CDoc.getDocumentElement();
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
 
         String xml = w3CDom.asString(w3CDoc);
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:v-bind=\"http://example.com\"><head/><body><div v-bind:class=\"test\"/></body></html>", xml);
+        assertEquals(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, root.getAttributeNode("xmlns:v-bind").getNamespaceURI());
+        assertEquals("http://example.com", div.lookupNamespaceURI("v-bind"));
+        assertEquals(1, div.getAttributes().getLength());
+        assertEquals("test", div.getAttributeNS("http://example.com", "class"));
     }
 
     @Test void nestedElementsWithUndeclaredNamespace() {
@@ -560,9 +593,149 @@ public class W3CDomTest {
         String html = "<html><body><div v-bind:class='test'><span v-bind:style='color:red'></span></div></body></html>";
         org.jsoup.nodes.Document jdoc = Jsoup.parse(html);
         org.w3c.dom.Document w3CDoc = w3CDom.fromJsoup(jdoc);
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
+        org.w3c.dom.Element span = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("span").item(0);
 
         String xml = w3CDom.asString(w3CDoc);
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><html xmlns=\"http://www.w3.org/1999/xhtml\"><head/><body><div xmlns:v-bind=\"undefined\" v-bind:class=\"test\"><span v-bind:style=\"color:red\"/></div></body></html>", xml);
+        assertTrue(div.hasAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "v-bind"));
+        assertFalse(span.hasAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "v-bind"));
+        assertEquals("undefined", span.lookupNamespaceURI("v-bind"));
+        assertEquals("color:red", span.getAttributeNS("undefined", "style"));
+    }
+
+    @Test void addedAttributeUsesInheritedNamespace() {
+        // attributes added after parsing have no namespace metadata, so resolve them from the active declaration
+        String xml = "<root xmlns:p='urn:p'><child/></root>";
+        org.jsoup.nodes.Document jdoc = Jsoup.parse(xml, "", Parser.xmlParser());
+        jdoc.expectFirst("child").attr("p:x", "value");
+
+        org.w3c.dom.Document w3CDoc = new W3CDom().fromJsoup(jdoc);
+        org.w3c.dom.Element child = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("child").item(0);
+
+        assertEquals("value", child.getAttributeNS("urn:p", "x"));
+        assertFalse(child.hasAttribute("xmlns:p"));
+    }
+
+    @Test void emptyBindingShadowsAncestor() {
+        // an empty declaration shadows its inherited binding only within the current scope
+        String html = "<html xmlns:p='urn:outer'><body><div xmlns:p='' p:x='value'></div><span p:x='after'></span></body></html>";
+        org.w3c.dom.Document w3CDoc = new W3CDom().fromJsoup(Jsoup.parse(html));
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
+        org.w3c.dom.Element span = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("span").item(0);
+
+        assertEquals("undefined", div.lookupNamespaceURI("p"));
+        assertEquals("value", div.getAttributeNS("undefined", "x"));
+        assertEquals("undefined", div.getAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "p"));
+        assertEquals("after", span.getAttributeNS("urn:outer", "x"));
+        assertFalse(span.hasAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "p"));
+    }
+
+    @Test void subtreeConversionPreservesInheritedNamespace() throws ParserConfigurationException {
+        // declarations outside the converted subtree must be carried into its standalone W3C output
+        String html = "<main xmlns:p='urn:p'><section><div p:x='value'></div></section></main>";
+        org.jsoup.nodes.Element section = Jsoup.parseBodyFragment(html).expectFirst("section");
+        org.w3c.dom.Document out = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+
+        new W3CDom().convert(section, out);
+        org.w3c.dom.Element div = (org.w3c.dom.Element) out.getElementsByTagName("div").item(0);
+
+        assertEquals("value", div.getAttributeNS("urn:p", "x"));
+        assertEquals("urn:p", div.getAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "p"));
+        assertDoesNotThrow(() -> new W3CDom().asString(out));
+    }
+
+    @Test void namespaceDisabledSubtreeDeclaresInheritedPrefix() throws ParserConfigurationException {
+        // attributes remain unnamespaced, but inherited prefixes must still be declared for serialization
+        String html = "<main xmlns:p='urn:p'><section><div p:x='value'></div></section></main>";
+        org.jsoup.nodes.Element section = Jsoup.parseBodyFragment(html).expectFirst("section");
+        org.w3c.dom.Document out = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+
+        W3CDom w3cDom = new W3CDom().namespaceAware(false);
+        w3cDom.convert(section, out);
+        org.w3c.dom.Element div = (org.w3c.dom.Element) out.getElementsByTagName("div").item(0);
+
+        assertNull(div.getAttributeNode("p:x").getNamespaceURI());
+        assertEquals("urn:p", div.getAttribute("xmlns:p"));
+        assertDoesNotThrow(() -> w3cDom.asString(out));
+    }
+
+    @Test void normalizesInvalidPrefixedAttribute() {
+        // normalize both prefix and local name without losing the declared namespace or value
+        String html = "<html xmlns:p;bad='urn:p'><body><div p;bad:x;local='value'></div></body></html>";
+        org.w3c.dom.Document w3CDoc = new W3CDom().fromJsoup(Jsoup.parse(html));
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
+
+        assertEquals(1, div.getAttributes().getLength());
+        assertEquals("value", div.getAttributeNS("urn:p", "x_local"));
+    }
+
+    @Test void normalizesMultiColonAttributeQName() {
+        // HTML permits multiple colons, but the W3C DOM accepts only one QName separator
+        String html = "<main><div a:b:c='v'><span>inside</span></div><p>after</p></main>";
+        org.w3c.dom.Document w3CDoc = new W3CDom().fromJsoup(Jsoup.parseBodyFragment(html));
+        org.w3c.dom.Element main = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("main").item(0);
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
+        org.w3c.dom.Element span = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("span").item(0);
+        org.w3c.dom.Element p = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("p").item(0);
+
+        assertSame(main, div.getParentNode());
+        assertSame(div, span.getParentNode());
+        assertSame(main, p.getParentNode());
+        assertEquals("v", div.getAttributeNS("undefined", "b_c"));
+    }
+
+    @Test void normalizesMultiColonElementQName() {
+        String html = "<main><a:b:c><span>inside</span></a:b:c><p>after</p></main>";
+        org.w3c.dom.Document w3CDoc = new W3CDom().fromJsoup(Jsoup.parseBodyFragment(html));
+        org.w3c.dom.Element main = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("main").item(0);
+        org.w3c.dom.Element child = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("a:b_c").item(0);
+        org.w3c.dom.Element span = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("span").item(0);
+        org.w3c.dom.Element p = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("p").item(0);
+
+        assertSame(main, child.getParentNode());
+        assertSame(child, span.getParentNode());
+        assertSame(main, p.getParentNode());
+    }
+
+    @Test void preservesValidQNameCharacters() {
+        // Unicode letters are valid starts; other valid characters are retained by prepending a safe start
+        String html = "<html xmlns:a='urn:a'><body><div a:é='unicode' a:_b='underscore' a:9b='digit'></div></body></html>";
+        org.w3c.dom.Document w3CDoc = new W3CDom().fromJsoup(Jsoup.parse(html));
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
+
+        assertEquals("unicode", div.getAttributeNS("urn:a", "é"));
+        assertEquals("underscore", div.getAttributeNS("urn:a", "_b"));
+        assertEquals("digit", div.getAttributeNS("urn:a", "_9b"));
+        assertEquals(3, div.getAttributes().getLength());
+    }
+
+    @Test void skipsUnrepresentableAttribute() {
+        // a reserved prefix bound to the wrong namespace cannot be represented, but must not drop its element
+        String html = "<main><div xmlns:xml='wrong' xml:x='v'><span>inside</span></div><p>after</p></main>";
+        org.w3c.dom.Document w3CDoc = new W3CDom().fromJsoup(Jsoup.parseBodyFragment(html));
+        org.w3c.dom.Element main = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("main").item(0);
+        org.w3c.dom.Element div = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("div").item(0);
+        org.w3c.dom.Element span = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("span").item(0);
+        org.w3c.dom.Element p = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("p").item(0);
+
+        assertSame(main, div.getParentNode());
+        assertSame(div, span.getParentNode());
+        assertSame(main, p.getParentNode());
+        assertFalse(div.hasAttribute("xml:x"));
+    }
+
+    @Test void preservesTreeForUnrepresentableElement() {
+        // invalid namespace combinations fall back to text without changing the surrounding tree
+        String html = "<main><xml:thing><span>inside</span></xml:thing><p>after</p></main>";
+        org.w3c.dom.Document w3CDoc = new W3CDom().fromJsoup(Jsoup.parseBodyFragment(html));
+        org.w3c.dom.Element main = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("main").item(0);
+        org.w3c.dom.Element span = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("span").item(0);
+        org.w3c.dom.Element p = (org.w3c.dom.Element) w3CDoc.getElementsByTagName("p").item(0);
+
+        assertSame(main, span.getParentNode());
+        assertSame(main, p.getParentNode());
+        assertEquals(0, w3CDoc.getElementsByTagName("xml:thing").getLength());
     }
 
     private static Stream<Arguments> parserProvider() {

--- a/src/test/java/org/jsoup/internal/NamespaceBindingsTest.java
+++ b/src/test/java/org/jsoup/internal/NamespaceBindingsTest.java
@@ -1,0 +1,64 @@
+package org.jsoup.internal;
+
+import org.jsoup.nodes.Attributes;
+import org.junit.jupiter.api.Test;
+
+import static org.jsoup.parser.Parser.NamespaceXml;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NamespaceBindingsTest {
+    @Test void restoresBindingsAfterNestedScopes() {
+        NamespaceBindings bindings = new NamespaceBindings();
+        bindings.put("xml", NamespaceXml);
+        bindings.put("p", "/base");
+
+        bindings.pushScope();
+        bindings.applyDeclarations(new Attributes().put("xmlns:p", "/one"));
+        assertEquals("/one", bindings.get("p"));
+
+        bindings.pushScope();
+        bindings.applyDeclarations(new Attributes().put("xmlns:p", ""));
+        assertEquals("", bindings.get("p"));
+        bindings.put("q", "/two");
+        assertEquals("/two", bindings.get("q"));
+
+        bindings.popScope();
+        assertEquals("/one", bindings.get("p"));
+        assertNull(bindings.get("q"));
+
+        bindings.popScope();
+        assertEquals("/base", bindings.get("p"));
+        assertEquals(NamespaceXml, bindings.get("xml"));
+    }
+
+    @Test void stateGrowsLinearlyWithScopeDepth() {
+        // each scope retains one marker and only its changed bindings
+        int depth = 1_000;
+        NamespaceBindings bindings = new NamespaceBindings();
+        bindings.put("xml", NamespaceXml);
+
+        for (int i = 0; i < depth; i++) {
+            bindings.pushScope();
+            bindings.put("p" + i, "urn:" + i);
+        }
+        bindings.put("p999", "urn:999"); // unchanged bindings don't add change records
+
+        assertEquals(depth + 1, bindings.bindingCount());
+        assertEquals(depth * 2, bindings.changeCount());
+
+        for (int i = 0; i < depth; i++)
+            bindings.popScope();
+
+        assertEquals(1, bindings.bindingCount());
+        assertEquals(0, bindings.changeCount());
+    }
+
+    @Test void recognizesNamespaceDeclarations() {
+        assertTrue(NamespaceBindings.isDeclaration("xmlns"));
+        assertTrue(NamespaceBindings.isDeclaration("xmlns:p"));
+        assertFalse(NamespaceBindings.isDeclaration("xml:lang"));
+    }
+}

--- a/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
+++ b/src/test/java/org/jsoup/parser/XmlTreeBuilderTest.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -743,24 +742,6 @@ public class XmlTreeBuilderTest {
         assertEquals("/incoming", y.tag().namespace());
     }
 
-    @Test void namespaceTrackingRetainsLinearState() {
-        int depth = 1_000;
-        XmlTreeBuilder treeBuilder = new XmlTreeBuilder();
-        Parser parser = new Parser(treeBuilder);
-        treeBuilder.initialiseParse(new StringReader(deeplyNamespacedXml(depth)), "", parser);
-
-        try {
-            while (treeBuilder.stack.size() < depth) {
-                assertTrue(treeBuilder.stepParser());
-            }
-
-            assertEquals(depth + 2, treeBuilder.namespaceBindings.size()); // declarations plus the two initial bindings
-            assertEquals(depth * 2, treeBuilder.namespaceChanges.size()); // one marker and binding change per element
-        } finally {
-            treeBuilder.closeParse();
-        }
-    }
-
     private static String deepXml(int depth) {
         StringBuilder xml = new StringBuilder("<root>");
         for (int i = 0; i < depth; i++) {
@@ -771,17 +752,6 @@ public class XmlTreeBuilderTest {
             xml.append("</n>");
         }
         xml.append("</root>");
-        return xml.toString();
-    }
-
-    private static String deeplyNamespacedXml(int depth) {
-        StringBuilder xml = new StringBuilder();
-        for (int i = 0; i < depth; i++) {
-            xml.append("<n xmlns:p").append(i).append("='urn:").append(i).append("'>");
-        }
-        for (int i = 0; i < depth; i++) {
-            xml.append("</n>");
-        }
         return xml.toString();
     }
 


### PR DESCRIPTION
This follows the XML namespace scope optimization in [#2556](https://github.com/jhy/jsoup/pull/2556).

`XmlTreeBuilder` and `W3Dom.W3CBuilder` both need to track namespace bindings as elements open and close. This extracts that work into a shared `NamespaceBindings` helper instead of maintaining two implementations.

The helper keeps one active bindings map and records only the changes needed to restore each parent scope. This preserves the XML parser’s improved memory use and processing time while making the same scoped lookup available to the W3C converter.

`W3CDom` uses one tracker for source bindings and another for declarations already emitted into the W3C tree. That replaces repeated ancestor searches with direct lookups and avoids emitting unnecessary declarations.

## W3C DOM fixes

This also fixes namespace conversion in several cases:

- Namespace declarations and prefixed attributes now carry the correct namespace URI, so namespace-aware DOM lookups work as expected. This implements the prefixed-attribute handling discussed in [#1839](https://github.com/jhy/jsoup/issues/1839).
- Attributes added after parsing, or included through subtree conversion, now use inherited prefix declarations.
- Namespace declarations now apply regardless of attribute order, and an empty declaration shadows an inherited binding only within its scope.
- With namespace awareness disabled, inherited and undeclared prefixes receive the declarations needed for XML serialization. This preserves and extends the undeclared-prefix behavior from [#2087](https://github.com/jhy/jsoup/issues/2087).
- Valid HTML names that are not XML QNames are normalized before being passed to the W3C DOM. For example, `a:b:c` becomes `a:b_c`.
- Attributes that the W3C DOM still cannot represent are skipped without dropping their containing element.
- Elements that cannot be represented fall back to text without moving their children or following siblings outside the surrounding tree.