### PR TITLE
Add Elements.before(Node) and after/prepend/append(Node) #953

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,11 @@
 ## 1.23.2 (pending)
 
 ### Improvements
-* Added `Elements#before(Node)`, `after(Node)`, `prepend(Node)`, and `append(Node)` to match the existing HTML string methods. The supplied node is cloned for each matched element. [#953](https://github.com/jhy/jsoup/issues/953)
 * Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery. [#2551](https://github.com/jhy/jsoup/pull/2551)
 * Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope. [#2556](https://github.com/jhy/jsoup/pull/2556)
 * Improved `W3CDom` conversion performance for documents with many nested namespace declarations. The W3C converter now uses the same optimized namespace tracking as the XML parser. [#2559](https://github.com/jhy/jsoup/pull/2559)
 * DOM mutation methods, including child insertion and replacement, now reject operations that would create a cycle, such as making a node its own child or moving an ancestor beneath a descendant. [#2552](https://github.com/jhy/jsoup/issues/2552)
+* Added `Elements#before(Node)`, `after(Node)`, `prepend(Node)`, and `append(Node)` to match the existing HTML string methods. [#953](https://github.com/jhy/jsoup/issues/953)
 
 ### Bug Fixes
 * Fixed `W3CDom` namespace conversion in several cases: [#2559](https://github.com/jhy/jsoup/pull/2559)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## 1.23.2 (pending)
 
 ### Improvements
+* Added `Elements#before(Node)`, `after(Node)`, `prepend(Node)`, and `append(Node)` to match the existing HTML string methods. The supplied node is cloned for each matched element. [#953](https://github.com/jhy/jsoup/issues/953)
 * Improved consecutive `StreamParser.selectFirst(...)` calls during progressive parsing, so later matches are returned with their parsed contents when earlier selections have left them as parser lookahead. E.g., given `<title>One</title><p id=hit>Full</p><p>Next</p>`, selecting `title` and then `#hit` now advances the partial lookahead and returns `<p id="hit">Full</p>`, rather than returning an empty `<p id="hit"></p>` before its content is parsed. The updated readiness tracking follows StreamParser's normal emission order across implicit HTML structure and parser recovery. [#2551](https://github.com/jhy/jsoup/pull/2551)
 * Improved XML parser performance and memory use for documents with many nested namespace declarations by recording namespace changes within each element scope. [#2556](https://github.com/jhy/jsoup/pull/2556)
 * Improved `W3CDom` conversion performance for documents with many nested namespace declarations. The W3C converter now uses the same optimized namespace tracking as the XML parser. [#2559](https://github.com/jhy/jsoup/pull/2559)

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -14,10 +14,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.function.Predicate;
+import java.util.function.BiConsumer;
 import java.util.function.UnaryOperator;
 
 /**
@@ -316,17 +315,14 @@ public class Elements extends Nodes<Element> {
     }
 
     /**
-     * Add the supplied node to the start of each matched element's inner HTML. The node is cloned for each target.
-     * @param node the node to add inside each element, before the existing HTML
-     * @return this, for chaining
-     * @see Element#prependChild(Node)
+     Add the supplied node to the start of each matched element's inner HTML. The node is cloned for each target.
+
+     @param node the node to add inside each element, before the existing HTML
+     @return this, for chaining
+     @see Element#prependChild(Node)
      */
     public Elements prepend(Node node) {
-        Validate.notNull(node);
-        for (Element element : this) {
-            element.prependChild(node.clone());
-        }
-        return this;
+        return insert(node, Element::prependChild);
     }
     
     /**
@@ -343,17 +339,14 @@ public class Elements extends Nodes<Element> {
     }
 
     /**
-     * Add the supplied node to the end of each matched element's inner HTML. The node is cloned for each target.
-     * @param node the node to add inside each element, after the existing HTML
-     * @return this, for chaining
-     * @see Element#appendChild(Node)
+     Add the supplied node to the end of each matched element's inner HTML. The node is cloned for each target.
+
+     @param node the node to add inside each element, after the existing HTML
+     @return this, for chaining
+     @see Element#appendChild(Node)
      */
     public Elements append(Node node) {
-        Validate.notNull(node);
-        for (Element element : this) {
-            element.appendChild(node.clone());
-        }
-        return this;
+        return insert(node, Element::appendChild);
     }
 
     /**
@@ -377,11 +370,7 @@ public class Elements extends Nodes<Element> {
      @see Element#before(Node)
      */
     public Elements before(Node node) {
-        Validate.notNull(node);
-        for (Element element : this) {
-            element.before(node.clone());
-        }
-        return this;
+        return insert(node, Element::before);
     }
 
     /**
@@ -405,10 +394,20 @@ public class Elements extends Nodes<Element> {
      @see Element#after(Node)
      */
     public Elements after(Node node) {
+        return insert(node, Element::after);
+    }
+
+    /**
+     Applies a node insertion to each matched element, cloning the node for each target.
+
+     @param node     the node to insert
+     @param inserter the insertion operation
+     @return this, for chaining
+     */
+    private Elements insert(Node node, BiConsumer<Element, Node> inserter) {
         Validate.notNull(node);
-        for (Element element : this) {
-            element.after(node.clone());
-        }
+        for (Element element : this)
+            inserter.accept(element, node.clone());
         return this;
     }
 

--- a/src/main/java/org/jsoup/select/Elements.java
+++ b/src/main/java/org/jsoup/select/Elements.java
@@ -314,6 +314,20 @@ public class Elements extends Nodes<Element> {
         }
         return this;
     }
+
+    /**
+     * Add the supplied node to the start of each matched element's inner HTML. The node is cloned for each target.
+     * @param node the node to add inside each element, before the existing HTML
+     * @return this, for chaining
+     * @see Element#prependChild(Node)
+     */
+    public Elements prepend(Node node) {
+        Validate.notNull(node);
+        for (Element element : this) {
+            element.prependChild(node.clone());
+        }
+        return this;
+    }
     
     /**
      * Add the supplied HTML to the end of each matched element's inner HTML.
@@ -324,6 +338,20 @@ public class Elements extends Nodes<Element> {
     public Elements append(String html) {
         for (Element element : this) {
             element.append(html);
+        }
+        return this;
+    }
+
+    /**
+     * Add the supplied node to the end of each matched element's inner HTML. The node is cloned for each target.
+     * @param node the node to add inside each element, after the existing HTML
+     * @return this, for chaining
+     * @see Element#appendChild(Node)
+     */
+    public Elements append(Node node) {
+        Validate.notNull(node);
+        for (Element element : this) {
+            element.appendChild(node.clone());
         }
         return this;
     }
@@ -342,6 +370,21 @@ public class Elements extends Nodes<Element> {
     }
 
     /**
+     Insert the supplied node before each matched element's outer HTML. The node is cloned for each target.
+
+     @param node the node to insert before each element
+     @return this, for chaining
+     @see Element#before(Node)
+     */
+    public Elements before(Node node) {
+        Validate.notNull(node);
+        for (Element element : this) {
+            element.before(node.clone());
+        }
+        return this;
+    }
+
+    /**
      Insert the supplied HTML after each matched element's outer HTML.
 
      @param html HTML to insert after each element
@@ -351,6 +394,21 @@ public class Elements extends Nodes<Element> {
     @Override
     public Elements after(String html) {
         super.after(html);
+        return this;
+    }
+
+    /**
+     Insert the supplied node after each matched element's outer HTML. The node is cloned for each target.
+
+     @param node the node to insert after each element
+     @return this, for chaining
+     @see Element#after(Node)
+     */
+    public Elements after(Node node) {
+        Validate.notNull(node);
+        for (Element element : this) {
+            element.after(node.clone());
+        }
         return this;
     }
 

--- a/src/test/java/org/jsoup/select/ElementsTest.java
+++ b/src/test/java/org/jsoup/select/ElementsTest.java
@@ -169,10 +169,38 @@ public class ElementsTest {
         assertEquals("<p>This <span>foo</span><a>is</a> <span>foo</span><a>jsoup</a>.</p>", TextUtil.stripNewlines(doc.body().html()));
     }
 
+    @Test public void beforeNode() {
+        Document doc = Jsoup.parse("<p>This <a>is</a> <a>jsoup</a>.</p>");
+        Element span = new Element("span").text("foo");
+        doc.select("a").before(span);
+        assertEquals("<p>This <span>foo</span><a>is</a> <span>foo</span><a>jsoup</a>.</p>", TextUtil.stripNewlines(doc.body().html()));
+        assertNull(span.parent()); // cloned per target; original is left alone
+        assertNotSame(span, doc.selectFirst("span"));
+    }
+
     @Test public void after() {
         Document doc = Jsoup.parse("<p>This <a>is</a> <a>jsoup</a>.</p>");
         doc.select("a").after("<span>foo</span>");
         assertEquals("<p>This <a>is</a><span>foo</span> <a>jsoup</a><span>foo</span>.</p>", TextUtil.stripNewlines(doc.body().html()));
+    }
+
+    @Test public void afterNode() {
+        Document doc = Jsoup.parse("<p>This <a>is</a> <a>jsoup</a>.</p>");
+        Element span = new Element("span").text("foo");
+        doc.select("a").after(span);
+        assertEquals("<p>This <a>is</a><span>foo</span> <a>jsoup</a><span>foo</span>.</p>", TextUtil.stripNewlines(doc.body().html()));
+        assertNull(span.parent());
+    }
+
+    @Test public void prependAppendNode() {
+        Document doc = Jsoup.parse("<p>One</p><p>Two</p><p>Three</p>");
+        Elements ps = doc.select("p");
+        Element bold = new Element("b").text("Bold");
+        Element ital = new Element("i").text("Ital");
+        ps.prepend(bold).append(ital);
+        assertEquals("<p><b>Bold</b>Two<i>Ital</i></p>", TextUtil.stripNewlines(ps.get(1).outerHtml()));
+        assertNull(bold.parent());
+        assertNull(ital.parent());
     }
 
     @Test public void wrap() {


### PR DESCRIPTION
#953 asked for Elements.before(Node). You said to do the same for after, prepend, and append so they match the string methods.

Each call clones the node. That way inserting into a list does not move one instance between targets, and I am not serializing through HTML.

Tests are in ElementsTest next to the existing string cases.
