### PR TITLE
Remove obsolete HTML stack lookup limits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
 * Aligned trailing comment placement with the HTML specification: comments after `</body>` remain children of the `html` element, while comments after `</html>` remain children of the document. [#2557](https://github.com/jhy/jsoup/pull/2557)
 * When using the optional `re2j` regular expression engine, heap exhaustion caused by complex selector patterns during matching is now normalized to a `ValidationException` with a `Pattern complexity error` message.
 * Fixed parsing of malformed SVG and MathML content so that breakout HTML tags are placed according to the HTML specification. [#2562](https://github.com/jhy/jsoup/issues/2562)
-* Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth.
+* Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth. [#2569](https://github.com/jhy/jsoup/pull/2569)
 
 
 ## 1.23.1 (2026-Jul-30)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 * Aligned trailing comment placement with the HTML specification: comments after `</body>` remain children of the `html` element, while comments after `</html>` remain children of the document. [#2557](https://github.com/jhy/jsoup/pull/2557)
 * When using the optional `re2j` regular expression engine, heap exhaustion caused by complex selector patterns during matching is now normalized to a `ValidationException` with a `Pattern complexity error` message.
 * Fixed parsing of malformed SVG and MathML content so that breakout HTML tags are placed according to the HTML specification. [#2562](https://github.com/jhy/jsoup/issues/2562)
+* Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth.
 
 
 ## 1.23.1 (2026-Jul-30)

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -525,7 +525,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     }
 
     boolean onStack(Element el) {
-        return onStack(stack, el);
+        return stack.contains(el);
     }
 
     /** Checks if there is an HTML element with the given name on the stack. */
@@ -533,25 +533,10 @@ public class HtmlTreeBuilder extends TreeBuilder {
         return getFromStack(elName) != null;
     }
 
-    private static final int maxQueueDepth = 256; // an arbitrary tension point between real HTML and crafted pain
-    private static boolean onStack(ArrayList<Element> queue, Element element) {
-        final int bottom = queue.size() - 1;
-        final int upper = bottom >= maxQueueDepth ? bottom - maxQueueDepth : 0;
-        for (int pos = bottom; pos >= upper; pos--) {
-            Element next = queue.get(pos);
-            if (next == element) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /** Gets the nearest (lowest) HTML element with the given name from the stack. */
     @Nullable
     Element getFromStack(String elName) {
-        final int bottom = stack.size() - 1;
-        final int upper = bottom >= maxQueueDepth ? bottom - maxQueueDepth : 0;
-        for (int pos = bottom; pos >= upper; pos--) {
+        for (int pos = stack.size() - 1; pos >= 0; pos--) {
             Element next = stack.get(pos);
             if (next.elementIs(elName, NamespaceHtml)) {
                 return next;
@@ -685,29 +670,18 @@ public class HtmlTreeBuilder extends TreeBuilder {
         queue.set(i, in);
     }
 
-    /**
-     * Reset the insertion mode, by searching up the stack for an appropriate insertion mode. The stack search depth
-     * is limited to {@link #maxQueueDepth}.
-     * @return true if the insertion mode was actually changed.
-     */
+    /** Reset the insertion mode by searching up the stack for an appropriate insertion mode. */
     boolean resetInsertionMode() {
         // https://html.spec.whatwg.org/multipage/parsing.html#the-insertion-mode
-        boolean last = false;
-        final int bottom = stack.size() - 1;
-        final int upper = bottom >= maxQueueDepth ? bottom - maxQueueDepth : 0;
         final HtmlTreeBuilderState origState = this.state;
 
         if (stack.size() == 0) { // nothing left of stack, just get to body
             transition(HtmlTreeBuilderState.InBody);
         }
 
-        LOOP: for (int pos = bottom; pos >= upper; pos--) {
-            Element node = stack.get(pos);
-            if (pos == upper) {
-                last = true;
-                if (fragmentParsing)
-                    node = contextElement;
-            }
+        LOOP: for (int pos = stack.size() - 1; pos >= 0; pos--) {
+            boolean last = pos == 0;
+            Element node = last && fragmentParsing ? contextElement : stack.get(pos);
             String name = node != null && NamespaceHtml.equals(node.tag().namespace()) ? node.normalName() : "";
 
             switch (name) {
@@ -1070,8 +1044,6 @@ public class HtmlTreeBuilder extends TreeBuilder {
     }
 
     void reconstructFormattingElements() {
-        if (stack.size() > maxQueueDepth)
-            return;
         Element last = lastFormattingElement();
         if (last == null || onStack(last))
             return;
@@ -1129,7 +1101,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
     }
 
     boolean isInActiveFormattingElements(Element el) {
-        return onStack(formattingElements, el);
+        return formattingElements.contains(el);
     }
 
     @Nullable

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -2660,6 +2660,29 @@ public class HtmlParserTest {
             assertEquals("<table>\n <tbody></tbody>\n <tr></tr>\n <td></td>\n</table>", container.html());
         }
 
+        @Test void deepBodyResetWithinMaxDepth() {
+            assertDeepBodyReset(255, 512);
+        }
+
+        @Test void deepBodyResetBeyondMaxDepth() {
+            assertDeepBodyReset(20, 16);
+        }
+
+        private void assertDeepBodyReset(int nesting, int maxDepth) {
+            StringBuilder html = new StringBuilder("<dl><b>");
+            for (int i = 0; i < nesting; i++) {
+                html.append("<r>");
+            }
+            html.append("</body>x</b>");
+
+            Parser parser = Parser.htmlParser().setMaxDepth(maxDepth);
+            Document doc = Jsoup.parse(html.toString(), "", parser);
+            Elements bodies = doc.select("body");
+            assertEquals(1, bodies.size());
+            assertEquals("x", bodies.first().text());
+            assertEquals(nesting, doc.select("r").size());
+        }
+
         @Test void customDepthLimit() {
             Parser parser = Parser.htmlParser().setMaxDepth(5);
             String input = "<html><body><div><div><div><div><div><div>";


### PR DESCRIPTION
Remove the old fixed `maxQueueDepth` checks, which conflicted with the parser’s configured `maxDepth`.

Use the configured maximum depth as the single limit for the HTML tree-builder stack.
