### PR TITLE
Stream large uploads with Java 11+ HttpClient

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 * DOM mutation methods, including child insertion and replacement, now reject operations that would create a cycle, such as making a node its own child or moving an ancestor beneath a descendant. [#2552](https://github.com/jhy/jsoup/issues/2552)
 * Added `Elements#before(Node)`, `after(Node)`, `prepend(Node)`, and `append(Node)` to match the existing HTML string methods. [#953](https://github.com/jhy/jsoup/issues/953)
 * XML serialization now repairs element and attribute names that start with an invalid character, rather than outputting `<null>` elements or dropping attributes. For example, an attribute named `1a` is written as `_1a`. Additional leading underscores keep repaired attribute names unique if they conflict with another attribute. [#2573](https://github.com/jhy/jsoup/issues/2573)
+* Large file-backed uploads through `Connection.requestBodyStream(InputStream)` now stream directly with the JDK `HttpClient` on Java 11+, rather than being loaded fully into memory first.
 
 ### Changes
 * Aligned the XML parser stack depth and lookups to the configured maximum, which now defaults to 512 for both HTML and XML. [#2570](https://github.com/jhy/jsoup/pull/2570)

--- a/src/main/java/org/jsoup/Connection.java
+++ b/src/main/java/org/jsoup/Connection.java
@@ -330,6 +330,8 @@ public interface Connection {
      </pre></code>
      <p>Or, use a FileInputStream to data from disk.</p>
      <p>You should close the stream in a finally block.</p>
+     <p>The stream is sent once and cannot be replayed. If a redirect or authentication challenge requires the request
+     to be resent, execution will fail; resend the request with a fresh stream.</p>
 
      @param stream the input stream to send.
      @return this Request, for chaining
@@ -867,6 +869,8 @@ public interface Connection {
          </pre></code>
          <p>Or, use a FileInputStream to data from disk.</p>
          <p>You should close the stream in a finally block.</p>
+         <p>The stream is sent once and cannot be replayed. If a redirect or authentication challenge requires the
+         request to be resent, execution will fail; resend the request with a fresh stream.</p>
 
          @param stream the input stream to send.
          @return this Request, for chaining

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -799,6 +799,11 @@ public class HttpConnection implements Connection {
             return this;
         }
 
+        /** Get the request body as an InputStream, or null if it is not a stream. */
+        @Nullable InputStream requestBodyStream() {
+            return body instanceof InputStream ? (InputStream) body : null;
+        }
+
         @Override
         public Request parser(Parser parser) {
             this.parser = parser;

--- a/src/main/java11/org/jsoup/helper/HttpClientExecutor.java
+++ b/src/main/java11/org/jsoup/helper/HttpClientExecutor.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.jsoup.helper.HttpConnection.Response;
 import static org.jsoup.helper.HttpConnection.Response.writePost;
@@ -147,13 +148,21 @@ class HttpClientExecutor extends RequestExecutor {
     }
 
     static HttpRequest.BodyPublisher requestBody(final HttpConnection.Request req) throws IOException {
-        if (req.method.hasBody()) {
-            ByteArrayOutputStream buf = new ByteArrayOutputStream();
-            writePost(req, buf);
-            return HttpRequest.BodyPublishers.ofByteArray(buf.toByteArray());
-        } else {
+        if (!req.method.hasBody())
             return HttpRequest.BodyPublishers.noBody();
+
+        InputStream bodyStream = req.requestBodyStream();
+        if (bodyStream != null) {
+            // stream the upload so that the HttpClient does not buffer it before sending
+            // a caller supplied stream is one-shot, so a replay gets nothing via an AtomicReference
+            AtomicReference<InputStream> stream = new AtomicReference<>(bodyStream);
+            return HttpRequest.BodyPublishers.ofInputStream(() -> stream.getAndSet(null));
         }
+
+        // other bodies are fields or text; need to serialize
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        writePost(req, buf);
+        return HttpRequest.BodyPublishers.ofByteArray(buf.toByteArray());
     }
 
     static class ProxyWrap extends ProxySelector {

--- a/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
+++ b/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
@@ -4,14 +4,18 @@ import org.jsoup.internal.SharedConstants;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.net.http.HttpRequest;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.jsoup.Connection.Method.POST;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpClientExecutorTest {
@@ -35,6 +39,24 @@ public class HttpClientExecutorTest {
         System.clearProperty(SharedConstants.UseHttpClient);
         RequestExecutor executor = RequestDispatch.get(new HttpConnection.Request(), null);
         assertTrue(HttpClientTestAccess.isHttpClientExecutor(executor));
+    }
+
+    @Test void requestBodyStreamIsNotBuffered() {
+        AtomicInteger reads = new AtomicInteger();
+        InputStream stream = new InputStream() {
+            @Override public int read() {
+                reads.incrementAndGet();
+                return -1;
+            }
+        };
+        HttpConnection.Request request = new HttpConnection.Request();
+        request.method(POST);
+        request.requestBodyStream(stream);
+
+        // building the publisher should not consume the stream; HttpClient only reads when sending
+        HttpRequest.BodyPublisher publisher = HttpClientTestAccess.requestBody(request);
+        assertEquals(-1, publisher.contentLength());
+        assertEquals(0, reads.get());
     }
 
     @Test void downgradesSocksProxyToUrlConnectionExecutor() {

--- a/src/test/java11/org/jsoup/helper/HttpClientTestAccess.java
+++ b/src/test/java11/org/jsoup/helper/HttpClientTestAccess.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URL;
+import java.net.http.HttpRequest;
 
 /**
  Test access shim for the Java 11 multi-release classes.
@@ -29,6 +30,17 @@ final class HttpClientTestAccess {
         if (resource == null)
             throw new IllegalStateException("Could not load " + ExecutorClassResource);
         return resource;
+    }
+
+    static HttpRequest.BodyPublisher requestBody(HttpConnection.Request request) {
+        // expose the publisher so we can verify that streamed bodies are created lazily
+        try {
+            return (HttpRequest.BodyPublisher) executorClass()
+                    .getDeclaredMethod("requestBody", HttpConnection.Request.class)
+                    .invoke(null, request);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not invoke HttpClientExecutor.requestBody", e);
+        }
     }
 
     static ProxySelector newProxyWrap() {


### PR DESCRIPTION
The Java 11+ HttpClient backend now streams `requestBodyStream(InputStream)` uploads directly, avoiding full in-memory buffering for large file-backed uploads.