### PR TITLE
Align text-state tokenization with the HTML spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@
 * When using the optional `re2j` regular expression engine, heap exhaustion caused by complex selector patterns during matching is now normalized to a `ValidationException` with a `Pattern complexity error` message.
 * Fixed parsing of malformed SVG and MathML content so that breakout HTML tags are placed according to the HTML specification. [#2562](https://github.com/jhy/jsoup/issues/2562)
 * Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth. [#2569](https://github.com/jhy/jsoup/pull/2569)
-* Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names.
+* Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names. [#2577](https://github.com/jhy/jsoup/pull/2577)
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 * When using the optional `re2j` regular expression engine, heap exhaustion caused by complex selector patterns during matching is now normalized to a `ValidationException` with a `Pattern complexity error` message.
 * Fixed parsing of malformed SVG and MathML content so that breakout HTML tags are placed according to the HTML specification. [#2562](https://github.com/jhy/jsoup/issues/2562)
 * Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth. [#2569](https://github.com/jhy/jsoup/pull/2569)
+* Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names.
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/parser/CharacterReader.java
+++ b/src/main/java/org/jsoup/parser/CharacterReader.java
@@ -117,7 +117,6 @@ public final class CharacterReader implements AutoCloseable {
         fillPoint = Math.min(bufLength, RefillPoint);
 
         scanBufferForNewlines(); // if enabled, we index newline positions for line number tracking
-        lastIcSeq = null; // cache for last containsIgnoreCase(seq)
     }
 
     void mark() {
@@ -147,11 +146,6 @@ public final class CharacterReader implements AutoCloseable {
      */
     public int pos() {
         return consumed + bufPos;
-    }
-
-    /** Tests if the buffer has been fully read. */
-    boolean readFully() {
-        return readFully;
     }
 
     /**
@@ -535,8 +529,9 @@ public final class CharacterReader implements AutoCloseable {
         return data;
     }
 
+    /** Consumes ASCII letters used by the HTML tokenizer's name states. */
     String consumeLetterSequence() {
-        return consumeMatching(Character::isLetter);
+        return consumeMatching(StringUtil::isAsciiLetter);
     }
 
     String consumeLetterThenDigitSequence() {
@@ -665,34 +660,6 @@ public final class CharacterReader implements AutoCloseable {
         } else {
             return false;
         }
-    }
-
-    // we maintain a cache of the previously scanned sequence, and return that if applicable on repeated scans.
-    // that improves the situation where there is a sequence of <p<p<p<p<p<p<p...</title> and we're bashing on the <p
-    // looking for the </title>. Resets in bufferUp()
-    @Nullable private String lastIcSeq; // scan cache
-    private int lastIcIndex; // nearest found indexOf
-
-    /** Used to check presence of </title>, </style> when we're in RCData and see a <xxx. */
-    boolean containsIgnoreCase(String seq) {
-        bufferUp();
-        if (seq.equals(lastIcSeq)) {
-            if (lastIcIndex == -1) return false;
-            if (lastIcIndex >= bufPos) return true;
-        }
-        lastIcSeq = seq;
-
-        int scanLength = seq.length();
-        int maxStart = bufLength - scanLength;
-        for (int scan = bufPos; scan <= maxStart; scan++) {
-            if (rangeMatchesIgnoreCase(seq, scan)) {
-                lastIcIndex = scan;
-                return true;
-            }
-        }
-
-        lastIcIndex = -1;
-        return false;
     }
 
     @Override

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -140,10 +140,7 @@ enum HtmlTreeBuilderState {
                         tb.startNoscript(start);
                     } else if (name.equals("script")) {
                         // skips some script rules as won't execute them
-                        tb.tokeniser.transition(TokeniserState.ScriptData);
-                        tb.markInsertionMode();
-                        tb.transition(Text);
-                        tb.insertElementFor(start);
+                        HandleTextState(start, tb, TokeniserState.ScriptData);
                     } else if (name.equals("head")) {
                         tb.error(this);
                         return false;
@@ -1878,6 +1875,7 @@ enum HtmlTreeBuilderState {
         return false;
     }
 
+    /** Inserts a text element and switches the tokenizer and tree builder into their text states. */
     private static void HandleTextState(Token.StartTag startTag, HtmlTreeBuilder tb, @Nullable TokeniserState state) {
         if (state != null)
             tb.tokeniser.transition(state);

--- a/src/main/java/org/jsoup/parser/Tag.java
+++ b/src/main/java/org/jsoup/parser/Tag.java
@@ -1,5 +1,7 @@
 package org.jsoup.parser;
 
+import org.jsoup.helper.Validate;
+import org.jsoup.internal.StringUtil;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
@@ -95,9 +97,11 @@ public class Tag implements Cloneable {
      Change the tag's name. As Tags are reused throughout a Document, this will change the name for all uses of this tag.
      @param tagName the new name of the tag. Case-sensitive.
      @return this tag
+     @throws IllegalArgumentException if this is a Data or RcData tag and the name cannot form a recognizable end tag
      @since 1.20.1
      */
     public Tag name(String tagName) {
+        if (is(RcData) || is(Data)) validateTextTagName(tagName);
         this.tagName = tagName;
         this.normalName = ParseSettings.normalName(tagName);
         setParserOptions();
@@ -161,12 +165,24 @@ public class Tag implements Cloneable {
      <p>Once a tag has a setting applied, it will be considered a known tag.</p>
      @param option the option to set
      @return this tag
+     @throws IllegalArgumentException if setting Data or RcData on a tag whose name cannot form a recognizable end tag
      @since 1.20.1
      */
     public Tag set(int option) {
+        if ((option & (RcData | Data)) != 0) validateTextTagName(tagName);
         options |= option;
         options |= Tag.Known; // considered known if touched
         return this;
+    }
+
+    /** Ensures a text-mode tag has an unambiguous tokenizer end tag. */
+    private static void validateTextTagName(String name) {
+        boolean valid = !name.isEmpty() && StringUtil.isAsciiLetter(name.charAt(0));
+        for (int i = 0; valid && i < name.length(); i++) {
+            char c = name.charAt(i);
+            valid = c != '<' && c != '>' && c != '/' && c != '\0' && c != '\uFFFD' && !StringUtil.isWhitespace(c);
+        }
+        Validate.isTrue(valid, "Data and RcData tag names must start with an ASCII letter and contain no whitespace, '<', '>', '/', null, or replacement characters");
     }
 
     /**

--- a/src/main/java/org/jsoup/parser/Tokeniser.java
+++ b/src/main/java/org/jsoup/parser/Tokeniser.java
@@ -49,7 +49,6 @@ final class Tokeniser {
     final Token.Comment commentPending = new Token.Comment(); // comment building up
     final Token.XmlDecl xmlDeclPending; // xml decl building up
     @Nullable private String lastStartTag; // the last start tag emitted, to test appropriate end tag
-    @Nullable private String lastStartCloseSeq; // "</" + lastStartTag, so we can quickly check for that in RCData
 
     private int markupStartPos, charStartPos = 0; // reader pos at the start of markup / characters. markup updated on state transition, char on token emit.
 
@@ -90,7 +89,6 @@ final class Tokeniser {
         if (token.type == Token.TokenType.StartTag) {
             Token.StartTag startTag = (Token.StartTag) token;
             lastStartTag = startTag.name();
-            lastStartCloseSeq = null; // only lazy inits
         } else if (token.type == Token.TokenType.EndTag) {
             Token.EndTag endTag = (Token.EndTag) token;
             if (endTag.hasAttributes())
@@ -262,25 +260,26 @@ final class Tokeniser {
         dataBuffer.reset();
     }
 
-    /** Test if CDATA sections are allowed at the adjusted current node */
+    /** Test if CDATA sections are allowed at the adjusted current node. */
     boolean isCdataAllowed() {
         return syntax == Document.OutputSettings.Syntax.xml
             || (treeBuilder.hasCurrentElement() && !Parser.NamespaceHtml.equals(treeBuilder.currentElement().tag().namespace()));
     }
 
+    /** Test if the pending end tag matches the last emitted start tag. */
     boolean isAppropriateEndTagToken() {
         return lastStartTag != null && tagPending.name().equalsIgnoreCase(lastStartTag);
     }
 
-    @Nullable String appropriateEndTagName() {
-        return lastStartTag; // could be null
-    }
+    /** Test if appending the character would keep the pending end tag a prefix of the expected name. */
+    boolean isAppropriateEndTagPrefix(char next) {
+        if (lastStartTag == null) return false;
 
-    /** Returns the closer sequence {@code </lastStart} */
-    String appropriateEndTagSeq() {
-        if (lastStartCloseSeq == null) // reset on start tag emit
-            lastStartCloseSeq = "</" + lastStartTag;
-        return lastStartCloseSeq;
+        String candidate = tagPending.normalName();
+        int length = candidate.length();
+        return length < lastStartTag.length()
+            && lastStartTag.regionMatches(true, 0, candidate, 0, length)
+            && lastStartTag.charAt(length) == next;
     }
 
     void error(TokeniserState state) {

--- a/src/main/java/org/jsoup/parser/TokeniserState.java
+++ b/src/main/java/org/jsoup/parser/TokeniserState.java
@@ -187,14 +187,7 @@ enum TokeniserState {
         // from < in rcdata
         @Override void read(Tokeniser t, CharacterReader r) {
             if (r.matches('/')) {
-                t.createTempBuffer();
                 t.advanceTransition(RCDATAEndTagOpen);
-            } else if (r.readFully() && r.matchesAsciiAlpha() && t.appropriateEndTagName() != null &&  !r.containsIgnoreCase(t.appropriateEndTagSeq())) {
-                // diverge from spec: got a start tag, but there's no appropriate end tag (</title>), so rather than
-                // consuming to EOF; break out here
-                t.tagPending = t.createTagPending(false).name(t.appropriateEndTagName());
-                t.emitTagPending();
-                t.transition(TagOpen); // straight into TagOpen, as we came from < and looks like we're on a start tag
             } else {
                 t.emit('<');
                 t.transition(Rcdata);
@@ -203,68 +196,17 @@ enum TokeniserState {
     },
     RCDATAEndTagOpen {
         @Override void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesAsciiAlpha()) {
-                t.createTagPending(false);
-                t.tagPending.appendTagName(r.current());
-                t.dataBuffer.append(r.current());
-                t.advanceTransition(RCDATAEndTagName);
-            } else {
-                t.emit("</");
-                t.transition(Rcdata);
-            }
+            readEndTag(t, r, RCDATAEndTagName, Rcdata);
         }
     },
     RCDATAEndTagName {
         @Override void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesAsciiAlpha()) {
-                String name = r.consumeTagName();
-                t.tagPending.appendTagName(name);
-                t.dataBuffer.append(name);
-                return;
-            }
-
-            char c = r.consume();
-            switch (c) {
-                case '\t':
-                case '\n':
-                case '\r':
-                case '\f':
-                case ' ':
-                    if (t.isAppropriateEndTagToken())
-                        t.transition(BeforeAttributeName);
-                    else
-                        anythingElse(t, r);
-                    break;
-                case '/':
-                    if (t.isAppropriateEndTagToken())
-                        t.transition(SelfClosingStartTag);
-                    else
-                        anythingElse(t, r);
-                    break;
-                case '>':
-                    if (t.isAppropriateEndTagToken()) {
-                        t.emitTagPending();
-                        t.transition(Data);
-                    }
-                    else
-                        anythingElse(t, r);
-                    break;
-                default:
-                    anythingElse(t, r);
-            }
-        }
-
-        private void anythingElse(Tokeniser t, CharacterReader r) {
-            t.emit("</");
-            t.emit(t.dataBuffer.value());
-            r.unconsume();
-            t.transition(Rcdata);
+            handleDataEndTag(t, r, Rcdata);
         }
     },
     RawtextLessthanSign {
         @Override void read(Tokeniser t, CharacterReader r) {
             if (r.matches('/')) {
-                t.createTempBuffer();
                 t.advanceTransition(RawtextEndTagOpen);
             } else {
                 t.emit('<');
@@ -286,7 +228,6 @@ enum TokeniserState {
         @Override void read(Tokeniser t, CharacterReader r) {
             switch (r.consume()) {
                 case '/':
-                    t.createTempBuffer();
                     t.transition(ScriptDataEndTagOpen);
                     break;
                 case '!':
@@ -430,7 +371,6 @@ enum TokeniserState {
                 t.emit(r.current());
                 t.advanceTransition(ScriptDataDoubleEscapeStart);
             } else if (r.matches('/')) {
-                t.createTempBuffer();
                 t.advanceTransition(ScriptDataEscapedEndTagOpen);
             } else {
                 t.emit('<');
@@ -440,15 +380,7 @@ enum TokeniserState {
     },
     ScriptDataEscapedEndTagOpen {
         @Override void read(Tokeniser t, CharacterReader r) {
-            if (r.matchesAsciiAlpha()) {
-                t.createTagPending(false);
-                t.tagPending.appendTagName(r.current());
-                t.dataBuffer.append(r.current());
-                t.advanceTransition(ScriptDataEscapedEndTagName);
-            } else {
-                t.emit("</");
-                t.transition(ScriptDataEscaped);
-            }
+            readEndTag(t, r, ScriptDataEscapedEndTagName, ScriptDataEscaped);
         }
     },
     ScriptDataEscapedEndTagName {
@@ -1701,49 +1633,53 @@ enum TokeniserState {
     private static final String replacementStr = String.valueOf(Tokeniser.replacementChar);
     private static final char eof = CharacterReader.EOF;
 
-    /**
-     * Handles RawtextEndTagName, ScriptDataEndTagName, and ScriptDataEscapedEndTagName. Same body impl, just
-     * different else exit transitions.
-     */
+    /** Handles the common RCDATA, RAWTEXT, and script-data end tag name states. */
     private static void handleDataEndTag(Tokeniser t, CharacterReader r, TokeniserState elseTransition) {
         if (r.matchesAsciiAlpha()) {
-            String name = r.consumeTagName();
+            String name = r.consumeLetterSequence();
             t.tagPending.appendTagName(name);
-            t.dataBuffer.append(name);
             return;
         }
 
-        boolean needsExitTransition = false;
+        if (!r.isEmpty()) {
+            char c = r.current();
+            if (isCustomEndTagNameChar(c) && t.isAppropriateEndTagPrefix(c)) {
+                r.advance();
+                t.tagPending.appendTagName(c);
+                return;
+            }
+        }
+
         if (t.isAppropriateEndTagToken() && !r.isEmpty()) {
-            char c = r.consume();
-            switch (c) {
+            switch (r.current()) {
                 case '\t':
                 case '\n':
                 case '\r':
                 case '\f':
                 case ' ':
+                    r.advance();
                     t.transition(BeforeAttributeName);
-                    break;
+                    return;
                 case '/':
+                    r.advance();
                     t.transition(SelfClosingStartTag);
-                    break;
+                    return;
                 case '>':
+                    r.advance();
                     t.emitTagPending();
                     t.transition(Data);
-                    break;
-                default:
-                    t.dataBuffer.append(c);
-                    needsExitTransition = true;
+                    return;
             }
-        } else {
-            needsExitTransition = true;
         }
 
-        if (needsExitTransition) {
-            t.emit("</");
-            t.emit(t.dataBuffer.value());
-            t.transition(elseTransition);
-        }
+        t.emit("</");
+        t.emit(t.tagPending.name());
+        t.transition(elseTransition); // reconsume the current character in the text state
+    }
+
+    /** Test if the character may extend a configured custom text tag name. */
+    private static boolean isCustomEndTagNameChar(char c) {
+        return c != '<' && c != '/' && c != '>' && !StringUtil.isWhitespace(c);
     }
 
     private static void readRawData(Tokeniser t, CharacterReader r, TokeniserState current, TokeniserState advance) {
@@ -1775,13 +1711,14 @@ enum TokeniserState {
         t.transition(advance);
     }
 
-    private static void readEndTag(Tokeniser t, CharacterReader r, TokeniserState a, TokeniserState b) {
+    /** Starts a text end tag candidate, or returns to its text state. */
+    private static void readEndTag(Tokeniser t, CharacterReader r, TokeniserState endTagNameState, TokeniserState textState) {
         if (r.matchesAsciiAlpha()) {
             t.createTagPending(false);
-            t.transition(a);
+            t.transition(endTagNameState);
         } else {
             t.emit("</");
-            t.transition(b);
+            t.transition(textState);
         }
     }
 

--- a/src/test/java/org/jsoup/parser/CharacterReaderTest.java
+++ b/src/test/java/org/jsoup/parser/CharacterReaderTest.java
@@ -176,9 +176,10 @@ public class CharacterReaderTest {
         assertEquals(" qux", r.consumeToAny('&', ';'));
     }
 
-    @Test public void consumeLetterSequence() {
-        CharacterReader r = new CharacterReader("One &bar; qux");
+    @Test public void consumeLetterSequenceInAscii() {
+        CharacterReader r = new CharacterReader("Oneã &bar; qux");
         assertEquals("One", r.consumeLetterSequence());
+        assertEquals('ã', r.consume());
         assertEquals(" &", r.consumeTo("bar;"));
         assertEquals("bar", r.consumeLetterSequence());
         assertEquals("; qux", r.consumeToEnd());
@@ -224,57 +225,6 @@ public class CharacterReaderTest {
         assertFalse(r.matchesIgnoreCase("ne Two Three Four"));
         assertEquals("ne Two Three", r.consumeToEnd());
         assertFalse(r.matchesIgnoreCase("ne"));
-    }
-
-    @Test public void containsIgnoreCase() {
-        CharacterReader r = new CharacterReader("One TWO three");
-        assertTrue(r.containsIgnoreCase("one"));
-        assertTrue(r.containsIgnoreCase("two"));
-        assertTrue(r.containsIgnoreCase("TwO"));
-        assertTrue(r.containsIgnoreCase("three"));
-        assertFalse(r.containsIgnoreCase("four"));
-    }
-
-    @Test public void containsIgnoreCaseFindsMixedCase() {
-        CharacterReader r = new CharacterReader("<p>text</TiTlE>");
-        assertTrue(r.containsIgnoreCase("</title>"));
-    }
-
-    @Test void containsIgnoreCaseBuffer() {
-        String html = "<p><p><p></title><p></TITLE><p>" + BufferBuster("Foo Bar Qux ") + "<foo><bar></title>";
-        CharacterReader r = new CharacterReader(html);
-
-        assertTrue(r.containsIgnoreCase("</title>"));
-        assertFalse(r.containsIgnoreCase("</not>"));
-        assertFalse(r.containsIgnoreCase("</not>")); // cached, but we only test functionally here
-        assertTrue(r.containsIgnoreCase("</title>"));
-        r.consumeTo("</title>");
-        assertTrue(r.containsIgnoreCase("</title>"));
-        r.consumeTo("<p>");
-        assertTrue(r.matches("<p>"));
-
-        assertTrue(r.containsIgnoreCase("</title>"));
-        assertTrue(r.containsIgnoreCase("</title>"));
-        assertFalse(r.containsIgnoreCase("</not>"));
-        assertFalse(r.containsIgnoreCase("</not>"));
-
-        r.consumeTo("</TITLE>");
-        r.consumeTo("<p>");
-        assertTrue(r.matches("<p>"));
-        assertFalse(r.containsIgnoreCase("</title>")); // because we haven't buffered up yet, we don't know
-        r.consumeTo("<foo>");
-        assertFalse(r.matches("<foo>")); // buffer underrun
-        r.consumeTo("<foo>");
-        assertTrue(r.matches("<foo>")); // cross the buffer
-        assertTrue(r.containsIgnoreCase("</TITLE>"));
-        assertTrue(r.containsIgnoreCase("</title>"));
-    }
-
-    static String BufferBuster(String content) {
-        StringBuilder builder = new StringBuilder();
-        while (builder.length() < maxBufferLen)
-            builder.append(content);
-        return builder.toString();
     }
 
     @Test public void matchesAny() {

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -147,11 +147,10 @@ public class HtmlParserTest {
     }
 
     @Test public void parsesUnterminatedTextarea() {
-        // don't parse right to end, but break on <p>
         Document doc = Jsoup.parse("<body><p><textarea>one<p>two");
         Element t = doc.select("textarea").first();
-        assertEquals("one", t.text());
-        assertEquals("two", doc.select("p").get(1).text());
+        assertEquals("one<p>two", t.text());
+        assertEquals(1, doc.select("p").size());
     }
 
     @Test public void parsesUnterminatedOption() {
@@ -1152,9 +1151,9 @@ public class HtmlParserTest {
         assertEquals("One <b>Two <b>Three", one.title());
         assertEquals("Test", one.select("p").first().text());
 
-        Document two = Jsoup.parse("<title>One<b>Two <p>Test</p>"); // no title, so <b> causes </title> breakout
-        assertEquals("One", two.title());
-        assertEquals("<b>Two \n <p>Test</p></b>", two.body().html());
+        Document two = Jsoup.parse("<title>One<b>Two <p>Test</p>");
+        assertEquals("One<b>Two <p>Test</p>", two.title());
+        assertEquals("", two.body().html());
     }
 
     @Test public void handlesUnclosedScriptAtEof() {

--- a/src/test/java/org/jsoup/parser/TagTest.java
+++ b/src/test/java/org/jsoup/parser/TagTest.java
@@ -2,6 +2,7 @@ package org.jsoup.parser;
 
 import org.jsoup.Jsoup;
 import org.jsoup.MultiLocaleExtension.MultiLocaleTest;
+import org.jsoup.helper.ValidationException;
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Test;
 
@@ -191,6 +192,27 @@ public class TagTest {
         assertTrue(input.isFormSubmittable());
         assertEquals(imgOpts, img.options);
         assertEquals(inputOpts, input.options);
+    }
+
+    @Test void validatesTextTagNames() {
+        String[] validNames = {"x", "custom-data", "custom-ã", "widget_2", "prefix:name"};
+        for (String name : validNames) {
+            assertTrue(new Tag(name).set(Tag.Data).is(Tag.Data));
+            assertTrue(new Tag(name).set(Tag.RcData).is(Tag.RcData));
+        }
+
+        String[] invalidNames = {"", "ã-custom", "x y", "x<y", "x>y", "x/y", "x\0y", "x\uFFFDy"};
+        for (String name : invalidNames) {
+            for (int textMode : new int[] {Tag.Data, Tag.RcData}) {
+                Tag tag = new Tag(name);
+                assertThrows(ValidationException.class, () -> tag.set(textMode), name);
+                assertFalse(tag.is(textMode));
+            }
+        }
+
+        Tag data = new Tag("custom-data").set(Tag.Data);
+        assertThrows(ValidationException.class, () -> data.name("x<y"));
+        assertEquals("custom-data", data.name());
     }
 
     @Test void stableHashcode() {

--- a/src/test/java/org/jsoup/parser/TokeniserStateTest.java
+++ b/src/test/java/org/jsoup/parser/TokeniserStateTest.java
@@ -2,17 +2,22 @@ package org.jsoup.parser;
 
 import org.jsoup.Jsoup;
 import org.jsoup.TextUtil;
+import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class TokeniserStateTest {
 
@@ -104,12 +109,30 @@ public class TokeniserStateTest {
         body = "<textarea><open";
         doc = Jsoup.parse(body);
         els = doc.select("textarea");
-        assertEquals("", els.text());
+        assertEquals("<open", els.text());
 
         body = "<textarea>hello world</?fake</textarea>";
         doc = Jsoup.parse(body);
         els = doc.select("textarea");
         assertEquals("hello world</?fake", els.text());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void textEndTagParsing(String input, String expected) {
+        Document doc = Jsoup.parseBodyFragment(input);
+        assertEquals(expected, TextUtil.normalizeSpaces(doc.body().html()));
+    }
+
+    private static Arguments[] textEndTagParsing() {
+        return new Arguments[] {
+            arguments("<style></t</style><img>", "<style></t</style><img>"),
+            arguments("<style></style</style><img>", "<style></style</style><img>"),
+            arguments("<script></t</script><img>", "<script></t</script><img>"),
+            arguments("<script><!--</t</script><img>", "<script><!--</t</script><img>"),
+            arguments("<textarea></t</textarea><img>", "<textarea>&lt;/t</textarea><img>"),
+            arguments("<textarea><img>", "<textarea>&lt;img&gt;</textarea>")
+        };
     }
 
     @Test
@@ -225,18 +248,6 @@ public class TokeniserStateTest {
     }
 
     @Test
-    public void testUnconsumeAfterBufferUp() {
-        // test for after consume() a bufferUp occurs (look-forward) but then attempts to unconsume. Would throw a "No buffer left to unconsume"
-        String triggeringSnippet = "<title>One <span>Two";
-        char[] padding = new char[CharacterReader.RefillPoint - triggeringSnippet.length() + 8]; // The "<span" part must be just at the limit. The "containsIgnoreCase" scan does a bufferUp, losing the unconsume
-        Arrays.fill(padding, ' ');
-        String paddedSnippet = String.valueOf(padding) + triggeringSnippet;
-        ParseErrorList errorList = ParseErrorList.tracking(1);
-        Parser.parseFragment(paddedSnippet, null, "", errorList);
-        // just asserting we don't get a WTF on unconsume
-    }
-
-    @Test
     public void testOpeningAngleBracketInsteadOfAttribute() {
         String triggeringSnippet = "<html <";
         ParseErrorList errorList = ParseErrorList.tracking(1);
@@ -284,18 +295,53 @@ public class TokeniserStateTest {
         assertEquals("<p foo></p>", doc.body().html());
     }
 
-    @Test void customDataTagWithHyphen() {
+    @ParameterizedTest
+    @MethodSource
+    void customDataEndTags(String input, String expected) {
         // https://github.com/jhy/jsoup/issues/2332
 
         TagSet tagSet = TagSet.Html();
         tagSet.valueOf("custom-data", Parser.NamespaceHtml).set(Tag.Data);
-        tagSet.valueOf("custom-rcdata", Parser.NamespaceHtml).set(Tag.RcData);
+        Document doc = Jsoup.parse("<body>" + input, Parser.htmlParser().tagSet(tagSet));
+        assertEquals(expected, TextUtil.normalizeSpaces(doc.body().html()));
+    }
 
-        String html = "<body><custom-data>a < > b</custom-data><p>One</p><custom-rcdata>a < > b</custom-rcdata><p>Two</p>";
-        Document doc = Jsoup.parse(html, Parser.htmlParser().tagSet(tagSet));
-        assertEquals(
-            "<custom-data>a < > b</custom-data><p>One</p><custom-rcdata>a &lt; &gt; b</custom-rcdata><p>Two</p>",
-            TextUtil.normalizeSpaces(doc.body().html()));
+    private static Arguments[] customDataEndTags() {
+        return new Arguments[] {
+            arguments("<custom-data>a < > b</custom-data><p>One</p>", "<custom-data>a < > b</custom-data><p>One</p>"),
+            arguments("<custom-data></custom-x</custom-data><p>One</p>", "<custom-data></custom-x</custom-data><p>One</p>"),
+            arguments("<custom-data>x</CUSTOM-DATA><p>One</p>", "<custom-data>x</custom-data><p>One</p>")
+        };
+    }
+
+    @Test void customRcdataEndTag() {
+        TagSet tagSet = TagSet.Html();
+        tagSet.valueOf("custom-rcdata", Parser.NamespaceHtml).set(Tag.RcData);
+        Document doc = Jsoup.parse("<body><custom-rcdata>a < > b</custom-rcdata><p>One</p>", Parser.htmlParser().tagSet(tagSet));
+        assertEquals("<custom-rcdata>a &lt; &gt; b</custom-rcdata><p>One</p>", TextUtil.normalizeSpaces(doc.body().html()));
+    }
+
+    @Test void customTextEndTagAcrossBufferBoundary() {
+        String prefix = "custom-";
+        String name = prefix + StringUtil.padding(CharacterReader.BufferSize + 1 - prefix.length(), -1).replace(' ', 'x');
+
+        assertCustomTextEndTag(name);
+    }
+
+    @Test void customTextEndTagWithNonAsciiLetter() {
+        assertCustomTextEndTag("custom-ã");
+    }
+
+    private static void assertCustomTextEndTag(String name) {
+        for (int textMode : new int[] {Tag.Data, Tag.RcData}) {
+            TagSet tagSet = TagSet.Html();
+            tagSet.valueOf(name, Parser.NamespaceHtml).set(textMode);
+            Document doc = Jsoup.parse("<body><" + name + ">x</" + name + "><p>after</p>", Parser.htmlParser().tagSet(tagSet));
+
+            assertEquals(2, doc.body().childrenSize());
+            assertEquals("p", doc.body().child(1).normalName());
+            assertEquals("after", doc.body().child(1).text());
+        }
     }
 
     @Test void customDataTagWithHyphenXml() {

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -664,5 +664,9 @@ public class CleanerTest {
         assertEquals("content is &lt;data&gt;", clean2);
     }
 
-
+    @Test void malformedRawtext() {
+        Safelist policy = Safelist.basic().addTags("style");
+        String input = "<style></t</style><img>";
+        assertEquals("<style></t</style>", Jsoup.clean(input, policy));
+    }
 }


### PR DESCRIPTION
This aligns RCDATA, RAWTEXT, and script-data end-tag handling with the HTML5 spec, including malformed-input recovery and EOF behavior.

It removes the RCDATA lookahead workaround for #83 and lets the text states share one simpler parsing path, while preserving exact matching for configured custom text tags.