### PR TITLE
Make hostless HTTP(S) URLs fail resolution and cleaning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,7 @@
 * Fixed parsing of malformed SVG and MathML content so that breakout HTML tags are placed according to the HTML specification. [#2562](https://github.com/jhy/jsoup/issues/2562)
 * Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth. [#2569](https://github.com/jhy/jsoup/pull/2569)
 * Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names. [#2577](https://github.com/jhy/jsoup/pull/2577)
-* Improved URL validation during HTTP/HTTPS URL resolution and cleaning; resolved URLs without a host are now rejected instead of being accepted based only on their scheme prefix, aligning to RFC 9110. Valid relative links and non-HTTP(S) schemes are unchanged.
+* Improved URL validation during HTTP/HTTPS URL resolution and cleaning; resolved URLs without a host are now rejected instead of being accepted based only on their scheme prefix, aligning to RFC 9110. Valid relative links and non-HTTP(S) schemes are unchanged. [#2579](https://github.com/jhy/jsoup/pull/2579)
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 * Fixed parsing of malformed SVG and MathML content so that breakout HTML tags are placed according to the HTML specification. [#2562](https://github.com/jhy/jsoup/issues/2562)
 * Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth. [#2569](https://github.com/jhy/jsoup/pull/2569)
 * Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names. [#2577](https://github.com/jhy/jsoup/pull/2577)
+* Improved URL validation during HTTP/HTTPS URL resolution and cleaning; resolved URLs without a host are now rejected instead of being accepted based only on their scheme prefix, aligning to RFC 9110. Valid relative links and non-HTTP(S) schemes are unchanged.
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/internal/StringUtil.java
+++ b/src/main/java/org/jsoup/internal/StringUtil.java
@@ -308,7 +308,9 @@ public final class StringUtil {
         if (url.getRef() != null) {
             fixedFile = fixedFile + "#" + url.getRef();
         }
-        return new URL(url.getProtocol(), url.getHost(), url.getPort(), fixedFile);
+        URL resolved = new URL(url.getProtocol(), url.getHost(), url.getPort(), fixedFile);
+        validateHttpUrl(resolved);
+        return resolved;
     }
 
     /**
@@ -321,22 +323,39 @@ public final class StringUtil {
         // workaround: java will allow control chars in a path URL and may treat as relative, but Chrome / Firefox will strip and may see as a scheme. Normalize to browser's view.
         baseUrl = stripControlChars(baseUrl); relUrl = stripControlChars(relUrl);
         try {
-            URL base;
-            try {
-                base = new URL(baseUrl);
-            } catch (MalformedURLException e) {
-                // the base is unsuitable, but the attribute/rel may be abs on its own, so try that
-                URL abs = new URL(relUrl);
-                return abs.toExternalForm();
-            }
+            URL base = new URL(baseUrl);
             return resolve(base, relUrl).toExternalForm();
         } catch (MalformedURLException e) {
-            // it may still be valid, just that Java doesn't have a registered stream handler for it, e.g. tel
-            // we test here vs at start to normalize supported URLs (e.g. HTTP -> http)
-            return validUriScheme.matcher(relUrl).find() ? relUrl : "";
+            try {
+                // the base is unsuitable, or resolution failed; the attribute/rel may be abs on its own
+                URL abs = new URL(relUrl);
+                validateHttpUrl(abs);
+                return abs.toExternalForm();
+            } catch (MalformedURLException ignored) {
+                // it may still be valid, just that Java doesn't have a registered stream handler for it, e.g. tel
+                // we test here vs at start to normalize supported URLs (e.g. HTTP -> http)
+                return validUriScheme.matcher(relUrl).find() && !hasHttpScheme(relUrl) ? relUrl : "";
+            }
         }
     }
     private static final Pattern validUriScheme = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+-.]*:");
+
+    /** Validates that an HTTP(S) URL has the host required by its scheme. */
+    private static void validateHttpUrl(URL url) throws MalformedURLException {
+        if (isHttpScheme(url.getProtocol()) && url.getHost().isEmpty())
+            throw new MalformedURLException("Invalid URL: host is missing");
+    }
+
+    /** Tests if the supplied scheme is HTTP or HTTPS. */
+    public static boolean isHttpScheme(String scheme) {
+        return scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https");
+    }
+
+    /** Tests if the supplied value starts with an HTTP or HTTPS scheme. */
+    public static boolean hasHttpScheme(String value) {
+        int colon = value.indexOf(':');
+        return colon > 0 && isHttpScheme(value.substring(0, colon));
+    }
 
     private static final Pattern controlChars = Pattern.compile("[\\x00-\\x1f]*"); // matches ascii 0 - 31, to strip from url
     private static String stripControlChars(final String input) {

--- a/src/main/java/org/jsoup/safety/Safelist.java
+++ b/src/main/java/org/jsoup/safety/Safelist.java
@@ -7,6 +7,7 @@ package org.jsoup.safety;
 
 import org.jsoup.helper.Validate;
 import org.jsoup.internal.Normalizer;
+import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Attributes;
 import org.jsoup.nodes.Element;
@@ -552,7 +553,7 @@ public class Safelist {
 
     private String getProtocolValue(Element el, Attribute attr) {
         String value = el.absUrl(attr.getKey());
-        if (value.isEmpty())
+        if (value.isEmpty() && !StringUtil.hasHttpScheme(attr.getValue()))
             value = attr.getValue(); // if it could not be made abs, run as-is to allow custom unknown protocols
         return value;
     }
@@ -569,9 +570,10 @@ public class Safelist {
                 }
             }
 
-            prot += ":";
-
-            if (lowerCase(value).startsWith(prot)) {
+            String lc = lowerCase(value);
+            if (lc.startsWith(prot)
+                && lc.length() > prot.length()
+                && lc.charAt(prot.length()) == ':') {
                 return true;
             }
         }

--- a/src/test/java/org/jsoup/integration/ConnectTest.java
+++ b/src/test/java/org/jsoup/integration/ConnectTest.java
@@ -614,6 +614,14 @@ public class ConnectTest {
         assertEquals(origin().hello.url(), doc.location());
     }
 
+    @Test public void rejectsHostlessHttpRedirect() {
+        IOException exception = assertThrows(IOException.class, () -> Jsoup.connect(origin().redirect.url())
+            .data(RedirectRoute.LocationParam, "https:/foo/bar")
+            .execute());
+
+        assertTrue(exception.getMessage().contains("host is missing"));
+    }
+
     @Test public void handlesEmptyRedirect() {
         boolean threw = false;
         try {

--- a/src/test/java/org/jsoup/internal/StringUtilTest.java
+++ b/src/test/java/org/jsoup/internal/StringUtilTest.java
@@ -3,6 +3,8 @@ package org.jsoup.internal;
 import org.jsoup.Jsoup;
 import org.junit.jupiter.api.Test;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -160,6 +162,34 @@ public class StringUtilTest {
 
     @Test void allowsSpaceInUrl() {
         assertEquals("https://example.com/foo bar/", resolve("HTTPS://example.com/example/", "../foo bar/"));
+    }
+
+    @Test void rejectsHostlessHttpUrls() throws MalformedURLException {
+        URL httpBase = new URL("http://example.com/a/b");
+        URL httpsBase = new URL("https://example.com/a/b");
+
+        assertEquals("https://example.com/foo/bar", resolve(httpsBase, "https:/foo/bar").toExternalForm());
+        assertThrows(MalformedURLException.class, () -> resolve(httpBase, "https:/foo/bar"));
+
+        assertEquals("", resolve("http://example.com/a/b", "https:/foo/bar"));
+        assertEquals("", resolve("", "https:/foo/bar"));
+        assertEquals("", resolve("", "https://"));
+        assertEquals("", resolve("", "https://?query"));
+
+        assertEquals("tel:867-5309", resolve("", "tel:867-5309"));
+        assertEquals("file:/tmp/example", resolve("", "file:/tmp/example"));
+    }
+
+    @Test void identifiesHttpSchemes() {
+        assertTrue(StringUtil.isHttpScheme("http"));
+        assertTrue(StringUtil.isHttpScheme("HTTPS"));
+        assertFalse(StringUtil.isHttpScheme("http:"));
+        assertFalse(StringUtil.isHttpScheme("ftp"));
+
+        assertTrue(StringUtil.hasHttpScheme("http://example.com"));
+        assertTrue(StringUtil.hasHttpScheme("HTTPS:/foo"));
+        assertFalse(StringUtil.hasHttpScheme("httpx://example.com"));
+        assertFalse(StringUtil.hasHttpScheme("/relative/path"));
     }
 
     @Test

--- a/src/test/java/org/jsoup/safety/CleanerTest.java
+++ b/src/test/java/org/jsoup/safety/CleanerTest.java
@@ -331,6 +331,38 @@ public class CleanerTest {
         assertEquals("<a href=\"/foo\">Link</a><img src=\"/bar\"> <img>", clean);
     }
 
+    @Test void dropsHostlessUrls() {
+        // http(s) URLs need a host after resolution. A one-slash URL resolves against the base when its scheme matches,
+        // but remains hostless when its scheme differs; preserved links retain their source spelling after validation
+        String html = "<a href='https:/foo/bar'>Cross scheme</a>"
+            + "<a href='https://'>Empty host</a>"
+            + "<a href='https://?query'>Query without host</a>";
+
+        String clean = Jsoup.clean(html, "http://example.com/a/b", Safelist.basic());
+
+        assertEquals("<a rel=\"nofollow\">Cross scheme</a>"
+            + "<a rel=\"nofollow\">Empty host</a>"
+            + "<a rel=\"nofollow\">Query without host</a>", clean);
+    }
+
+    @Test void resolvesSameSchemeUrl() {
+        String clean = Jsoup.clean("<a href='https:/foo/bar'>Link</a>", "https://example.com/a/b", Safelist.basic());
+
+        assertEquals("<a href=\"https://example.com/foo/bar\">Link</a>", clean);
+    }
+
+    @Test void checksPreservedLinks() {
+        Safelist safelist = Safelist.basic().preserveRelativeLinks(true);
+
+        Document httpBase = Jsoup.parseBodyFragment("<a href='https:/foo/bar'>Link</a>", "http://example.com/a/b");
+        Cleaner cleaner = new Cleaner(safelist);
+        assertFalse(cleaner.isValid(httpBase));
+        assertEquals("<a rel=\"nofollow\">Link</a>", cleaner.clean(httpBase).body().html());
+
+        String httpsOutput = Jsoup.clean("<a href='https:/foo/bar'>Link</a>", "https://example.com/a/b", safelist);
+        assertEquals("<a href=\"https:/foo/bar\">Link</a>", httpsOutput);
+    }
+
     @Test public void dropsUnresolvableRelativeLinks() { // when not preserving
         String html = "<a href='/foo'>Link</a>";
         String clean = Jsoup.clean(html, Safelist.basic());


### PR DESCRIPTION
HTTP and HTTPS resolution now rejects results without a host in accordance with RFC 9110.

The Safelist fallback preserves custom URI schemes without reviving malformed HTTP(S) values.