### PR TITLE
HTTP redirects use standard URL resolution for single-slash locations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # jsoup Changelog
+# jsoup Changelog
 
 ## 1.23.2 (pending)
 
@@ -34,6 +35,7 @@
 * Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth. [#2569](https://github.com/jhy/jsoup/pull/2569)
 * Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names. [#2577](https://github.com/jhy/jsoup/pull/2577)
 * Improved URL validation during HTTP/HTTPS URL resolution and cleaning; resolved URLs without a host are now rejected instead of being accepted based only on their scheme prefix, aligning to RFC 9110. Valid relative links and non-HTTP(S) schemes are unchanged. [#2579](https://github.com/jhy/jsoup/pull/2579)
+* Redirects with malformed single-slash HTTP locations now use standard URL resolution to align with browsers.
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,7 +35,7 @@
 * Fixed deeply nested malformed HTML parsing that could lose the document body because stack lookups did not align to the configured maximum parser depth. [#2569](https://github.com/jhy/jsoup/pull/2569)
 * Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names. [#2577](https://github.com/jhy/jsoup/pull/2577)
 * Improved URL validation during HTTP/HTTPS URL resolution and cleaning; resolved URLs without a host are now rejected instead of being accepted based only on their scheme prefix, aligning to RFC 9110. Valid relative links and non-HTTP(S) schemes are unchanged. [#2579](https://github.com/jhy/jsoup/pull/2579)
-* Redirects with malformed single-slash HTTP locations now use standard URL resolution to align with browsers.
+* Redirects with malformed single-slash HTTP locations now use standard URL resolution to align with browsers. [#2580](https://github.com/jhy/jsoup/pull/2580)
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -953,8 +953,6 @@ public class HttpConnection implements Connection {
 
                     String location = res.header(LOCATION);
                     Validate.notNull(location);
-                    if (location.startsWith("http:/") && location.charAt(6) != '/') // fix broken Location: http:/temp/AAG_New/en/index.php
-                        location = location.substring(6);
                     URL redir = StringUtil.resolve(req.url(), location);
                     if (!sameOrigin(req.url(), redir)) {
                         // remove sensitive headers; defense-in-depth against open redirects

--- a/src/test/java/org/jsoup/integration/ConnectTest.java
+++ b/src/test/java/org/jsoup/integration/ConnectTest.java
@@ -614,6 +614,18 @@ public class ConnectTest {
         assertEquals(origin().hello.url(), doc.location());
     }
 
+    @Test void handlesShortBrokenHttpRedirect() throws IOException {
+        URL start = new URL(origin().redirect.url());
+
+        // the redirect should resolve to /; ignore the test server's expected 404.
+        Connection.Response response = Jsoup.connect(start.toExternalForm())
+            .data(RedirectRoute.LocationParam, "http:/")
+            .ignoreHttpErrors(true)
+            .execute();
+
+        assertEquals(new URL(start, "/"), response.url());
+    }
+
     @Test public void rejectsHostlessHttpRedirect() {
         IOException exception = assertThrows(IOException.class, () -> Jsoup.connect(origin().redirect.url())
             .data(RedirectRoute.LocationParam, "https:/foo/bar")

--- a/src/test/java/org/jsoup/internal/StringUtilTest.java
+++ b/src/test/java/org/jsoup/internal/StringUtilTest.java
@@ -168,6 +168,8 @@ public class StringUtilTest {
         URL httpBase = new URL("http://example.com/a/b");
         URL httpsBase = new URL("https://example.com/a/b");
 
+        // http:/foo resolves from the origin root, not relative to /a/.
+        assertEquals("http://example.com/foo", resolve(httpBase, "http:/foo").toExternalForm());
         assertEquals("https://example.com/foo/bar", resolve(httpsBase, "https:/foo/bar").toExternalForm());
         assertThrows(MalformedURLException.class, () -> resolve(httpBase, "https:/foo/bar"));
 


### PR DESCRIPTION
Simplify to remove an old server workaround, and align to browser implementations.