### PR TITLE
Template stack checks need to exclude the fragment context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@
 * Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names. [#2577](https://github.com/jhy/jsoup/pull/2577)
 * Improved URL validation during HTTP/HTTPS URL resolution and cleaning; resolved URLs without a host are now rejected instead of being accepted based only on their scheme prefix, aligning to RFC 9110. Valid relative links and non-HTTP(S) schemes are unchanged. [#2579](https://github.com/jhy/jsoup/pull/2579)
 * Redirects with malformed single-slash HTTP locations now use standard URL resolution to align with browsers. [#2580](https://github.com/jhy/jsoup/pull/2580)
+* Template fragment parsing now handles unmatched `</template>` tags without throwing a `ValidationException`.
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -533,6 +533,12 @@ public class HtmlTreeBuilder extends TreeBuilder {
         return getFromStack(elName) != null;
     }
 
+    /** Checks if there is an HTML element with the given name above the synthetic fragment context. */
+    boolean onStackAboveContext(String elName) {
+        Element el = getFromStack(elName);
+        return el != null && el != contextElement;
+    }
+
     /** Gets the nearest (lowest) HTML element with the given name from the stack. */
     @Nullable
     Element getFromStack(String elName) {

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -163,7 +163,7 @@ enum HtmlTreeBuilderState {
                     } else if (inSorted(name, Constants.InHeadEnd)) {
                         return anythingElse(t, tb);
                     } else if (name.equals("template")) {
-                        if (!tb.onStack(name)) {
+                        if (!tb.onStackAboveContext(name)) {
                             tb.error(this);
                         } else {
                             tb.generateImpliedEndTags(true);
@@ -1578,7 +1578,7 @@ enum HtmlTreeBuilderState {
                     }
                     break;
                 case EOF:
-                    if (!tb.onStack("template")) {// stop parsing
+                    if (!tb.onStackAboveContext("template")) { // stop parsing
                         return true;
                     }
                     tb.error(this);

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -2036,6 +2036,20 @@ public class HtmlParserTest {
         assertEquals(want, TextUtil.stripNewlines(doc.html()));
     }
 
+    @Test void templateFragmentContextCannotBeClosedByInputAtEof() {
+        Document doc = Jsoup.parseBodyFragment("<template id=context></template>");
+        Element template = doc.expectFirst("#context");
+        template.html("</template><p><template>");
+        assertEquals("<p><template></template></p>", TextUtil.stripNewlines(template.html()));
+    }
+
+    @Test void templateFragmentCanCloseNestedTemplate() {
+        Document doc = Jsoup.parseBodyFragment("<template id=context></template>");
+        Element template = doc.expectFirst("#context");
+        template.html("</template><p><template><b>One</b></template><i>Two</i>");
+        assertEquals("<p><template><b>One</b></template><i>Two</i></p>", TextUtil.stripNewlines(template.html()));
+    }
+
     @Test void templateFragment() {
         // https://github.com/jhy/jsoup/issues/1315
         String html = "<template id=\"lorem-ipsum\"><tr><td>Lorem</td><td>Ipsum</td></tr></template>";


### PR DESCRIPTION
Template end-tag and EOF processing now distinguish input created elements from the synthetic fragment context.

This preserves the initial template insertion mode while allowing nested templates to close normally.