### PR TITLE
Fix source tracking through HTML repair and malformed EOF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 * Improved URL validation during HTTP/HTTPS URL resolution and cleaning; resolved URLs without a host are now rejected instead of being accepted based only on their scheme prefix, aligning to RFC 9110. Valid relative links and non-HTTP(S) schemes are unchanged. [#2579](https://github.com/jhy/jsoup/pull/2579)
 * Redirects with malformed single-slash HTTP locations now use standard URL resolution to align with browsers. [#2580](https://github.com/jhy/jsoup/pull/2580)
 * Template fragment parsing now handles unmatched `</template>` tags without throwing a `ValidationException`.
+* Improved source tracking for adopted formatting elements and malformed markup ending at EOF.
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,8 +35,8 @@
 * Aligned RCDATA, RAWTEXT, and script-data parsing with the HTML specification: malformed end tags no longer consume following markup, unclosed `title`/`textarea` content stays text through EOF, and custom text tags match exact names. [#2577](https://github.com/jhy/jsoup/pull/2577)
 * Improved URL validation during HTTP/HTTPS URL resolution and cleaning; resolved URLs without a host are now rejected instead of being accepted based only on their scheme prefix, aligning to RFC 9110. Valid relative links and non-HTTP(S) schemes are unchanged. [#2579](https://github.com/jhy/jsoup/pull/2579)
 * Redirects with malformed single-slash HTTP locations now use standard URL resolution to align with browsers. [#2580](https://github.com/jhy/jsoup/pull/2580)
-* Template fragment parsing now handles unmatched `</template>` tags without throwing a `ValidationException`.
-* Improved source tracking for adopted formatting elements and malformed markup ending at EOF.
+* Template fragment parsing now handles unmatched `</template>` tags without throwing a `ValidationException`. [#2581](https://github.com/jhy/jsoup/pull/2581)
+* Improved source tracking for adopted formatting elements and malformed markup ending at EOF. [#2582](https://github.com/jhy/jsoup/pull/2582)
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/nodes/NodeInternals.java
+++ b/src/main/java/org/jsoup/nodes/NodeInternals.java
@@ -28,6 +28,16 @@ public final class NodeInternals {
     }
 
     /**
+     Clears a copied end-tag range so a parser-recreated element can track its own close.
+     */
+    public static void clearEndSourceRange(Element element) {
+        Validate.notNull(element);
+        Range.Spans spans = element.spans();
+        if (spans != null)
+            spans.clearEndSourceRange();
+    }
+
+    /**
      Sets parser-tracked source offsets for an attribute.
      */
     public static void attributeRange(

--- a/src/main/java/org/jsoup/nodes/Range.java
+++ b/src/main/java/org/jsoup/nodes/Range.java
@@ -424,6 +424,12 @@ public class Range {
             endTagEndPos = endPos;
         }
 
+        /** Clears the end-tag range when a parser-created element is recreated from an earlier start token. */
+        void clearEndSourceRange() {
+            endTagStartPos = -1;
+            endTagEndPos = -1;
+        }
+
         /**
          Gets the source ranges for an attribute slot.
          */

--- a/src/main/java/org/jsoup/parser/CharacterReader.java
+++ b/src/main/java/org/jsoup/parser/CharacterReader.java
@@ -145,7 +145,8 @@ public final class CharacterReader implements AutoCloseable {
      * @return current position
      */
     public int pos() {
-        return consumed + bufPos;
+        // consuming EOF advances to a virtual position so it can be unconsumed; don't expose that beyond the input
+        return consumed + Math.min(bufPos, bufLength);
     }
 
     /**

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilder.java
@@ -11,6 +11,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.FormElement;
 import org.jsoup.nodes.Node;
+import org.jsoup.nodes.NodeInternals;
 import org.jsoup.nodes.TextNode;
 import org.jspecify.annotations.Nullable;
 
@@ -1075,7 +1076,7 @@ public class HtmlTreeBuilder extends TreeBuilder {
 
             // 8. create new element from element, 9 insert into current node, onto stack
             skip = false; // can only skip increment from 4.
-            Element newEl = new Element(tagFor(entry.nodeName(), entry.normalName(), defaultNamespace(), settings), null, entry.attributes().clone());
+            Element newEl = recreateElement(entry);
             doInsertElement(newEl);
 
             // 10. replace entry with new entry
@@ -1086,6 +1087,14 @@ public class HtmlTreeBuilder extends TreeBuilder {
                 break;
         }
     }
+
+    /** Copies an element's originating source ranges, ready to track a new close. */
+    Element recreateElement(Element source) {
+        Element element = new Element(source.tag(), null, source.attributes().clone());
+        NodeInternals.clearEndSourceRange(element);
+        return element;
+    }
+
     private static final int maxUsedFormattingElements = 12; // limit how many elements get recreated
 
     void clearFormattingElementsToLastMarker() {

--- a/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
+++ b/src/main/java/org/jsoup/parser/HtmlTreeBuilderState.java
@@ -914,7 +914,7 @@ enum HtmlTreeBuilderState {
                         tb.removeFromActiveFormattingElements(el);
                         break; // exit inner loop; proceed with step 14 using current lastEl
                     }
-                    Element replacement = new Element(tb.tagFor(el.nodeName(), el.normalName(), tb.defaultNamespace(), ParseSettings.preserveCase), tb.getBaseUri());
+                    Element replacement = tb.recreateElement(el);
                     tb.replaceActiveFormattingElement(el, replacement);
                     tb.replaceOnStack(el, replacement);
                     el = replacement;
@@ -932,8 +932,7 @@ enum HtmlTreeBuilderState {
                 // just use commonAncestor as target:
                 commonAncestor.appendChild(lastEl);
                 // 15. [Create an element for the token] for which formattingElement was created, in the [HTML namespace], with furthestBlock as the intended parent.
-                Element adoptor = new Element(formatEl.tag(), tb.getBaseUri());
-                adoptor.attributes().addAll(formatEl.attributes()); // also attributes
+                Element adoptor = tb.recreateElement(formatEl);
                 // 16. Take all of the child nodes of furthestBlock and append them to the element created in the last step.
                 for (Node child : furthestBlock.childNodes()) {
                     adoptor.appendChild(child);

--- a/src/main/java/org/jsoup/parser/TreeBuilder.java
+++ b/src/main/java/org/jsoup/parser/TreeBuilder.java
@@ -333,6 +333,11 @@ abstract class TreeBuilder {
     void trackNodePosition(Node node, boolean isStart) {
         if (!trackSourceRange) return;
 
+        if (isStart && node.sourceRange().isTracked())
+            return; // recreated nodes retain the position of their originating token
+        if (!isStart && node instanceof Element && ((Element) node).endSourceRange().isTracked())
+            return; // an element's first close is its source close
+
         final Token token = currentToken;
         int startPos = token.startPos();
         int endPos = token.endPos();
@@ -341,8 +346,6 @@ abstract class TreeBuilder {
         if (node instanceof Element) {
             final Element el = (Element) node;
             if (token.isEOF()) {
-                if (el.endSourceRange().isTracked())
-                    return; // /body and /html are left on stack until EOF, don't reset them
                 startPos = endPos = reader.pos();
             } else if (isStart) { // opening tag
                 if  (!token.isStartTag() || !el.normalName().equals(token.asStartTag().normalName)) {

--- a/src/test/java/org/jsoup/parser/CharacterReaderTest.java
+++ b/src/test/java/org/jsoup/parser/CharacterReaderTest.java
@@ -31,8 +31,10 @@ public class CharacterReaderTest {
         assertEquals('e', r.consume());
         assertTrue(r.isEmpty());
         assertEquals(CharacterReader.EOF, r.consume());
+        assertEquals(3, r.pos());
         assertTrue(r.isEmpty());
         assertEquals(CharacterReader.EOF, r.consume());
+        assertEquals(3, r.pos());
     }
 
     @Test public void unconsume() {

--- a/src/test/java/org/jsoup/parser/HtmlParserTest.java
+++ b/src/test/java/org/jsoup/parser/HtmlParserTest.java
@@ -1045,8 +1045,7 @@ public class HtmlParserTest {
 
     @Test public void handlesMisnestedAInDivs() {
         String h = "<a 1><div 2><div 3><a 4>child</a></div></div></a>";
-        String w = "<a 1></a> <div 2> <a 1=\"\"></a> <div 3> <a 1=\"\"></a><a 4>child</a> </div> </div>"; // chrome checked
-        // todo - come back to how we copy the attributes, to keep boolean setting (not ="")
+        String w = "<a 1></a> <div 2> <a 1></a> <div 3> <a 1></a><a 4>child</a> </div> </div>";
 
         Document doc = Jsoup.parse(h);
         assertEquals(
@@ -1236,8 +1235,8 @@ public class HtmlParserTest {
         assertEquals("<3:25>: Invalid character reference: missing semicolon on [&amp]", errors.get(5).toString());
         assertEquals("<3:36>: Invalid character reference: character [1114112] outside of valid range", errors.get(6).toString());
         assertEquals("<3:48>: Unexpected EndTag token [</div>] when in state [InBody]", errors.get(7).toString());
-        assertEquals("<3:53>: Unexpectedly reached end of file (EOF) in input state [TagName]", errors.get(8).toString());
-        assertEquals("<3:53>: Unexpected EOF token [] when in state [InBody]", errors.get(9).toString());
+        assertEquals("<3:52>: Unexpectedly reached end of file (EOF) in input state [TagName]", errors.get(8).toString());
+        assertEquals("<3:52>: Unexpected EOF token [] when in state [InBody]", errors.get(9).toString());
     }
 
     @Test public void tracksLimitedErrorsWhenRequested() {

--- a/src/test/java/org/jsoup/parser/PositionTest.java
+++ b/src/test/java/org/jsoup/parser/PositionTest.java
@@ -288,6 +288,82 @@ class PositionTest {
         assertFalse(doc.expectFirst("meta").endSourceRange().isImplicit());
         assertEquals("html:0-0~31-31; head:0-0~6-6; meta:0-6~0-6; body:6-6~31-31; img:6-11~6-11; p:11-14~17-17; p:17-20~23-23; p:23-26~31-31; ", track.toString());
     }
+
+    @Test void tracksAdoptedFormattingElementsFromTheirStartTokens() {
+        Document anchors = Jsoup.parse("<a><address><a>", TrackingHtmlParser);
+        StringBuilder anchorTrack = new StringBuilder();
+        anchors.select("a").forEach(anchor -> accumulatePositions(anchor, anchorTrack));
+        assertEquals("a:0-3~12-12; a:0-3~12-12; a:12-15~15-15; ", anchorTrack.toString());
+
+        Document nobrs = Jsoup.parse("<nobr><address><nobr>", TrackingHtmlParser);
+        StringBuilder nobrTrack = new StringBuilder();
+        nobrs.select("nobr").forEach(nobr -> accumulatePositions(nobr, nobrTrack));
+        assertEquals("nobr:0-6~15-15; nobr:0-6~15-15; nobr:15-21~21-21; ", nobrTrack.toString());
+    }
+
+    @Test void tracksAdoptedFormattingAttributes() {
+        Document host = Document.createShell("");
+        List<Node> nodes = TrackingHtmlParser.parseFragmentInput("<b id=one><p></b>", host.body(), "");
+        List<Element> bold = nodes.stream()
+            .flatMap(node -> node.nodeStream(Element.class))
+            .filter(element -> element.normalName().equals("b"))
+            .collect(Collectors.toList());
+
+        assertEquals(2, bold.size());
+        for (Element element : bold) {
+            assertEquals("1,1:0-1,11:10", element.sourceRange().toString());
+            assertEquals("1,4:3-1,6:5=1,7:6-1,10:9", element.attributes().sourceRange("id").toString());
+            assertEquals("1,14:13-1,18:17", element.endSourceRange().toString());
+        }
+    }
+
+    @Test void tracksAdoptedFormattingElementsInsideTemplates() {
+        String html = "<template><b><p></b></template><p>tail</p>";
+        Document doc = Jsoup.parse(html, TrackingHtmlParser);
+        Elements bold = doc.select("b");
+
+        assertEquals(2, bold.size());
+        for (Element element : bold) {
+            assertEquals("1,11:10-1,14:13", element.sourceRange().toString());
+            assertTrue(element.endSourceRange().isTracked());
+        }
+    }
+
+    @Test void reconstructedFormattingElementsTrackTheirOwnClose() {
+        Document doc = Jsoup.parse("<p><b>one</p>two", TrackingHtmlParser);
+        Elements bold = doc.select("b");
+
+        assertEquals(2, bold.size());
+        assertEquals("1,4:3-1,7:6", bold.get(0).sourceRange().toString());
+        assertEquals("1,10:9-1,10:9", bold.get(0).endSourceRange().toString());
+        assertEquals("1,4:3-1,7:6", bold.get(1).sourceRange().toString());
+        assertEquals("1,17:16-1,17:16", bold.get(1).endSourceRange().toString());
+    }
+
+    @Test void malformedEofRangesStayWithinSource() {
+        for (String html : new String[] {"<?xml", "<!", "<!--", "<a", "</a", "<!DOCTYPE", "<a x="}) {
+            Document doc = Jsoup.parse(html, TrackingHtmlParser);
+            doc.forEachNode(node -> {
+                assertRangeWithinSource(node.sourceRange(), html);
+                if (node instanceof Element)
+                    assertRangeWithinSource(((Element) node).endSourceRange(), html);
+            });
+            assertEquals(html.length(), doc.endSourceRange().endPos(), html);
+        }
+
+        Document multiline = Jsoup.parse("One\n<?xml", TrackingHtmlParser);
+        assertEquals("2,6:9-2,6:9", multiline.endSourceRange().toString());
+        Comment comment = multiline.nodeStream(Comment.class).findFirst().orElseThrow();
+        assertEquals("2,1:4-2,6:9", comment.sourceRange().toString());
+    }
+
+    private static void assertRangeWithinSource(Range range, String source) {
+        if (!range.isTracked()) return;
+        assertTrue(range.startPos() >= 0, range::toString);
+        assertTrue(range.startPos() <= range.endPos(), range::toString);
+        assertTrue(range.endPos() <= source.length(), range::toString);
+    }
+
     private void printRange(Node node) {
         if (node instanceof Element) {
             Element el = (Element) node;

--- a/src/test/java/org/jsoup/parser/PositionTest.java
+++ b/src/test/java/org/jsoup/parser/PositionTest.java
@@ -353,7 +353,7 @@ class PositionTest {
 
         Document multiline = Jsoup.parse("One\n<?xml", TrackingHtmlParser);
         assertEquals("2,6:9-2,6:9", multiline.endSourceRange().toString());
-        Comment comment = multiline.nodeStream(Comment.class).findFirst().orElseThrow();
+        Comment comment = multiline.nodeStream(Comment.class).findFirst().orElseThrow(() -> new AssertionError("comment missing"));
         assertEquals("2,1:4-2,6:9", comment.sourceRange().toString());
     }
 

--- a/src/test/java/org/jsoup/parser/TokeniserStateTest.java
+++ b/src/test/java/org/jsoup/parser/TokeniserStateTest.java
@@ -136,6 +136,12 @@ public class TokeniserStateTest {
     }
 
     @Test
+    void scriptDoubleEscapeTagAtEof() {
+        assertEquals("<!--<script", Jsoup.parse("<script><!--<script").expectFirst("script").data());
+        assertEquals("<!--<script>foo</script", Jsoup.parse("<script><!--<script>foo</script").expectFirst("script").data());
+    }
+
+    @Test
     public void testRCDATAEndTagName() {
         for (char c : whiteSpace) {
             String body = String.format("<textarea>data</textarea%c>", c);


### PR DESCRIPTION
Source tracking now follows formatting elements through misnested-HTML repair, so adopted and reconstructed anchors, nobr elements, fragments, and templates retain their originating ranges and record their own closes.

Malformed markup ending at EOF now reports ranges at the input boundary, while script data ending during double-escape lookahead preserves its final character. The parser carries start-tag and attribute ranges onto recreated elements and clamps reported EOF positions without changing tokenizer lookahead behavior.