### PR TITLE
Java 11 HTTP client reuse covers ordinary connections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 * Redirects with malformed single-slash HTTP locations now use standard URL resolution to align with browsers. [#2580](https://github.com/jhy/jsoup/pull/2580)
 * Template fragment parsing now handles unmatched `</template>` tags without throwing a `ValidationException`. [#2581](https://github.com/jhy/jsoup/pull/2581)
 * Improved source tracking for adopted formatting elements and malformed markup ending at EOF. [#2582](https://github.com/jhy/jsoup/pull/2582)
+* Extended Java 11+ HTTP client reuse from requests sharing a `Jsoup.newSession()` to ordinary `Jsoup.connect(...)` calls, reducing transport thread and connection setup churn under sustained request loads. Sessions with custom authentication or SSL contexts continue to use their own client. [#2516](https://github.com/jhy/jsoup/issues/2516)
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 * Added `Elements#before(Node)`, `after(Node)`, `prepend(Node)`, and `append(Node)` to match the existing HTML string methods. [#953](https://github.com/jhy/jsoup/issues/953)
 * XML serialization now repairs element and attribute names that start with an invalid character, rather than outputting `<null>` elements or dropping attributes. For example, an attribute named `1a` is written as `_1a`. Additional leading underscores keep repaired attribute names unique if they conflict with another attribute. [#2573](https://github.com/jhy/jsoup/issues/2573)
 * Large file-backed uploads through `Connection.requestBodyStream(InputStream)` now stream directly with the JDK `HttpClient` on Java 11+, rather than being loaded fully into memory first.
+* Extended Java 11+ HTTP client reuse from requests sharing a `Jsoup.newSession()` to ordinary `Jsoup.connect(...)` calls, reducing transport thread and connection setup churn under sustained request loads. Sessions with custom authentication or SSL contexts continue to use their own client. [#2584](https://github.com/jhy/jsoup/pull/2584)
 
 ### Changes
 * Aligned the XML parser stack depth and lookups to the configured maximum, which now defaults to 512 for both HTML and XML. [#2570](https://github.com/jhy/jsoup/pull/2570)
@@ -37,7 +38,6 @@
 * Redirects with malformed single-slash HTTP locations now use standard URL resolution to align with browsers. [#2580](https://github.com/jhy/jsoup/pull/2580)
 * Template fragment parsing now handles unmatched `</template>` tags without throwing a `ValidationException`. [#2581](https://github.com/jhy/jsoup/pull/2581)
 * Improved source tracking for adopted formatting elements and malformed markup ending at EOF. [#2582](https://github.com/jhy/jsoup/pull/2582)
-* Extended Java 11+ HTTP client reuse from requests sharing a `Jsoup.newSession()` to ordinary `Jsoup.connect(...)` calls, reducing transport thread and connection setup churn under sustained request loads. Sessions with custom authentication or SSL contexts continue to use their own client. [#2516](https://github.com/jhy/jsoup/issues/2516)
 
 ## 1.23.1 (2026-Jul-30)
 

--- a/src/main/java/org/jsoup/helper/HttpConnection.java
+++ b/src/main/java/org/jsoup/helper/HttpConnection.java
@@ -74,8 +74,7 @@ public class HttpConnection implements Connection {
 
     private HttpConnection.Request req;
     private Connection.@Nullable Response res;
-    @Nullable Object client; // The HttpClient for this Connection, if via the HttpClientExecutor
-    @Nullable RequestAuthenticator lastAuth; // The previous Authenticator used by this Connection, if via the HttpClientExecutor
+    volatile @Nullable Object clientState; // Java 11 HttpClient state, held as Object for Java 8 compatibility
 
     /**
      Create a new Connection, with the request URL specified.

--- a/src/main/java11/org/jsoup/helper/HttpClientExecutor.java
+++ b/src/main/java11/org/jsoup/helper/HttpClientExecutor.java
@@ -15,11 +15,14 @@ import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.ssl.SSLContext;
 
 import static org.jsoup.helper.HttpConnection.Response;
 import static org.jsoup.helper.HttpConnection.Response.writePost;
@@ -29,9 +32,11 @@ import static org.jsoup.helper.HttpConnection.Response.writePost;
  property {@code jsoup.useHttpClient} to {@code false}.
  */
 class HttpClientExecutor extends RequestExecutor {
-    // HttpClient expects proxy settings per client; we do per request, so held as a thread local. Can't do same for
-    // auth because that callback is on a worker thread, so can only do auth per Connection. So we create a new client
-    // if the authenticator is different between requests
+    private static final Object SharedClientLock = new Object();
+    private static volatile @Nullable ClientState sharedClientState;
+
+    // HttpClient expects proxy settings per client; jsoup supports them per request, so resolve them from the calling
+    // thread.
     static ThreadLocal<@Nullable Proxy> perRequestProxy = new ThreadLocal<>();
 
     @Nullable
@@ -42,33 +47,57 @@ class HttpClientExecutor extends RequestExecutor {
     }
 
     /**
-     Retrieve the HttpClient from the Connection, or create a new one. Allows for connection pooling of requests in the
-     same Connection (session).
+     Returns the shared client for default requests, or the owning connection's configured client.
      */
     HttpClient client() {
-        // we try to reuse the same Client across requests in a given Connection; but if the request's auth or ssl context have changed, we need to create a new client
-        if (req.connection.client != null) {
-            HttpClient client = (HttpClient) req.connection.client;
-            boolean reuse = true;
+        RequestAuthenticator auth = req.authenticator;
+        // HttpClient captures the JVM default SSL context when built, and that default can change at runtime.
+        SSLContext sslContext = req.sslContext != null ? req.sslContext : defaultSslContext();
+        if (auth == null && req.sslContext == null) return sharedClient(sslContext);
+        return configuredClient(auth, sslContext);
+    }
 
-            RequestAuthenticator prevAuth = req.connection.lastAuth;
-            req.connection.lastAuth = req.authenticator;
-            if (prevAuth != req.authenticator) // might both be null
-                reuse = false;
-            if (req.sslContext != null && !(client.sslContext() == req.sslContext)) // client returns default context if not otherwise set
-                reuse = false;
-            if (reuse) return client;
+    private HttpClient configuredClient(@Nullable RequestAuthenticator auth, SSLContext sslContext) {
+        ClientState state = (ClientState) req.connection.clientState;
+        if (state != null && state.matches(auth, sslContext)) return state.client;
+        synchronized (req.connection) {
+            // another request may have initialized this connection's client while we waited for the lock.
+            state = (ClientState) req.connection.clientState;
+            if (state == null || !state.matches(auth, sslContext)) {
+                state = new ClientState(auth, sslContext);
+                req.connection.clientState = state;
+            }
+            return state.client;
         }
+    }
 
+    private static HttpClient sharedClient(SSLContext sslContext) {
+        ClientState state = sharedClientState;
+        if (state != null && state.matches(null, sslContext)) return state.client;
+        synchronized (SharedClientLock) {
+            state = sharedClientState;
+            if (state != null && state.matches(null, sslContext)) return state.client;
+            state = new ClientState(null, sslContext);
+            sharedClientState = state;
+            return state.client;
+        }
+    }
+
+    private static HttpClient newClient(@Nullable RequestAuthenticator authenticator, SSLContext sslContext) {
         HttpClient.Builder builder = HttpClient.newBuilder();
         builder.followRedirects(HttpClient.Redirect.NEVER); // customized redirects
         builder.proxy(new ProxyWrap()); // thread local impl for per request; called on executing thread
-        if (req.authenticator != null) builder.authenticator(new AuthenticationHandler(req.authenticator));
-        if (req.sslContext    != null) builder.sslContext(req.sslContext);
+        if (authenticator != null) builder.authenticator(new AuthenticationHandler(authenticator));
+        builder.sslContext(sslContext);
+        return builder.build();
+    }
 
-        HttpClient client = builder.build();
-        req.connection.client = client;
-        return client;
+    private static SSLContext defaultSslContext() {
+        try {
+            return SSLContext.getDefault();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("No default SSL context is available", e);
+        }
     }
 
     @Override
@@ -191,6 +220,22 @@ class HttpClientExecutor extends RequestExecutor {
             if (defaultSelector != null && defaultSelector != this) {
                 defaultSelector.connectFailed(uri, sa, ioe);
             }
+        }
+    }
+
+    private static final class ClientState {
+        final HttpClient client;
+        final @Nullable RequestAuthenticator authenticator;
+        final SSLContext sslContext;
+
+        ClientState(@Nullable RequestAuthenticator authenticator, SSLContext sslContext) {
+            this.client = newClient(authenticator, sslContext);
+            this.authenticator = authenticator;
+            this.sslContext = sslContext;
+        }
+
+        boolean matches(@Nullable RequestAuthenticator authenticator, SSLContext sslContext) {
+            return this.authenticator == authenticator && this.sslContext == sslContext;
         }
     }
 }

--- a/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
+++ b/src/test/java11/org/jsoup/helper/HttpClientExecutorTest.java
@@ -1,8 +1,12 @@
 package org.jsoup.helper;
 
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
 import org.jsoup.internal.SharedConstants;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -10,15 +14,29 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntFunction;
 
 import static org.jsoup.Connection.Method.POST;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class HttpClientExecutorTest {
+    @AfterEach void resetHttpClient() {
+        HttpClientTestAccess.resetSharedClient();
+        disableHttpClient();
+    }
+
     @Test void loadsMultiReleaseHttpClientExecutor() {
         // sanity check that the test is resolving the packaged Java 11 override, not a copy on the test classpath
         String resource = HttpClientTestAccess.executorClassResource().toExternalForm();
@@ -26,19 +44,90 @@ public class HttpClientExecutorTest {
     }
 
     @Test void getsHttpClient() {
-        try {
-            enableHttpClient();
-            RequestExecutor executor = RequestDispatch.get(new HttpConnection.Request(), null);
-            assertTrue(HttpClientTestAccess.isHttpClientExecutor(executor));
-        } finally {
-            disableHttpClient(); // reset to previous default for JDK8 compat tests
-        }
+        enableHttpClient();
+        RequestExecutor executor = RequestDispatch.get(new HttpConnection.Request(), null);
+        assertTrue(HttpClientTestAccess.isHttpClientExecutor(executor));
     }
 
     @Test void getsHttpClientByDefault() {
         System.clearProperty(SharedConstants.UseHttpClient);
         RequestExecutor executor = RequestDispatch.get(new HttpConnection.Request(), null);
         assertTrue(HttpClientTestAccess.isHttpClientExecutor(executor));
+    }
+
+    @Test void sharesDefaultClientAcrossConnections() {
+        enableHttpClient();
+        Object first = HttpClientTestAccess.client(Jsoup.connect("https://example.com/one"));
+        Object second = HttpClientTestAccess.client(Jsoup.connect("https://example.com/two"));
+        assertSame(first, second);
+    }
+
+    @Test void sharesDefaultClientAcrossConcurrentConnections() throws Exception {
+        enableHttpClient();
+        HttpClientTestAccess.resetSharedClient();
+        Set<Object> clients = concurrentClients(i -> Jsoup.connect("https://example.com/" + i));
+        assertEquals(1, clients.size());
+    }
+
+    @Test void refreshesDefaultClientWhenSslContextChanges() throws Exception {
+        SSLContext original = SSLContext.getDefault();
+        SSLContext replacement = SSLContext.getInstance("TLS");
+        replacement.init(null, null, null);
+        try {
+            enableHttpClient();
+            HttpClientTestAccess.resetSharedClient();
+            Object first = HttpClientTestAccess.client(Jsoup.connect("https://example.com/one"));
+            SSLContext.setDefault(replacement);
+            Object second = HttpClientTestAccess.client(Jsoup.connect("https://example.com/two"));
+            assertNotSame(first, second);
+            assertSame(replacement, ((HttpClient) second).sslContext());
+        } finally {
+            SSLContext.setDefault(original);
+        }
+    }
+
+    @Test void reusesConfiguredClientWithinSession() {
+        enableHttpClient();
+        Connection session = Jsoup.newSession().auth(context -> null);
+        Object first = HttpClientTestAccess.client(session.newRequest("https://example.com/one"));
+        Object second = HttpClientTestAccess.client(session.newRequest("https://example.com/two"));
+        assertSame(first, second);
+    }
+
+    @Test void rebuildsClientWhenAuthenticatorChanges() {
+        enableHttpClient();
+        RequestAuthenticator firstAuth = context -> null;
+        RequestAuthenticator secondAuth = context -> null;
+        assertNotSame(firstAuth, secondAuth);
+
+        Connection session = Jsoup.newSession();
+        Object first = HttpClientTestAccess.client(
+            session.newRequest("https://example.com/one").auth(firstAuth));
+        Object second = HttpClientTestAccess.client(
+            session.newRequest("https://example.com/two").auth(secondAuth));
+        assertNotSame(first, second);
+    }
+
+    @Test void rebuildsClientWhenSslContextChanges() throws Exception {
+        SSLContext firstContext = SSLContext.getInstance("TLS");
+        SSLContext secondContext = SSLContext.getInstance("TLS");
+        firstContext.init(null, null, null);
+        secondContext.init(null, null, null);
+        enableHttpClient();
+
+        Connection session = Jsoup.newSession();
+        Object first = HttpClientTestAccess.client(
+            session.newRequest("https://example.com/one").sslContext(firstContext));
+        Object second = HttpClientTestAccess.client(
+            session.newRequest("https://example.com/two").sslContext(secondContext));
+        assertNotSame(first, second);
+    }
+
+    @Test void createsOneClientForConcurrentSessionRequests() throws Exception {
+        enableHttpClient();
+        Connection session = Jsoup.newSession().auth(context -> null);
+        Set<Object> clients = concurrentClients(i -> session.newRequest("https://example.com/" + i));
+        assertEquals(1, clients.size());
     }
 
     @Test void requestBodyStreamIsNotBuffered() {
@@ -60,17 +149,13 @@ public class HttpClientExecutorTest {
     }
 
     @Test void downgradesSocksProxyToUrlConnectionExecutor() {
-        try {
-            enableHttpClient();
-            HttpConnection.Request request = new HttpConnection.Request();
-            request.proxy(new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("localhost", 1080)));
+        enableHttpClient();
+        HttpConnection.Request request = new HttpConnection.Request();
+        request.proxy(new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("localhost", 1080)));
 
-            // SOCKS handling only matters on the Java 11+ path where HttpClient would otherwise be selected (and just bypasses)
-            RequestExecutor executor = RequestDispatch.get(request, null);
-            assertInstanceOf(UrlConnectionExecutor.class, executor);
-        } finally {
-            disableHttpClient(); // reset to previous default for JDK8 compat tests
-        }
+        // SOCKS handling only matters on the Java 11+ path where HttpClient would otherwise be selected (and just bypasses)
+        RequestExecutor executor = RequestDispatch.get(request, null);
+        assertInstanceOf(UrlConnectionExecutor.class, executor);
     }
 
     public static void enableHttpClient() {
@@ -163,6 +248,33 @@ public class HttpClientExecutorTest {
             assertTrue(called[0]);
         } finally {
             ProxySelector.setDefault(original);
+        }
+    }
+
+    private static Set<Object> concurrentClients(IntFunction<Connection> connectionFactory) throws Exception {
+        int count = 40;
+        ExecutorService executor = Executors.newFixedThreadPool(count);
+        // hold every worker at the first lookup so lazy initialization is concurrent
+        CountDownLatch ready = new CountDownLatch(count);
+        CountDownLatch start = new CountDownLatch(1);
+        Set<Object> clients = ConcurrentHashMap.newKeySet();
+        List<Future<?>> futures = new ArrayList<>(count);
+        try {
+            for (int i = 0; i < count; i++) {
+                int request = i;
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    clients.add(HttpClientTestAccess.client(connectionFactory.apply(request)));
+                    return null;
+                }));
+            }
+            ready.await();
+            start.countDown();
+            for (Future<?> future : futures) future.get();
+            return clients;
+        } finally {
+            executor.shutdownNow();
         }
     }
 }

--- a/src/test/java11/org/jsoup/helper/HttpClientTestAccess.java
+++ b/src/test/java11/org/jsoup/helper/HttpClientTestAccess.java
@@ -1,7 +1,10 @@
 package org.jsoup.helper;
 
+import org.jsoup.Connection;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URL;
@@ -40,6 +43,28 @@ final class HttpClientTestAccess {
                     .invoke(null, request);
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Could not invoke HttpClientExecutor.requestBody", e);
+        }
+    }
+
+    static Object client(Connection connection) {
+        try {
+            HttpConnection.Request request = (HttpConnection.Request) connection.request();
+            RequestExecutor executor = RequestDispatch.get(request, null);
+            Method method = executorClass().getDeclaredMethod("client");
+            method.setAccessible(true);
+            return method.invoke(executor);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not retrieve the configured HttpClient", e);
+        }
+    }
+
+    static void resetSharedClient() {
+        try {
+            Field field = executorClass().getDeclaredField("sharedClientState");
+            field.setAccessible(true);
+            field.set(null, null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Could not reset the shared HttpClient", e);
         }
     }
 

--- a/src/test/java11/org/jsoup/integration/HttpClientConnectIT.java
+++ b/src/test/java11/org/jsoup/integration/HttpClientConnectIT.java
@@ -1,9 +1,25 @@
 package org.jsoup.integration;
 
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
 import org.jsoup.helper.HttpClientExecutorTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.jsoup.integration.TestServer.ProxyVia;
+import static org.jsoup.integration.TestServer.origin;
+import static org.jsoup.integration.TestServer.proxySettings;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class HttpClientConnectIT extends ConnectIT {
     @BeforeAll
@@ -27,5 +43,37 @@ public class HttpClientConnectIT extends ConnectIT {
 
     @Override @Disabled
     public void canInterruptThenJoinASpawnedThread() throws InterruptedException {
+    }
+
+    @Test public void concurrentRequestsKeepProxyRoutesIsolated() throws Exception {
+        int requestCount = 32;
+        TestServer.ProxySettings proxy = proxySettings();
+        String url = origin().hello.url();
+        ExecutorService callers = Executors.newFixedThreadPool(requestCount);
+        CountDownLatch ready = new CountDownLatch(requestCount);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<?>> futures = new ArrayList<>(requestCount);
+        try {
+            // mix direct and proxied requests to verify that sharing the client does not share proxy settings
+            for (int i = 0; i < requestCount; i++) {
+                boolean viaProxy = i % 2 == 0;
+                futures.add(callers.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    Connection connection = Jsoup.connect(url);
+                    if (viaProxy) connection.proxy(proxy.hostname, proxy.port);
+                    Connection.Response response = connection.execute();
+                    response.parse();
+                    if (viaProxy) assertEquals(ProxyVia, response.header("Via"));
+                    else assertNull(response.header("Via"));
+                    return null;
+                }));
+            }
+            ready.await();
+            start.countDown();
+            for (Future<?> future : futures) future.get();
+        } finally {
+            callers.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
Requests via `Jsoup.newSession()` already reused their HttpClient. This extends that reuse to independent `Jsoup.connect(...)` calls, so repeated requests do not create a new transport client and its threads each time.

Custom authentication and SSL contexts remain isolated, and proxy selection remains per request.

Fixes: #2516